### PR TITLE
IBX-1772: Passed created content draft to ContentProxyCreateEvent context

### DIFF
--- a/src/contracts/Event/ContentProxyCreateEvent.php
+++ b/src/contracts/Event/ContentProxyCreateEvent.php
@@ -18,6 +18,9 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class ContentProxyCreateEvent extends Event
 {
+    public const OPTION_CONTENT_DRAFT = 'contentDraft';
+    public const OPTION_IS_ON_THE_FLY = 'isOnTheFly';
+
     /** @var \Symfony\Component\HttpFoundation\Response|null */
     private $response;
 

--- a/src/lib/Event/Options.php
+++ b/src/lib/Event/Options.php
@@ -8,9 +8,10 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Event;
 
-use Ibexa\Contracts\Core\Options\OptionsBag;
+use Ibexa\Contracts\Core\Options\MutableOptionsBag;
+use Ibexa\Contracts\Core\Repository\Exceptions\OutOfBoundsException;
 
-final class Options implements OptionsBag
+final class Options implements MutableOptionsBag
 {
     /** @var array */
     private $options;
@@ -37,6 +38,22 @@ final class Options implements OptionsBag
     public function has(string $key): bool
     {
         return isset($this->options[$key]);
+    }
+
+    public function set(string $key, $value): void
+    {
+        $this->options[$key] = $value;
+    }
+
+    public function remove(string $key): void
+    {
+        if (!array_key_exists($key, $this->options)) {
+            throw new OutOfBoundsException(
+                sprintf("Option '%s' doesn't exist", $key)
+            );
+        }
+
+        unset($this->options[$key]);
     }
 }
 

--- a/src/lib/EventListener/ContentProxyCreateDraftListener.php
+++ b/src/lib/EventListener/ContentProxyCreateDraftListener.php
@@ -77,9 +77,9 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
             []
         );
 
-        $options->set('content_draft', $contentDraft);
+        $options->set(ContentProxyCreateEvent::OPTION_CONTENT_DRAFT, $contentDraft);
 
-        if ($options->get('isOnTheFly', false)) {
+        if ($options->get(ContentProxyCreateEvent::OPTION_IS_ON_THE_FLY, false)) {
             $response = new RedirectResponse(
                 $this->router->generate('ezplatform.content_on_the_fly.edit', [
                     'contentId' => $contentDraft->id,

--- a/src/lib/EventListener/ContentProxyCreateDraftListener.php
+++ b/src/lib/EventListener/ContentProxyCreateDraftListener.php
@@ -77,6 +77,8 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
             []
         );
 
+        $options->set('content_draft', $contentDraft);
+
         if ($options->get('isOnTheFly', false)) {
             $response = new RedirectResponse(
                 $this->router->generate('ezplatform.content_on_the_fly.edit', [

--- a/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
+++ b/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
@@ -77,6 +77,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $eventDispatcher->dispatch($createEvent);
 
         self::assertEquals(new RedirectResponse('redirect_test_url'), $createEvent->getResponse());
+        self::assertInstanceOf(Content::class, $createEvent->getOptions()->get('content_draft'));
     }
 
     public function testCreateContentOnTheFlyAutosaveEnabled(): void
@@ -142,6 +143,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $eventDispatcher->dispatch($createEvent);
 
         $this->assertEquals(new RedirectResponse('redirect_on_the_fly_test_url'), $createEvent->getResponse());
+        self::assertInstanceOf(Content::class, $createEvent->getOptions()->get('content_draft'));
     }
 
     public function testTranslateContentAutosaveEnabled(): void

--- a/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
+++ b/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
@@ -79,7 +79,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         self::assertEquals(new RedirectResponse('redirect_test_url'), $createEvent->getResponse());
         self::assertInstanceOf(
             Content::class,
-            $createEvent->getOptions()->get(ContentProxyCreateEvent::OPTION_CONTENT_DRAFT)
+            $createEvent->getOptions()->get('contentDraft')
         );
     }
 
@@ -129,7 +129,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             'eng-EN',
             1234,
             new Options([
-                ContentProxyCreateEvent::OPTION_IS_ON_THE_FLY => true,
+                'isOnTheFly' => true,
             ])
         );
 
@@ -148,7 +148,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $this->assertEquals(new RedirectResponse('redirect_on_the_fly_test_url'), $createEvent->getResponse());
         self::assertInstanceOf(
             Content::class,
-            $createEvent->getOptions()->get(ContentProxyCreateEvent::OPTION_CONTENT_DRAFT)
+            $createEvent->getOptions()->get('contentDraft')
         );
     }
 
@@ -262,7 +262,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $createOnTheFlyEvent
             ->method('getOptions')
             ->willReturn(new Options([
-                ContentProxyCreateEvent::OPTION_IS_ON_THE_FLY => true,
+                'isOnTheFly' => true,
             ]));
 
         $translateEvent = $this->createMock(ContentProxyTranslateEvent::class);

--- a/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
+++ b/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
@@ -77,7 +77,10 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $eventDispatcher->dispatch($createEvent);
 
         self::assertEquals(new RedirectResponse('redirect_test_url'), $createEvent->getResponse());
-        self::assertInstanceOf(Content::class, $createEvent->getOptions()->get('content_draft'));
+        self::assertInstanceOf(
+            Content::class,
+            $createEvent->getOptions()->get(ContentProxyCreateEvent::OPTION_CONTENT_DRAFT)
+        );
     }
 
     public function testCreateContentOnTheFlyAutosaveEnabled(): void
@@ -126,7 +129,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             'eng-EN',
             1234,
             new Options([
-                'isOnTheFly' => true,
+                ContentProxyCreateEvent::OPTION_IS_ON_THE_FLY => true,
             ])
         );
 
@@ -143,7 +146,10 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $eventDispatcher->dispatch($createEvent);
 
         $this->assertEquals(new RedirectResponse('redirect_on_the_fly_test_url'), $createEvent->getResponse());
-        self::assertInstanceOf(Content::class, $createEvent->getOptions()->get('content_draft'));
+        self::assertInstanceOf(
+            Content::class,
+            $createEvent->getOptions()->get(ContentProxyCreateEvent::OPTION_CONTENT_DRAFT)
+        );
     }
 
     public function testTranslateContentAutosaveEnabled(): void
@@ -256,7 +262,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
         $createOnTheFlyEvent
             ->method('getOptions')
             ->willReturn(new Options([
-                'onTheFly' => true,
+                ContentProxyCreateEvent::OPTION_IS_ON_THE_FLY => true,
             ]));
 
         $translateEvent = $this->createMock(ContentProxyTranslateEvent::class);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1772
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Worth addition (kinda required for Taxonomy) to creating content. While subscribing to `ContentProxyCreateEvent` you could only use generated Response which was not really helpful if you needed to work on created content. So, after making `ContentProxyCreateEvent::$options` mutable I could pass `content_draft` option for further manipulation in event listeners.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
