### PR TITLE
IBX-1015: Added support for subitems grouping in admin-ui menu

### DIFF
--- a/src/bundle/Resources/public/scss/_main-menu.scss
+++ b/src/bundle/Resources/public/scss/_main-menu.scss
@@ -79,7 +79,7 @@
                 }
 
                 .ibexa-main-menu__item {
-                    &--group-name:before {
+                    &--group-name {
                         width: 0;
                     }
                 }
@@ -132,14 +132,7 @@
         &--group-name {
             color: $ibexa-color-light-700;
             font-size: $ibexa-text-font-size-small;
-
-            &:before {
-                content: "";
-                border-top: 1px solid $ibexa-color-info-800;
-                transition: width 0.30s linear;
-                width: 100%;
-                display: block;
-            }
+            border-top: calculateRem(1px) solid $ibexa-color-info-800;
         }
     }
 

--- a/src/bundle/Resources/public/scss/_main-menu.scss
+++ b/src/bundle/Resources/public/scss/_main-menu.scss
@@ -43,6 +43,11 @@
 
                 &__item-text-column {
                     padding: calculateRem(10px);
+
+                    &--group {
+                        color: $ibexa-color-light-700;
+                        font-size: $ibexa-text-font-size-small;
+                    }
                 }
             }
 
@@ -70,6 +75,12 @@
 
                     &__toggler {
                         margin-right: calculateRem(6px);
+                    }
+                }
+
+                .ibexa-main-menu__item {
+                    &--group-name:before {
+                        width: 0;
                     }
                 }
             }
@@ -117,6 +128,19 @@
             top: calculateRem(12px);
             left: calculateRem(48px);
         }
+
+        &--group-name {
+            color: $ibexa-color-light-700;
+            font-size: $ibexa-text-font-size-small;
+
+            &:before {
+                content: "";
+                border-top: 1px solid $ibexa-color-info-800;
+                transition: width 0.30s linear;
+                width: 100%;
+                display: block;
+            }
+        }
     }
 
     &__item-action {
@@ -142,6 +166,10 @@
 
                 &__item-text-column {
                     color: $ibexa-color-info;
+
+                    &--group {
+                        color: $ibexa-color-light-700;
+                    }
                 }
             }
         }
@@ -189,10 +217,10 @@
 
         &--bottom {
             width: calc(100% - #{calculateRem(24px)});
-            margin: 0 auto;          
+            margin: 0 auto;
         }
     }
-    
+
     &__resizer {
         position: absolute;
         top: 0;

--- a/src/bundle/Resources/public/scss/_popup-menu.scss
+++ b/src/bundle/Resources/public/scss/_popup-menu.scss
@@ -21,6 +21,19 @@
         &--hidden {
             display: none;
         }
+
+        &--group-name {
+            flex-direction: column;
+            height: 100%;
+            align-items: initial;
+
+            &:before {
+                content: "";
+                border-top: 1px solid $ibexa-color-info-800;
+                width: 100%;
+                display: block;
+            }
+        }
     }
 
     .ibexa-popup-menu__item-content {
@@ -46,6 +59,21 @@
             opacity: 0.2;
             cursor: default;
         }
+
+        &--group-name {
+            color: $ibexa-color-light-700;
+            font-size: $ibexa-text-font-size-small;
+            cursor: initial;
+
+            &:hover {
+                background-color: initial;
+                color: $ibexa-color-light-700;
+            }
+        }
+    }
+
+    .ibexa-popup-menu__items-list {
+        padding-left: 0;
     }
 
     &--info-neon {

--- a/src/bundle/Resources/public/scss/_popup-menu.scss
+++ b/src/bundle/Resources/public/scss/_popup-menu.scss
@@ -26,13 +26,7 @@
             flex-direction: column;
             height: 100%;
             align-items: initial;
-
-            &:before {
-                content: "";
-                border-top: 1px solid $ibexa-color-info-800;
-                width: 100%;
-                display: block;
-            }
+            border-top: calculateRem(1px) solid $ibexa-color-info-800;
         }
     }
 

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -206,6 +206,11 @@
         <target state="new">Content</target>
         <note>key: main__content</note>
       </trans-unit>
