### PR TITLE
IBX-1889: Visually the sub items are at the same level as the parent in the content tree

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
@@ -5,7 +5,7 @@
     position: relative;
 
     &:not(&--is-root-item) {
-        &:after {
+        &::after {
             content: ' ';
             display: block;
             position: absolute;
@@ -24,7 +24,7 @@
         }
 
         &:not(.c-list-item--has-sub-items) {
-            &:after {
+            &::after {
                 width: calculateRem(28px);
             }
         }
@@ -57,7 +57,7 @@
     }
 
     &__prefix-actions-item-empty {
-        &:after {
+        &::after {
             content: ' ';
             display: block;
             position: absolute;
@@ -114,7 +114,7 @@
         height: 100%;
         width: calculateRem(16px);
 
-        &:before {
+        &::before {
             width: 0;
             height: 0;
             border-style: solid;
@@ -200,7 +200,7 @@
     &--is-expanded {
         max-height: initial;
 
-        &:before {
+        &::before {
             content: ' ';
             display: block;
             position: absolute;
@@ -227,7 +227,7 @@
         > .c-list-item {
             &__row {
                 .c-list-item__toggler {
-                    &:before {
+                    &::before {
                         border-width: calculateRem(6px) calculateRem(4px) 0 calculateRem(4px);
                         border-color: $ibexa-color-dark transparent transparent transparent;
                         transform: translateY(-50%);

--- a/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
@@ -22,6 +22,12 @@
             left: calculateRem(-3px);
             top: calculateRem(16px);
         }
+
+        &:not(.c-list-item--has-sub-items) {
+            &:after {
+                width: calculateRem(28px);
+            }
+        }
     }
 
     &__row {

--- a/src/bundle/ui-dev/src/modules/content-tree/components/list-item/list.item.component.js
+++ b/src/bundle/ui-dev/src/modules/content-tree/components/list-item/list.item.component.js
@@ -176,7 +176,7 @@ class ListItem extends Component {
     }
 
     renderItemLabel() {
-        const { totalSubitemsCount, href, name, locationId, indent, onClick } = this.props;
+        const { href, name, locationId, indent, onClick } = this.props;
 
         if (locationId === 1) {
             return null;
@@ -186,7 +186,6 @@ class ListItem extends Component {
         const togglerAttrs = {
             className: togglerClassName,
             onClick: this.toggleExpandedState,
-            hidden: !totalSubitemsCount,
             tabIndex: -1,
         };
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1889](https://issues.ibexa.co/browse/IBX-1889)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
