### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -18,7 +18,7 @@ class ComponentPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
-    public const TAG_NAME = 'ezplatform.admin_ui.component';
+    public const TAG_NAME = 'ibexa.admin_ui.component';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
     public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = FieldTypeDefinitionFormMapperDispatcher::class;
-    public const FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ezplatform.field_type.form_mapper.definition';
+    public const FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ibexa.admin_ui.field_type.form.mapper.definition';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
     public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = FieldTypeDefinitionFormMapperDispatcher::class;
-    public const DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ez.fieldFormMapper.definition';
     public const FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ezplatform.field_type.form_mapper.definition';
 
     public function process(ContainerBuilder $container)
@@ -29,50 +28,23 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 
         $dispatcherDefinition = $container->findDefinition(self::FIELD_TYPE_FORM_MAPPER_DISPATCHER);
 
-        foreach ($this->findTaggedFormMapperServices($container) as $id => $tags) {
+        $serviceTags = $container->findTaggedServiceIds(
+            self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG
+        );
+        foreach ($serviceTags as $id => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['fieldType'])) {
                     throw new LogicException(
-                        '`ezplatform.field_type.form_mapper` or deprecated `ez.fieldFormMapper` service tags need a "fieldType" attribute to identify which Field Type the mapper is for.'
+                        sprintf(
+                            '`%s` service tag needs a "fieldType" attribute to identify which Field Type the mapper is for.',
+                            self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG
+                        )
                     );
                 }
 
                 $dispatcherDefinition->addMethodCall('addMapper', [new Reference($id), $tag['fieldType']]);
             }
         }
-    }
-
-    /**
-     * Gathers services tagged as either
-     * - ez.fieldFormMapper.value (deprecated)
-     * - ez.fieldFormMapper.definition (deprecated)
-     * - ezplatform.field_type.form_mapper.value
-     * - ezplatform.field_type.form_mapper.definition.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return array
-     */
-    private function findTaggedFormMapperServices(ContainerBuilder $container): array
-    {
-        $deprecatedFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG);
-        $fieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG);
-
-        foreach ($deprecatedFieldFormMapperDefinitionTags as $ezFieldFormMapperValueTag) {
-            @trigger_error(
-                sprintf(
-                    'The `%s` service tag is deprecated and will be removed in eZ Platform 4.0. Use `%s` instead.',
-                    self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG,
-                    self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
-        return array_merge(
-            $deprecatedFieldFormMapperDefinitionTags,
-            $fieldFormMapperDefinitionTags
-        );
     }
 }
 

--- a/src/bundle/DependencyInjection/Compiler/LimitationFormMapperPass.php
+++ b/src/bundle/DependencyInjection/Compiler/LimitationFormMapperPass.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class LimitationFormMapperPass implements CompilerPassInterface
 {
+    private const LIMITATION_MAPPER_FORM_TAG = 'ibexa.admin_ui.limitation.mapper.form';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezplatform.content_forms.limitation_form_mapper.registry')) {
@@ -24,15 +26,22 @@ class LimitationFormMapperPass implements CompilerPassInterface
 
         $registry = $container->findDefinition('ezplatform.content_forms.limitation_form_mapper.registry');
 
-        foreach ($container->findTaggedServiceIds('ez.limitation.formMapper') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            self::LIMITATION_MAPPER_FORM_TAG
+        );
+        foreach ($taggedServiceIds as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['limitationType'])) {
                     throw new LogicException(
-                        'ez.limitation.formMapper service tag needs a "limitationType" attribute to identify which LimitationType the mapper is for.'
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs a "limitationType" attribute to identify which LimitationType the mapper is for.',
+                            $serviceId,
+                            self::LIMITATION_MAPPER_FORM_TAG
+                        )
                     );
                 }
 
-                $registry->addMethodCall('addMapper', [new Reference($id), $attribute['limitationType']]);
+                $registry->addMethodCall('addMapper', [new Reference($serviceId), $attribute['limitationType']]);
             }
         }
     }