+      <trans-unit id="17346107dfddb344b04c455b071d001dadf80d6f" resname="main__content__group_settings">
+        <source>Settings</source>
+        <target state="new">Settings</target>
+        <note>key: main__content__group_settings</note>
+      </trans-unit>
       <trans-unit id="1dd8b693879304af831a7adaf4ca59c7d8cb31b9" resname="main__content__content_structure">
         <source>Content structure</source>
         <target state="new">Content structure</target>

--- a/src/bundle/Resources/views/themes/admin/ui/menu/main_2nd_level.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/main_2nd_level.html.twig
@@ -42,11 +42,13 @@
 
                             <ul id="{{ child.name }}-popup" class="ibexa-popup-menu ibexa-popup-menu--info-neon ibexa-popup-menu--hidden">
                                 {% for item in child.children %}
+                                    {% set renderItemAsGroup = item.children|length > 0 %}
                                     {{ block('popupItem') }}
                                 {% endfor %}
                             </ul>
                         </li>
                         {% for item in child.children %}
+                            {% set renderItemAsGroup = item.children|length > 0 %}
                             {{ block('item') }}
                         {% endfor %}
                     </ul>
@@ -88,9 +90,15 @@
 
     {% set link_attributes = item.linkAttributes|merge(linkAttributes) %}
 
-    <a{{ knp_menu.attributes(link_attributes) }}>
-        <div class="ibexa-main-menu__item-text-column">{{ block('label') }}</div>
-    </a>
+    {% if renderItemAsGroup|default() %}
+        <div {{ knp_menu.attributes(link_attributes) }}>
+            <span class="ibexa-main-menu__item-text-column ibexa-main-menu__item-text-column--group">{{ block('label') }}</span>
+        </div>
+    {% else %}
+        <a {{ knp_menu.attributes(link_attributes) }}>
+            <span class="ibexa-main-menu__item-text-column">{{ block('label') }}</span>
+        </a>
+    {% endif %}
 {% endblock %}
 
 {% block spanElement %}

--- a/src/bundle/Resources/views/themes/admin/ui/menu/main_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/main_base.html.twig
@@ -3,8 +3,13 @@
 
 {% block popupItem %}
     {% if item.displayed %}
+        {% set classes = [
+            'ibexa-popup-menu__item',
+            (renderItemAsGroup|default() ? 'ibexa-popup-menu__item--group-name')
+        ] %}
+
         {% set node_attributes = {
-            'class': 'ibexa-popup-menu__item',
+            'class': classes|join(' ')
         } %}
 
         <li {{ knp_menu.attributes(node_attributes) }}>
@@ -12,6 +17,15 @@
                 {{ block('popupLinkElement') }}
             {%- else %}
                 {{ block('popupSpanElement') }}
+
+                {% if item.children %}
+                    <ul class="ibexa-popup-menu__items-list">
+                        {% for item in item.children %}
+                            {% set renderItemAsGroup = item.children|length > 0 %}
+                            {{ block('popupItem') }}
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             {%- endif %}
         </li>
     {% endif %}
@@ -32,13 +46,17 @@
 {% endblock %}
 
 {% block popupSpanElement %}
