### PR TITLE
Moved anchor_params variable to block scope

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
@@ -3,7 +3,6 @@
 {% trans_default_domain 'content_edit' %}
 
 {% set grouped_fields = grouped_fields|default([]) %}
-{% set anchor_params = { items: grouped_fields|keys } %}
 {% set is_autosave_enabled = ibexa_user_settings['autosave'] is same as('enabled') %}
 {% set form_has_autosave = form.autosave is defined %}
 {% set default_form_templates = ibexa_admin_ui_config.contentEditFormTemplates %}
@@ -15,15 +14,21 @@
 
 {% form_theme form with form_templates %}
 
-{% if without_close_button is not defined or without_close_button != true %}
-    {% set referrer_location = content is defined and is_published ? location : parent_location %}
-
-    {% set anchor_params = anchor_params|merge({
-        close_href: path('_ez_content_view', { 'contentId': referrer_location.contentId, 'locationId': referrer_location.id })
-    }) %}
-{% endif %}
-
 {% block main_container_class %}{{ parent() }} {{ extra_main_class }}{% endblock %}
+
+{% block left_sidebar %}
+    {% set anchor_params = { items: grouped_fields|keys } %}
+
+    {% if without_close_button is not defined or without_close_button != true %}
+        {% set referrer_location = content is defined and is_published ? location : parent_location %}
+
+        {% set anchor_params = anchor_params|merge({
+            close_href: path('_ez_content_view', { 'contentId': referrer_location.contentId, 'locationId': referrer_location.id })
+        }) %}
+    {% endif %}
+
+    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+{% endblock %}
 
 {% block content%}
     {% block form_before %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -4,6 +4,10 @@
 
 {% block header_row %}{% endblock %}
 
+{% block left_sidebar %}
+    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+{% endblock %}
+
 {% block content_column %}
     <div class="ibexa-main-container__content-column">
         {% block header %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -5,7 +5,7 @@
 {% block header_row %}{% endblock %}
 
 {% block left_sidebar %}
-    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params|default({}) %}
 {% endblock %}
 
 {% block content_column %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -4,10 +4,6 @@
 
 {% block header_row %}{% endblock %}
 
-{% block left_sidebar %}
-    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
-{% endblock %}
-
 {% block content_column %}
     <div class="ibexa-main-container__content-column">
         {% block header %}{% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

* `anchor_params` variable is used only in  `left_sidebar` block, so it's scope should be narrowed to block.

* `left_sidebar` block could be overwriten in child template so then there is no need to compute `anchor_params` at all

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