--- a/src/bundle/DependencyInjection/Compiler/LimitationValueMapperPass.php
+++ b/src/bundle/DependencyInjection/Compiler/LimitationValueMapperPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class LimitationValueMapperPass implements CompilerPassInterface
 {
     public const LIMITATION_VALUE_MAPPER_REGISTRY = 'ezplatform.content_forms.limitation_value_mapper.registry';
-    public const LIMITATION_VALUE_MAPPER_TAG = 'ez.limitation.valueMapper';
+    public const LIMITATION_VALUE_MAPPER_TAG = 'ibexa.admin_ui.limitation.mapper.value';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/bundle/DependencyInjection/Compiler/TabPass.php
+++ b/src/bundle/DependencyInjection/Compiler/TabPass.php
@@ -18,7 +18,7 @@ class TabPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
-    public const TAG_TAB = 'ezplatform.tab';
+    public const TAG_TAB = 'ibexa.admin_ui.tab';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/src/bundle/DependencyInjection/Compiler/UiConfigProviderPass.php
+++ b/src/bundle/DependencyInjection/Compiler/UiConfigProviderPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class UiConfigProviderPass implements CompilerPassInterface
 {
-    public const TAG_CONFIG_PROVIDER = 'ezplatform.admin_ui.config_provider';
+    public const TAG_CONFIG_PROVIDER = 'ibexa.admin_ui.config.provider';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/src/bundle/Resources/config/services/components/content/edit.yaml
+++ b/src/bundle/Resources/config/services/components/content/edit.yaml
@@ -6,4 +6,4 @@ services:
 
     Ibexa\AdminUi\Component\Content\PreviewUnavailableTwigComponent:
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'content-edit-form-before' }
+            - { name: ibexa.admin_ui.component, group: 'content-edit-form-before' }

--- a/src/bundle/Resources/config/services/dashboard.yaml
+++ b/src/bundle/Resources/config/services/dashboard.yaml
@@ -5,7 +5,7 @@ services:
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.tab, group: dashboard-my }
+            - { name: ibexa.admin_ui.tab, group: dashboard-my }
 
     Ibexa\AdminUi\Tab\Dashboard\MyContentTab:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
@@ -13,7 +13,7 @@ services:
         arguments:
             $contentSubtreeQueryType: '@Ibexa\AdminUi\QueryType\ContentSubtreeQueryType'
         tags:
-            - { name: ezplatform.tab, group: dashboard-my }
+            - { name: ibexa.admin_ui.tab, group: dashboard-my }
 
     Ibexa\AdminUi\Tab\Dashboard\MyMediaTab:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
@@ -21,7 +21,7 @@ services:
         arguments:
             $mediaSubtreeQueryType: '@Ibexa\AdminUi\QueryType\MediaSubtreeQueryType'
         tags:
-            - { name: ezplatform.tab, group: dashboard-my }
+            - { name: ibexa.admin_ui.tab, group: dashboard-my }
 
     Ibexa\AdminUi\Tab\Dashboard\EveryoneMediaTab:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
@@ -29,7 +29,7 @@ services:
         arguments:
             $mediaSubtreeQueryType: '@Ibexa\AdminUi\QueryType\MediaSubtreeQueryType'
         tags:
-            - { name: ezplatform.tab, group: dashboard-everyone }
+            - { name: ibexa.admin_ui.tab, group: dashboard-everyone }
 
     Ibexa\AdminUi\Tab\Dashboard\EveryoneContentTab:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
@@ -37,7 +37,7 @@ services:
         arguments:
             $contentSubtreeQueryType: '@Ibexa\AdminUi\QueryType\ContentSubtreeQueryType'
         tags:
-            - { name: ezplatform.tab, group: dashboard-everyone }
+            - { name: ibexa.admin_ui.tab, group: dashboard-everyone }
 
     Ibexa\AdminUi\Tab\Dashboard\PagerContentToDataMapper:
         parent: Ibexa\AdminUi\Pagination\Mapper\AbstractPagerContentToDataMapper
@@ -49,25 +49,25 @@ services:
         arguments:
             $template: '@@ezdesign/ui/dashboard/block/me.html.twig'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'dashboard-blocks' }
+            - { name: ibexa.admin_ui.component, group: 'dashboard-blocks' }
 
     ezplatform.adminui.dashboard.all:
         parent: Ibexa\AdminUi\Component\TwigComponent
         arguments:
             $template: '@@ezdesign/ui/dashboard/block/all.html.twig'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'dashboard-blocks' }
+            - { name: ibexa.admin_ui.component, group: 'dashboard-blocks' }
 
     ezplatform.adminui.dashboard.my.tab_groups:
         parent: Ibexa\AdminUi\Component\TabsComponent
         arguments:
             $groupIdentifier: 'dashboard-my'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'dashboard-my-tab-groups' }
+            - { name: ibexa.admin_ui.component, group: 'dashboard-my-tab-groups' }
 
     ezplatform.adminui.dashboard.all.tab_groups:
         parent: Ibexa\AdminUi\Component\TabsComponent
         arguments:
             $groupIdentifier: 'dashboard-everyone'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'dashboard-all-tab-groups' }
