### PR TITLE
[Behat] Adjusted suite paths to rebranding

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -1,11 +1,11 @@
 browser:
     extensions:
         Behat\MinkExtension:
-            files_path: '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/TestFiles/'
+            files_path: '%paths.base%/vendor/ibexa/admin-ui/src/lib/Behat/TestFiles/'
     suites:
         admin-ui:
             paths:
-              - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
+              - '%paths.base%/vendor/ibexa/admin-ui/features/standard'
             filters:
                 tags: "~@broken"
             contexts: 
@@ -36,7 +36,7 @@ browser:
 
         personas:
             paths:
-                - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/personas'
+                - '%paths.base%/vendor/ibexa/admin-ui/features/personas'
             contexts:
                 - Ibexa\Behat\Browser\Context\DebuggingContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext

--- a/features/standard/SystemInfo.feature
+++ b/features/standard/SystemInfo.feature
@@ -18,15 +18,9 @@ Feature: System info verification
     When I go to "Composer" tab in System Information
     Then I see "Composer" system information table
       And I see listed packages
-        | Name                                    |
-        | ezsystems/ez-support-tools              |
-        | ezsystems/ezplatform-admin-ui           |
-        | ezsystems/ezplatform-admin-ui-assets    |
-        | ezsystems/ezplatform-design-engine      |
-        | ezsystems/ezplatform-http-cache         |
-        | ezsystems/ezplatform-solr-search-engine |
-        | ezsystems/ezplatform-kernel             |
-        | ezsystems/ezplatform-content-forms      |
+        | Name                     |
+        | ibexa/admin-ui           |
+        | ibexa/core               |
 
   @javascript
   Scenario: Check Repository System Information
@@ -48,16 +42,7 @@ Feature: System info verification
     When I go to "Symfony Kernel" tab in System Information
     Then I see "Symfony Kernel" system information table
       And I see listed bundles
-        | Name                                      |
-        | EzPlatformAdminUiAssetsBundle             |
-        | EzPlatformAdminUiBundle                   |
-        | EzPlatformDesignEngineBundle              |
-        | EzPublishCoreBundle                       |
-        | EzPublishIOBundle                         |
-        | EzPublishLegacySearchEngineBundle         |
-        | EzPlatformRestBundle                      |
-        | EzSystemsEzPlatformSolrSearchEngineBundle |
-        | EzSystemsEzSupportToolsBundle             |
-        | EzSystemsPlatformHttpCacheBundle          |
-        | EzSystemsPlatformInstallerBundle          |
-        | EzPlatformContentFormsBundle              |
+        | Name                     |
+        | IbexaAdminUiAssetsBundle |
+        | IbexaAdminUiBundle       |
+        | IbexaCoreBundle          |


### PR DESCRIPTION
This PR adjusts config file paths and tests to the rebranding process.

I've removed some of the bundles from the list, because TBH I don't see the advantage in checking all of them.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
