### PR TITLE
[Behat] Fixed System info tests

### DIFF
--- a/features/standard/SystemInfo.feature
+++ b/features/standard/SystemInfo.feature
@@ -46,3 +46,8 @@ Feature: System info verification
         | IbexaAdminUiAssetsBundle |
         | IbexaAdminUiBundle       |
         | IbexaCoreBundle          |
+
+  @javascript
+  Scenario: Check services
+    When I go to "Services" tab in System Information
+    Then I see "Services" system information table

--- a/src/lib/Behat/Page/SystemInfoPage.php
+++ b/src/lib/Behat/Page/SystemInfoPage.php
@@ -11,9 +11,11 @@ namespace Ibexa\AdminUi\Behat\Page;
 use Behat\Mink\Session;
 use Ibexa\AdminUi\Behat\Component\Table\TableBuilder;
 use Ibexa\AdminUi\Behat\Component\TableNavigationTab;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\Behat\Browser\Page\Page;
 use Ibexa\Behat\Browser\Routing\Router;
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
 
 class SystemInfoPage extends Page
@@ -43,7 +45,7 @@ class SystemInfoPage extends Page
 
     public function verifyCurrentTableHeader(string $header)
     {
-        $this->getHTMLPage()->find($this->getLocator('tableTitle'))->assert()->textEquals($header);
+        $this->getHTMLPage()->find($this->getHeaderLocator($header))->assert()->textEquals($header);
     }
 
     public function verifyPackages(array $packages)
@@ -80,8 +82,27 @@ class SystemInfoPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('tableTitle', '.tab-pane.active .ez-fieldgroup__name'),
             new VisibleCSSLocator('packagesTable', '.tab-pane.active .ez-fieldgroup:nth-of-type(2)'),
         ];
+    }
+
+    private function getHeaderLocator(string $header): LocatorInterface
+    {
+        $normalHeader = new VisibleCSSLocator('normalHeader', '.ez-fieldgroup__name');
+        $boldedHeader = new VisibleCSSLocator('boldedHeader', '.ibexa-table-header__headline');
+
+        switch ($header) {
+            case 'Product':
+            case 'Repository':
+            case 'Hardware':
+            case 'PHP':
+            case 'Services':
+                return $normalHeader;
+            case 'Composer':
+            case 'Symfony Kernel':
+                return $boldedHeader;
+            default:
+                throw new InvalidArgumentException(sprintf('Unsupported header: %s', $header));
+        }
     }
 }


### PR DESCRIPTION
Failing build: https://github.com/ibexa/admin-ui/actions/runs/1582117472

```
    Then I see "Composer" system information table    # Ibexa\AdminUi\Behat\BrowserContext\SystemInfoContext::iSeeSystemInformationTable()
      Failed asserting that expected string 'Composer' is equal to actual 'Packages' for css locator 'tableTitle': '.tab-pane.active .ez-fieldgroup__name'
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'Composer'
      +'Packages'
```
```
     Then I see "Symfony Kernel" system information table    # Ibexa\AdminUi\Behat\BrowserContext\SystemInfoContext::iSeeSystemInformationTable()
      Failed asserting that expected string 'Symfony Kernel' is equal to actual 'Bundles' for css locator 'tableTitle': '.tab-pane.active .ez-fieldgroup__name'
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'Symfony Kernel'
      +'Bundles'
```

Adapting tests to the changes done in https://github.com/ibexa/admin-ui/pull/112

I've also decided to use the opportunity and add a quick test for https://github.com/ibexa/system-info/pull/4 