+            - { name: ibexa.admin_ui.component, group: 'dashboard-all-tab-groups' }

--- a/src/bundle/Resources/config/services/fieldtype_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/fieldtype_form_mappers.yaml
@@ -15,51 +15,51 @@ services:
 
     Ibexa\AdminUi\FieldType\Mapper\AuthorFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezauthor }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezauthor }
 
     Ibexa\AdminUi\FieldType\Mapper\BinaryFileFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezbinaryfile }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezbinaryfile }
 
     Ibexa\AdminUi\FieldType\Mapper\CheckboxFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezboolean }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezboolean }
 
     Ibexa\AdminUi\FieldType\Mapper\SelectionFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezselection }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezselection }
 
     Ibexa\AdminUi\FieldType\Mapper\CountryFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezcountry }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezcountry }
 
     Ibexa\AdminUi\FieldType\Mapper\DateFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezdate }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezdate }
 
     Ibexa\AdminUi\FieldType\Mapper\DateTimeFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezdatetime }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezdatetime }
 
     Ibexa\AdminUi\FieldType\Mapper\FloatFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezfloat }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezfloat }
 
     Ibexa\AdminUi\FieldType\Mapper\ImageFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezimage }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezimage }
 
     Ibexa\AdminUi\FieldType\Mapper\IntegerFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezinteger }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezinteger }
 
     Ibexa\AdminUi\FieldType\Mapper\ISBNFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezisbn }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezisbn }
 
     Ibexa\AdminUi\FieldType\Mapper\MediaFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezmedia }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezmedia }
 
     Ibexa\AdminUi\FieldType\Mapper\RelationFormMapper:
         parent: Ibexa\AdminUi\FieldType\Mapper\AbstractRelationFormMapper
@@ -67,7 +67,7 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezobjectrelation }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezobjectrelation }
 
     Ibexa\AdminUi\FieldType\Mapper\RelationListFormMapper:
         parent: Ibexa\AdminUi\FieldType\Mapper\AbstractRelationFormMapper
@@ -75,20 +75,20 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezobjectrelationlist }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezobjectrelationlist }
 
     Ibexa\AdminUi\FieldType\Mapper\TextLineFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezstring }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezstring }
 
     Ibexa\AdminUi\FieldType\Mapper\TextBlockFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: eztext }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: eztext }
 
     Ibexa\AdminUi\FieldType\Mapper\TimeFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: eztime }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: eztime }
 
     Ibexa\AdminUi\FieldType\Mapper\UserAccountFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezuser }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezuser }

--- a/src/bundle/Resources/config/services/form_ui_action_mappers.yaml
+++ b/src/bundle/Resources/config/services/form_ui_action_mappers.yaml
@@ -9,12 +9,12 @@ services:
 
     Ibexa\AdminUi\UI\Action\FormUiActionMapper:
         tags:
-            - { name: ezplatform.admin_ui.form_ui_action_mapper }
+            - { name: ibexa.admin_ui.form_ui.mapper.action }
 
     Ibexa\Contracts\AdminUi\UI\Action\FormUiActionMapperInterface:
         alias: 'Ibexa\AdminUi\UI\Action\FormUiActionMapper'
 
     Ibexa\AdminUi\UI\Action\FormUiActionMappingDispatcher:
         arguments:
-            $mappers: !tagged ezplatform.admin_ui.form_ui_action_mapper
+            $mappers: !tagged ibexa.admin_ui.form_ui.mapper.action
             $defaultMapper: '@Ibexa\AdminUi\UI\Action\FormUiActionMapper'

--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -6,7 +6,7 @@ services:
 
     _instanceof:
         Ibexa\AdminUi\Form\TrashLocationOptionProvider\TrashLocationOptionProvider:
-            tags: ['ezplatform.form.trash_location_option']
+            tags: [ ibexa.admin_ui.form.trash_location_option ]
 
     Ibexa\AdminUi\Form\SubmitHandler: ~
 
@@ -358,22 +358,22 @@ services:
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\HasAssetRelation:
         tags:
-            - { name: 'ezplatform.form.trash_location_option', priority: 40 }
+            - { name: ibexa.admin_ui.form.trash_location_option, priority: 40 }
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\HasChildren:
         tags:
-            - { name: 'ezplatform.form.trash_location_option', priority: 80 }
+            - { name: ibexa.admin_ui.form.trash_location_option, priority: 80 }
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\HasReverseRelations:
         tags:
-            - { name: 'ezplatform.form.trash_location_option', priority: 100 }
+            - { name: ibexa.admin_ui.form.trash_location_option, priority: 100 }
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\HasUniqueAssetRelation:
         tags:
-            - { name: 'ezplatform.form.trash_location_option', priority: 60 }
+            - { name: ibexa.admin_ui.form.trash_location_option, priority: 60 }
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\OptionsFactory:
-        arguments: [!tagged ezplatform.form.trash_location_option]
+        arguments: [!tagged ibexa.admin_ui.form.trash_location_option]
 
     Ibexa\AdminUi\Form\Extension\RichTextTypeExtension:
         public: true

--- a/src/bundle/Resources/config/services/modules/content_tree.yaml
+++ b/src/bundle/Resources/config/services/modules/content_tree.yaml
@@ -13,4 +13,4 @@ services:
 
     Ibexa\AdminUi\UI\Config\Provider\Module\ContentTree:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'contentTree' }
+            - { name: ibexa.admin_ui.config.provider, key: 'contentTree' }

--- a/src/bundle/Resources/config/services/modules/subitems.yaml
+++ b/src/bundle/Resources/config/services/modules/subitems.yaml
@@ -10,7 +10,7 @@ services:
         autoconfigure: false
         public: true
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\AdminUi\UI\Module\Subitems\Values\SubitemsRow }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\AdminUi\UI\Module\Subitems\Values\SubitemsRow }
 
     Ibexa\AdminUi\UI\Module\Subitems\ValueObjectVisitor\SubitemsList:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -18,7 +18,7 @@ services:
         autoconfigure: false
         public: true
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\AdminUi\UI\Module\Subitems\Values\SubitemsList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\AdminUi\UI\Module\Subitems\Values\SubitemsList }
 
     Ibexa\AdminUi\UI\Module\Subitems\ContentViewParameterSupplier:
         $outputVisitor: '@ezpublish_rest.output.visitor.json'

--- a/src/bundle/Resources/config/services/rest.yaml
+++ b/src/bundle/Resources/config/services/rest.yaml
@@ -2,17 +2,17 @@ services:
   Ibexa\AdminUi\REST\Input\Parser\BulkOperation:
       parent: ezpublish_rest.input.parser
       tags:
-        - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.BulkOperation }
+        - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.BulkOperation }
 
   Ibexa\AdminUi\REST\Input\Parser\Operation:
       parent: ezpublish_rest.input.parser
       tags:
-        - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.Operation }
+        - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.Operation }
 
   Ibexa\AdminUi\REST\Output\ValueObjectVisitor\BulkOperationResponse:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
-        - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\AdminUi\REST\Value\BulkOperationResponse }
+        - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\AdminUi\REST\Value\BulkOperationResponse }
 
   #
   # Content Tree
@@ -21,22 +21,22 @@ services:
   Ibexa\AdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequestNode:
     parent: ezpublish_rest.input.parser
     tags:
-      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTreeLoadSubtreeRequestNode }
+      - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTreeLoadSubtreeRequestNode }
 
   Ibexa\AdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequest:
     parent: ezpublish_rest.input.parser
     tags:
-      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTreeLoadSubtreeRequest }
+      - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTreeLoadSubtreeRequest }
 
   Ibexa\AdminUi\REST\Output\ValueObjectVisitor\ContentTree\Node:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
-          - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\AdminUi\REST\Value\ContentTree\Node }
+          - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\AdminUi\REST\Value\ContentTree\Node }
 
   Ibexa\AdminUi\REST\Output\ValueObjectVisitor\ContentTree\Root:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
-          - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\AdminUi\REST\Value\ContentTree\Root }
+          - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\AdminUi\REST\Value\ContentTree\Root }
 
   #
   # Content type create/edit form
@@ -44,17 +44,17 @@ services:
   Ibexa\AdminUi\REST\Input\Parser\ContentType\FieldDefinitionCreate:
     parent: ezpublish_rest.input.parser
     tags:
-      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypFieldDefinitionCreate }
+      - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypFieldDefinitionCreate }
 
   Ibexa\AdminUi\REST\Input\Parser\ContentType\FieldDefinitionDelete:
     parent: ezpublish_rest.input.parser
     tags:
-      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeFieldDefinitionDelete }
+      - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeFieldDefinitionDelete }
 
   Ibexa\AdminUi\REST\Input\Parser\ContentType\FieldDefinitionReorder:
     parent: ezpublish_rest.input.parser
     tags:
