### PR TITLE
IBX-1458: Fix dropdown 'invalid input tooltip' displayed in lower than dropdown

### DIFF
--- a/src/bundle/Resources/public/scss/_dropdown.scss
+++ b/src/bundle/Resources/public/scss/_dropdown.scss
@@ -1,12 +1,19 @@
 .ibexa-dropdown {
+    position: relative;
     font-family: $font-family-sans-serif;
     letter-spacing: calculateRem(0.12px);
     font-size: $ibexa-text-font-size-medium;
 
+    select {
+        height: 100%;
+        width: 100%;
+    }
+
     &__source {
+        position: absolute;
+        height: 100%;
+        width: 100%;
         opacity: 0;
-        height: 0;
-        overflow: hidden;
     }
 
     &__wrapper {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1458
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![Screenshot 2022-01-24 at 19 52 50](https://user-images.githubusercontent.com/10233057/150845733-745dff45-a98b-455d-a0c4-ea22bbddd052.png)

