### PR TITLE
IBX-1164: [Roles] missing translation in roles dropdown

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
@@ -26,6 +26,7 @@
         {{ no_items and not is_dynamic or is_disabled ? "ibexa-dropdown--disabled" }}
         {{ class|default('') }}
     "
+    {% if is_hidden|default(false) %}hidden="hidden"{% endif %}
 >
     <div class="ibexa-dropdown__source">
         {{ source|default(null)|raw }}

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
@@ -20,7 +20,8 @@
             translation_domain: choice_translation_domain|default(false),
             custom_form: false,
             class: attr.dropdown_class|default(''),
-            is_disabled: attr.disabled|default(false),
+            is_disabled: attr.disabled|default(false) or disabled|default(false),
+            is_hidden: attr.hidden|default(false),
         } %}
     {% endif %}
 {%- endblock choice_widget -%}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1164
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds hidden attribute, as before, in 3.3 this select wasn't visible from this form and it wasn't translated neither.
(and as it's hidden, it doesn't matter if it's translated)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