-      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeFieldDefinitionReorder }
+      - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeFieldDefinitionReorder }
 
   Ibexa\AdminUi\REST\Security\NonAdminRESTRequestMatcher:
       arguments:

--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -41,15 +41,15 @@ services:
             - '@ezpublish.siteaccess_service'
             - '@Ibexa\AdminUi\Siteaccess\SiteAccessKeyGenerator'
         tags:
-            - { name: ez.limitation.formMapper, limitationType: SiteAccess }
-            - { name: ez.limitation.valueMapper, limitationType: SiteAccess }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: SiteAccess }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: SiteAccess }
 
     ezplatform.content_forms.limitation.form_mapper.null:
         class: "%ezplatform.content_forms.limitation.form_mapper.null.class%"
         arguments: ["%ezplatform.content_forms.limitation.null.template%"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: "Null" }
-            - { name: ez.limitation.valueMapper, limitationType: "Null" }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: "Null" }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: "Null" }
 
     ezplatform.content_forms.limitation.form_mapper.content_type:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -61,8 +61,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Class }
-            - { name: ez.limitation.valueMapper, limitationType: Class }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Class }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Class }
 
     ezplatform.content_forms.limitation.form_mapper.parent_content_type:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -74,8 +74,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: ParentClass }
-            - { name: ez.limitation.valueMapper, limitationType: ParentClass }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: ParentClass }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: ParentClass }
 
     ezplatform.content_forms.limitation.form_mapper.section:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -87,8 +87,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Section }
-            - { name: ez.limitation.valueMapper, limitationType: Section }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Section }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Section }
 
     ezplatform.content_forms.limitation.form_mapper.new_section:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -100,8 +100,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: NewSection }
-            - { name: ez.limitation.valueMapper, limitationType: NewSection }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: NewSection }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: NewSection }
 
     ezplatform.content_forms.limitation.form_mapper.object_state:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -113,8 +113,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: State }
-            - { name: ez.limitation.valueMapper, limitationType: State }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: State }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: State }
 
     ezplatform.content_forms.limitation.form_mapper.new_object_state:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -126,8 +126,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: NewState }
-            - { name: ez.limitation.valueMapper, limitationType: NewState }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: NewState }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: NewState }
 
     ezplatform.content_forms.limitation.form_mapper.language:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -139,8 +139,8 @@ services:
         calls:
             - [setLogger, ['@?logger']]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Language }
-            - { name: ez.limitation.valueMapper, limitationType: Language }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Language }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Language }
 
     ezplatform.content_forms.limitation.form_mapper.owner:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -150,8 +150,8 @@ services:
         class: "%ezplatform.content_forms.limitation.form_mapper.owner.class%"
         arguments: ["@translator"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Owner }
-            - { name: ez.limitation.valueMapper, limitationType: Owner }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Owner }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Owner }
 
     ezplatform.content_forms.limitation.form_mapper.parent_owner:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -161,8 +161,8 @@ services:
         class: "%ezplatform.content_forms.limitation.form_mapper.owner.class%"
         arguments: ["@translator"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: ParentOwner }
-            - { name: ez.limitation.valueMapper, limitationType: ParentOwner }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: ParentOwner }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: ParentOwner }
 
     ezplatform.content_forms.limitation.form_mapper.group:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -172,8 +172,8 @@ services:
         class: "%ezplatform.content_forms.limitation.form_mapper.group.class%"
         arguments: ["@translator"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Group }
-            - { name: ez.limitation.valueMapper, limitationType: Group }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Group }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Group }
 
     ezplatform.content_forms.limitation.form_mapper.parent_group:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -183,8 +183,8 @@ services:
         class: "%ezplatform.content_forms.limitation.form_mapper.group.class%"
         arguments: ["@translator"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: ParentGroup }
-            - { name: ez.limitation.valueMapper, limitationType: ParentGroup }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: ParentGroup }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: ParentGroup }
 
     ezplatform.content_forms.limitation.form_mapper.parent_depth:
         parent: ezplatform.content_forms.limitation.form_mapper.multiple_selection
@@ -194,8 +194,8 @@ services:
         class: "%ezplatform.content_forms.limitation.form_mapper.parent_depth.class%"
         arguments: ["%ezplatform.content_forms.limitation.form_mapper.parent_depth.max_depth%"]
         tags:
-            - { name: ez.limitation.formMapper, limitationType: ParentDepth }
-            - { name: ez.limitation.valueMapper, limitationType: ParentDepth }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: ParentDepth }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: ParentDepth }
 
     ezplatform.content_forms.limitation.form_mapper.udw_based:
         class: Ibexa\AdminUi\Limitation\Mapper\UDWBasedMapper
