### PR TITLE
Fixed return type declaration for AbstractBuilder::createMenuItem

### DIFF
--- a/src/contracts/Menu/AbstractBuilder.php
+++ b/src/contracts/Menu/AbstractBuilder.php
@@ -41,7 +41,7 @@ abstract class AbstractBuilder
      *
      * @return \Knp\Menu\ItemInterface
      */
-    protected function createMenuItem(string $id, array $options = []): ?ItemInterface
+    protected function createMenuItem(string $id, array $options = []): ItemInterface
     {
         return $this->factory->createItem($id, $options);
     }


### PR DESCRIPTION
This PR fixes invalid return type declaration that causes error: 

`Parameter #1 $child of method Knp\Menu\ItemInterface::addChild() expects Knp\Menu\ItemInterface|string, Knp\Menu\ItemInterface|null given.
` 