-    {{ block('label') }}
+    <div class="ibexa-popup-menu__item-content ibexa-popup-menu__item-content--group-name">{{ block('label') }}</div>
 {% endblock %}
 
 {% block item %}
     {% if item.displayed %}
         {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
         {%- set classes = classes|merge(['ibexa-main-menu__item']) %}
+
+        {% if renderItemAsGroup|default() %}
+            {%- set classes = classes|merge(['ibexa-main-menu__item--group-name']) -%}
+        {% endif %}
 
         {%- if item.extras.separate is defined and item.extras.separate -%}
             {%- set classes = classes|merge(['ibexa-main-menu__item--separator']) -%}
@@ -64,11 +82,20 @@
             <li class="ibexa-main-menu__separator ibexa-main-menu__separator--top"></li>
         {%- endif -%}
 
-        <li{{ knp_menu.attributes(attributes) }}>
+        <li {{ knp_menu.attributes(attributes) }}>
             {%- if item.uri is not empty and (not matcher.isCurrent(item) or options.currentAsLink) %}
                 {{ block('linkElement') }}
             {%- else %}
                 {{ block('spanElement') }}
+
+                {% if item.children and options.depth == 2 %}
+                    <ul class="ibexa-main-menu__items-list">
+                        {% for item in item.children %}
+                            {% set renderItemAsGroup = item.children|length > 0 %}
+                            {{ block('item') }}
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             {%- endif %}
         </li>
 

--- a/src/contracts/Menu/AbstractBuilder.php
+++ b/src/contracts/Menu/AbstractBuilder.php
@@ -41,7 +41,7 @@ abstract class AbstractBuilder
      *
      * @return \Knp\Menu\ItemInterface
      */
-    protected function createMenuItem(string $id, array $options): ?ItemInterface
+    protected function createMenuItem(string $id, array $options = []): ?ItemInterface
     {
         return $this->factory->createItem($id, $options);
     }

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -30,6 +30,7 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
 
     /* Main Menu / Content */
     const ITEM_CONTENT = 'main__content';
+    const ITEM_CONTENT_GROUP_SETTINGS = 'main__content__group_settings';
     const ITEM_CONTENT__CONTENT_STRUCTURE = 'main__content__content_structure';
     const ITEM_CONTENT__MEDIA = 'main__content__media';
 
@@ -174,95 +175,85 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         $token = $this->tokenStorage->getToken();
 
         /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */
-        $menu = $this->factory->createItem('root');
+        $menu = $this->createMenuItem('root');
 
-        $menu->addChild($this->factory->createItem(self::ITEM_DASHBOARD, [
-                'route' => 'ezplatform.dashboard',
-                'attributes' => [
-                    'data-tooltip-placement' => 'right',
-                    'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
-                ],
-                'extras' => [
-                    'icon' => 'dashboard-clean',
-                    'orderNumber' => 20,
-                ],
-            ]
-        ));
+        $contentMenu = $menu->addChild(self::ITEM_CONTENT, [
+            'attributes' => [
+                'data-tooltip-placement' => 'right',
+                'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
+            ],
+            'extras' => [
+                'icon' => 'hierarchy',
+                'orderNumber' => 40,
+            ],
+        ]);
 
-        $menu->addChild($this->factory->createItem(self::ITEM_CONTENT, [
-                'attributes' => [
-                    'data-tooltip-placement' => 'right',
-                    'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
-                ],
-                'extras' => [
-                    'icon' => 'hierarchy',
-                    'orderNumber' => 40,
-                ],
-            ]
-        ));
+        $contentMenu->addChild(self::ITEM_DASHBOARD, [
+            'route' => 'ezplatform.dashboard',
+            'attributes' => [
+                'data-tooltip-placement' => 'right',
+                'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
+            ],
+            'extras' => [
+                'icon' => 'dashboard-clean',
+                'orderNumber' => 20,
+            ],
+        ]);
 
-        $menu->addChild($this->factory->createItem(self::ITEM_ADMIN, [
-                'attributes' => [
-                    'data-tooltip-placement' => 'right',
-                    'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
-                ],
-                'extras' => [
-                    'separate' => true,
-                    'bottom_item' => true,
-                    'icon' => 'settings-block',
-                    'orderNumber' => 140,
-                ],
-            ]
-        ));
+        $adminMenu = $menu->addChild(self::ITEM_ADMIN, [
+            'attributes' => [
+                'data-tooltip-placement' => 'right',
+                'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
+            ],
+            'extras' => [
+                'separate' => true,
+                'bottom_item' => true,
+                'icon' => 'settings-block',
+                'orderNumber' => 140,
+            ],
+        ]);
 
         if (null !== $token && is_object($token->getUser())) {
-            $menu->addChild($this->factory->createItem(self::ITEM_BOOKMARKS, [
-                    'route' => 'ezplatform.bookmark.list',
-                    'attributes' => [
-                        'data-tooltip-placement' => 'right',
-                        'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
-                    ],
-                    'extras' => [
-                        'bottom_item' => true,
-                        'icon' => 'bookmark',
-                        'orderNumber' => 160,
-                    ],
-                ]
-            ));
-        }
-
-        $menu->addChild($this->factory->createItem(self::ITEM_TRASH, [
-                'route' => 'ezplatform.trash.list',
+            $menu->addChild(self::ITEM_BOOKMARKS, [
+                'route' => 'ezplatform.bookmark.list',
                 'attributes' => [
                     'data-tooltip-placement' => 'right',
                     'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
                 ],
                 'extras' => [
                     'bottom_item' => true,
-                    'icon' => 'trash',
-                    'orderNumber' => 180,
+                    'icon' => 'bookmark',
+                    'orderNumber' => 160,
                 ],
-            ]
-        ));
+            ]);
+        }
 