@@ -211,8 +211,8 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Node }
-            - { name: ez.limitation.valueMapper, limitationType: Node }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Node }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Node }
 
     ezplatform.content_forms.limitation.form_mapper.subtree:
         parent: ezplatform.content_forms.limitation.form_mapper.udw_based
@@ -221,5 +221,5 @@ services:
         public: false
         class: "%ezplatform.content_forms.limitation.form_mapper.subtree.class%"
         tags:
-            - { name: ez.limitation.formMapper, limitationType: Subtree }
-            - { name: ez.limitation.valueMapper, limitationType: Subtree }
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Subtree }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Subtree }

--- a/src/bundle/Resources/config/services/search.yaml
+++ b/src/bundle/Resources/config/services/search.yaml
@@ -3,4 +3,4 @@ services:
     autowire: true
     public: false
     tags:
-      - { name: ezplatform.admin_ui.component, group: global-search }
+      - { name: ibexa.admin_ui.component, group: global-search }

--- a/src/bundle/Resources/config/services/siteaccess.yaml
+++ b/src/bundle/Resources/config/services/siteaccess.yaml
@@ -12,7 +12,7 @@ services:
 
     Ibexa\AdminUi\Siteaccess\SiteaccessResolver:
         arguments:
-            $siteaccessPreviewVoters: !tagged ezplatform.admin_ui.siteaccess_preview_voter
+            $siteaccessPreviewVoters: !tagged ibexa.admin_ui.site_access.preview.voter
             $siteAccessService: '@ezpublish.siteaccess_service'
 
     Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver:
@@ -22,4 +22,4 @@ services:
     Ibexa\AdminUi\Siteaccess\AdminSiteaccessPreviewVoter:
         arguments:
             $repositoryConfigurationProvider: '@ezpublish.api.repository_configuration_provider'
-        tags: ['ezplatform.admin_ui.siteaccess_preview_voter']
+        tags: [ ibexa.admin_ui.site_access.preview.voter ]

--- a/src/bundle/Resources/config/services/strategies.yaml
+++ b/src/bundle/Resources/config/services/strategies.yaml
@@ -8,4 +8,4 @@ services:
 
     Ibexa\AdminUi\Strategy\ContentTypeThumbnailStrategy:
         tags:
-            - { name: ezplatform.spi.content.thumbnail_strategy, priority: -100 }
+            - { name: ibexa.repository.thumbnail.strategy.content, priority: -100 }

--- a/src/bundle/Resources/config/services/tabs/content_type.yaml
+++ b/src/bundle/Resources/config/services/tabs/content_type.yaml
@@ -4,7 +4,7 @@ services:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractEventDispatchingTab
         public: true
         tags:
-            - { name: ezplatform.tab, group: content-type }
+            - { name: ibexa.admin_ui.tab, group: content-type }
 
     ezplatform.adminui.content_type.tab_groups:
         parent: Ibexa\AdminUi\Component\TabsComponent
@@ -12,4 +12,4 @@ services:
             $template: '@@ezdesign/ui/tab/content_type.html.twig'
             $groupIdentifier: 'content-type'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'content-type-tab-groups' }
+            - { name: ibexa.admin_ui.component, group: 'content-type-tab-groups' }

--- a/src/bundle/Resources/config/services/tabs/locationview.yaml
+++ b/src/bundle/Resources/config/services/tabs/locationview.yaml
@@ -4,21 +4,21 @@ services:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
         public: true
         tags:
-            - { name: ezplatform.tab, group: location-view }
+            - { name: ibexa.admin_ui.tab, group: location-view }
 
     Ibexa\AdminUi\Tab\LocationView\RolesTab:
         autowire: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.tab, group: location-view }
+            - { name: ibexa.admin_ui.tab, group: location-view }
 
     Ibexa\AdminUi\Tab\LocationView\PoliciesTab:
         autowire: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.tab, group: location-view }
+            - { name: ibexa.admin_ui.tab, group: location-view }
 
     Ibexa\AdminUi\Tab\LocationView\ContentTab:
         public: true
@@ -26,7 +26,7 @@ services:
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.tab, group: location-view }
+            - { name: ibexa.admin_ui.tab, group: location-view }
 
     ezplatform.adminui.location_view.tab_groups:
         parent: Ibexa\AdminUi\Component\TabsComponent
@@ -34,11 +34,11 @@ services:
             $template: '@@ezdesign/ui/tab/location_view.html.twig'
             $groupIdentifier: 'location-view'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'location-view-tab-groups' }
+            - { name: ibexa.admin_ui.component, group: 'location-view-tab-groups' }
 
     Ibexa\AdminUi\Tab\LocationView\UrlsTab:
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractEventDispatchingTab
         arguments:
             $translationHelper: '@ezpublish.translation_helper'
         tags:
-            - { name: ezplatform.tab, group: location-view }
+            - { name: ibexa.admin_ui.tab, group: location-view }

--- a/src/bundle/Resources/config/services/tabs/url_management.yaml
+++ b/src/bundle/Resources/config/services/tabs/url_management.yaml
@@ -5,16 +5,16 @@ services:
             $template: '@@ezdesign/ui/tab/url_management.html.twig'
             $groupIdentifier: 'link-manager'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'link-manager-block' }
+            - { name: ibexa.admin_ui.component, group: 'link-manager-block' }
 
     Ibexa\AdminUi\Tab\URLManagement\URLWildcardsTab:
         class: Ibexa\AdminUi\Tab\URLManagement\URLWildcardsTab
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
         tags:
-            - { name: ezplatform.tab, group: 'link-manager' }
+            - { name: ibexa.admin_ui.tab, group: 'link-manager' }
 
     Ibexa\AdminUi\Tab\URLManagement\LinkManagerTab:
         class: Ibexa\AdminUi\Tab\URLManagement\LinkManagerTab
         parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
         tags:
-            - { name: ezplatform.tab, group: 'link-manager' }
+            - { name: ibexa.admin_ui.tab, group: 'link-manager' }

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -18,15 +18,15 @@ services:
             $fallbackContentType: '%ezplatform.multifile_upload.fallback_content_type%'
             $maxFileSize: '%ez_systems.multifile_upload.max_file_size%'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'multiFileUpload' }
+            - { name: ibexa.admin_ui.config.provider, key: 'multiFileUpload' }
 
     Ibexa\AdminUi\UI\Config\Provider\SortFieldMappings:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'sortFieldMappings' }
+            - { name: ibexa.admin_ui.config.provider, key: 'sortFieldMappings' }
 
     Ibexa\AdminUi\UI\Config\Provider\SortOrderMappings:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'sortOrderMappings' }
+            - { name: ibexa.admin_ui.config.provider, key: 'sortOrderMappings' }
 
     ezsystems.ezplatform_admin_ui.ui.config.provider.image_variations:
         class: Ibexa\AdminUi\UI\Config\Provider\ScopeParameterBasedValue
@@ -35,7 +35,7 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $parameterName: 'image_variations'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'imageVariations' }
+            - { name: ibexa.admin_ui.config.provider, key: 'imageVariations' }
 
     ezsystems.ezplatform_admin_ui.ui.config.provider.content_edit_form_templates:
         class: Ibexa\AdminUi\UI\Config\Provider\ScopeParameterBasedValue
@@ -44,53 +44,53 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $parameterName: 'admin_ui_forms.content_edit_form_templates'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'contentEditFormTemplates' }
+            - { name: ibexa.admin_ui.config.provider, key: 'contentEditFormTemplates' }
 
     Ibexa\AdminUi\UI\Config\Provider\User:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'user' }
+            - { name: ibexa.admin_ui.config.provider, key: 'user' }
 
     Ibexa\AdminUi\UI\Config\Provider\Languages:
         arguments:
             $siteAccesses: '%ezpublish.siteaccess.list%'
             $siteAccessService: '@ezpublish.siteaccess_service'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'languages' }
+            - { name: ibexa.admin_ui.config.provider, key: 'languages' }
 
     Ibexa\AdminUi\UI\Config\Provider\ContentTypes:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'contentTypes' }
+            - { name: ibexa.admin_ui.config.provider, key: 'contentTypes' }
 
     Ibexa\AdminUi\UI\Config\Provider\Module\UniversalDiscoveryWidget:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'universalDiscoveryWidget' }
+            - { name: ibexa.admin_ui.config.provider, key: 'universalDiscoveryWidget' }
 
     Ibexa\AdminUi\UI\Config\Provider\Module\SubItemsList:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'subItems' }
+            - { name: ibexa.admin_ui.config.provider, key: 'subItems' }
 
     Ibexa\AdminUi\UI\Config\Provider\FieldType\ImageAsset\Mapping:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'imageAssetMapping' }
+            - { name: ibexa.admin_ui.config.provider, key: 'imageAssetMapping' }
 
     # Notifications
     Ibexa\AdminUi\UI\Config\Provider\Notifications:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'notifications' }