-        $contentMenuItems = $this->getContentMenuItems();
-        $adminMenuItems = $this->getAdminMenuItems();
+        $menu->addChild(self::ITEM_TRASH, [
+            'route' => 'ezplatform.trash.list',
+            'attributes' => [
+                'data-tooltip-placement' => 'right',
+                'data-tooltip-extra-class' => 'ibexa-tooltip--info-neon',
+            ],
+            'extras' => [
+                'bottom_item' => true,
+                'icon' => 'trash',
+                'orderNumber' => 180,
+            ],
+        ]);
 
-        $menu[self::ITEM_CONTENT]->setChildren($contentMenuItems);
-        $menu[self::ITEM_ADMIN]->setChildren($adminMenuItems);
+        $this->addContentMenuItems($contentMenu);
+        $this->addAdminMenuItems($adminMenu);
 
         return $menu;
     }
 
     /**
-     * @return array
+     * @param \Knp\Menu\ItemInterface $menu
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    private function getContentMenuItems(): array
+    private function addContentMenuItems(ItemInterface $menu): void
     {
-        $menuItems = [];
-
         $rootContentId = $this->configResolver->getParameter('location_ids.content_structure');
         $rootMediaId = $this->configResolver->getParameter('location_ids.media');
 
@@ -271,58 +262,79 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
             $rootContentId,
             [
                 'label' => self::ITEM_CONTENT__CONTENT_STRUCTURE,
+                'extras' => [
+                    'orderNumber' => 25,
+                ],
             ]
         );
+
         $mediaItem = $this->factory->createLocationMenuItem(
             self::ITEM_CONTENT__MEDIA,
             $rootMediaId,
-            ['label' => self::ITEM_CONTENT__MEDIA]
+            [
+                'label' => self::ITEM_CONTENT__MEDIA,
+                'extras' => [
+                    'orderNumber' => 35,
+                ],
+            ]
         );
 
-        if (null !== $contentStructureItem) {
-            $menuItems[$contentStructureItem->getName()] = $contentStructureItem;
-        }
-
-        if (null !== $mediaItem) {
-            $menuItems[$mediaItem->getName()] = $mediaItem;
-        }
-
-        return $menuItems;
-    }
-
-    /**
-     * @return array
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
-    private function getAdminMenuItems(): array
-    {
-        $menuItems = [];
+        $contentGroupSettings = $menu->addChild(
+            self::ITEM_CONTENT_GROUP_SETTINGS,
+            [
+                'extras' => [
+                    'orderNumber' => 75,
+                ],
+            ],
+        );
 
         if ($this->permissionResolver->hasAccess('section', 'view') !== false) {
-            $menuItems[self::ITEM_ADMIN__SECTIONS] = $this->createMenuItem(
+            $contentGroupSettings->addChild(
                 self::ITEM_ADMIN__SECTIONS,
                 self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__SECTIONS]
             );
         }
 
+        $contentGroupSettings->addChild(
+            self::ITEM_ADMIN__CONTENT_TYPES,
+            self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__CONTENT_TYPES]
+        );
+
+        if ($this->permissionResolver->hasAccess('state', 'administrate')) {
+            $contentGroupSettings->addChild(
+                self::ITEM_ADMIN__OBJECT_STATES,
+                self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__OBJECT_STATES]
+            );
+        }
+
+        if (null !== $contentStructureItem) {
+            $menu->addChild($contentStructureItem);
+        }
+
+        if (null !== $mediaItem) {
+            $menu->addChild($mediaItem);
+        }
+    }
+
+    /**
+     * @param \Knp\Menu\ItemInterface $menu
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function addAdminMenuItems(ItemInterface $menu): void
+    {
         if ($this->permissionResolver->hasAccess('role', 'read')) {
-            $menuItems[self::ITEM_ADMIN__ROLES] = $this->createMenuItem(
+            $menu->addChild(
                 self::ITEM_ADMIN__ROLES,
                 self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__ROLES]
             );
         }
         if ($this->permissionResolver->hasAccess('setup', 'administrate')) {
-            $menuItems[self::ITEM_ADMIN__LANGUAGES] = $this->createMenuItem(
+            $menu->addChild(
                 self::ITEM_ADMIN__LANGUAGES,
                 self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__LANGUAGES]
             );
         }
-
-        $menuItems[self::ITEM_ADMIN__CONTENT_TYPES] = $this->createMenuItem(
-            self::ITEM_ADMIN__CONTENT_TYPES,
-            self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__CONTENT_TYPES]
-        );
 
         $rootUsersId = $this->configResolver->getParameter('location_ids.users');
         $usersItem = $this->factory->createLocationMenuItem(
@@ -337,22 +349,13 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         );
 
         if (null !== $usersItem) {
-            $menuItems[$usersItem->getName()] = $usersItem;
+            $menu->addChild($usersItem);
         }
 
-        if ($this->permissionResolver->hasAccess('state', 'administrate')) {
-            $menuItems[self::ITEM_ADMIN__OBJECT_STATES] = $this->createMenuItem(
-                self::ITEM_ADMIN__OBJECT_STATES,
-                self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__OBJECT_STATES]
-            );
-        }
-
-        $menuItems[self::ITEM_ADMIN__URL_MANAGEMENT] = $this->createMenuItem(
+        $menu->addChild(
             self::ITEM_ADMIN__URL_MANAGEMENT,
             self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__URL_MANAGEMENT]
         );
-
-        return $menuItems;
     }
 
     /**
@@ -365,6 +368,7 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
             (new Message(self::ITEM_BOOKMARKS, 'menu'))->setDesc('Bookmarks'),
             (new Message(self::ITEM_TRASH, 'menu'))->setDesc('Trash'),
             (new Message(self::ITEM_CONTENT, 'menu'))->setDesc('Content'),
+            (new Message(self::ITEM_CONTENT_GROUP_SETTINGS, 'menu'))->setDesc('Settings'),
             (new Message(self::ITEM_CONTENT__CONTENT_STRUCTURE, 'menu'))->setDesc('Content structure'),
             (new Message(self::ITEM_CONTENT__MEDIA, 'menu'))->setDesc('Media'),
             (new Message(self::ITEM_ADMIN, 'menu'))->setDesc('Admin'),

--- a/src/lib/Menu/MenuItemFactory.php
+++ b/src/lib/Menu/MenuItemFactory.php
@@ -69,11 +69,14 @@ class MenuItemFactory implements FactoryInterface
 
     public function createItem($name, array $options = []): ItemInterface
     {
-        $defaults = [
-            'extras' => ['translation_domain' => 'menu'],
-        ];
+        if (empty($options['extras']['translation_domain'])) {
+            $options['extras']['translation_domain'] = 'menu';
+        }
 
-        return $this->factory->createItem($name, array_merge_recursive($defaults, $options));
+        $item = $this->factory->createItem($name, $options);
+        $item->setFactory($this);
+
+        return $item;
     }
 }
 

--- a/tests/lib/Menu/MainMenuBuilerTest.php
+++ b/tests/lib/Menu/MainMenuBuilerTest.php
@@ -39,6 +39,11 @@ class MainMenuBuilerTest extends TestCase
     protected function setUp(): void
     {
         $knpFactory = $this->createMock(\Knp\Menu\FactoryInterface::class);
+        $knpFactory->method('createItem')
+            ->willReturnCallback(static function (string $name) use ($knpFactory) {
+                return new MenuItem($name, $knpFactory);
+            })
+        ;
 
         $parameterMap = [
             ['location_ids.content_structure', null, null, 5],
@@ -197,7 +202,6 @@ class MainMenuBuilerTest extends TestCase
 
     private function assertMenuHasAllItems(array $menu): void
     {
-        $this->assertArrayHasKey(MainMenuBuilder::ITEM_DASHBOARD, $menu);
         $this->assertArrayHasKey(MainMenuBuilder::ITEM_CONTENT, $menu);
         $this->assertArrayHasKey(MainMenuBuilder::ITEM_ADMIN, $menu);
         $this->assertArrayHasKey(MainMenuBuilder::ITEM_BOOKMARKS, $menu);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1015](https://issues.ibexa.co/browse/IBX-1015)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


As a developer I want to group submenu items and change order of items in groups

![Screenshot 2021-11-16 at 14 44 39](https://user-images.githubusercontent.com/3495796/141996569-caf3bb36-e1c2-4b85-9dd6-0fca2f520d96.png)

![Screenshot 2021-11-17 at 21 02 32](https://user-images.githubusercontent.com/3495796/142273978-c8ea6684-16b7-4e7f-b791-49b19cf37e53.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

follow up for https://github.com/ezsystems/ezplatform-admin-ui/pull/2003