+            - { name: ibexa.admin_ui.config.provider, key: 'notifications' }
 
     # Date related configuration
     Ibexa\AdminUi\UI\Config\Provider\Timezone:
         class: Ibexa\AdminUi\UI\Config\Provider\Timezone
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'timezone' }
+            - { name: ibexa.admin_ui.config.provider, key: 'timezone' }
 
     Ibexa\AdminUi\UI\Config\Provider\DateFormat:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'dateFormat' }
+            - { name: ibexa.admin_ui.config.provider, key: 'dateFormat' }
 
     Ibexa\AdminUi\UI\Config\Provider\Autosave:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'autosave' }
+            - { name: ibexa.admin_ui.config.provider, key: 'autosave' }
 
     Ibexa\Bundle\AdminUi\Templating\Twig\PathStringExtension: ~
 
@@ -98,11 +98,11 @@ services:
 
     Ibexa\AdminUi\UI\Config\Provider\UserContentTypes:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'userContentTypes' }
+            - { name: ibexa.admin_ui.config.provider, key: 'userContentTypes' }
 
     Ibexa\AdminUi\UI\Config\Provider\Sections:
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'sections' }
+            - { name: ibexa.admin_ui.config.provider, key: 'sections' }
 
     Ibexa\Bundle\AdminUi\Templating\Twig\TimeDiffExtension: ~
 
@@ -110,10 +110,10 @@ services:
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'locations' }
+            - { name: ibexa.admin_ui.config.provider, key: 'locations' }
 
     Ibexa\AdminUi\UI\Config\Provider\IconPaths:
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezplatform.admin_ui.config_provider, key: 'iconPaths' }
+            - { name: ibexa.admin_ui.config.provider, key: 'iconPaths' }

--- a/src/bundle/Resources/config/services/user_settings.yaml
+++ b/src/bundle/Resources/config/services/user_settings.yaml
@@ -13,10 +13,10 @@ services:
 
     Ibexa\AdminUi\UserSetting\Autosave:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: autosave, group: content_edit, priority: 30 }
-            - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: autosave }
+            - { name: ibexa.user.setting.value, identifier: autosave, group: content_edit, priority: 30 }
+            - { name: ibexa.user.setting.mapper.form, identifier: autosave }
 
     Ibexa\AdminUi\UserSetting\AutosaveInterval:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: autosave_interval, group: content_edit, priority: 20 }
-            - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: autosave_interval }
+            - { name: ibexa.user.setting.value, identifier: autosave_interval, group: content_edit, priority: 20 }
+            - { name: ibexa.user.setting.mapper.form, identifier: autosave_interval }

--- a/src/bundle/Resources/config/services/views.yaml
+++ b/src/bundle/Resources/config/services/views.yaml
@@ -14,13 +14,13 @@ services:
             $viewParametersInjector: '@ezpublish.view.view_parameters.injector.dispatcher'
             $contentActionDispatcher: '@ezplatform.content_forms.action_dispatcher.content'
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }
 
     Ibexa\AdminUi\View\Provider\ContentTranslateView\Configured:
         arguments:
             $matcherFactory: '@ezplatform.admin_ui.view.content_translate.matcher_factory'
         tags:
-            - { name: ezpublish.view_provider, type: Ibexa\AdminUi\View\ContentTranslateView, priority: 10 }
+            - { name: ibexa.view.provider, type: Ibexa\AdminUi\View\ContentTranslateView, priority: 10 }
 
     ezplatform.admin_ui.view.content_translate.matcher_factory:
         class: '%ezpublish.view.matcher_factory.class%'

--- a/src/contracts/Tab/TabInterface.php
+++ b/src/contracts/Tab/TabInterface.php
@@ -10,7 +10,7 @@ namespace Ibexa\Contracts\AdminUi\Tab;
 
 /**
  * Tab interface representing UI tabs. Tabs are assigned to groups which are rendered in the UI.
- * Use `ezplatform.tab` tag with attribute `group` to tag your concrete implementation service.
+ * Use `ibexa.admin_ui.tab` tag with attribute `group` to tag your concrete implementation service.
  */
 interface TabInterface
 {

--- a/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -49,7 +49,6 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
     public function tagsProvider(): array
     {
         return [
-            [FieldTypeFormMapperDispatcherPass::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG],
             [FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG],
         ];
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

Additionally, the support for the service tag `ez.fieldFormMapper.definition` deprecated prior Ibexa v3.3 has been dropped.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review