### PR TITLE
[Behat] Added switching into specific tabs in Roles feature

### DIFF
--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
+use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
@@ -39,6 +40,9 @@ class UniversalDiscoveryWidget extends Component
     public function confirm(): void
     {
         $this->getHTMLPage()->find($this->getLocator('confirmButton'))->click();
+        $this->getHTMLPage()
+            ->setTimeout(3)
+            ->waitUntilCondition(new ElementNotExistsCondition($this->getHTMLPage(), $this->getLocator('udw')));
     }
 
     public function cancel(): void

--- a/src/lib/Behat/Page/AdminUpdateItemPage.php
+++ b/src/lib/Behat/Page/AdminUpdateItemPage.php
@@ -39,6 +39,11 @@ class AdminUpdateItemPage extends Page
         throw new \Exception('Update Page cannot be opened on its own!');
     }
 
+    public function switchToTab(string $tabName): void
+    {
+        $this->getHTMLPage()->findAll($this->getLocator('tab'))->getByCriterion(new ElementTextCriterion($tabName))->click();
+    }
+
     public function getName(): string
     {
         return 'Admin item update';
@@ -78,6 +83,7 @@ class AdminUpdateItemPage extends Page
             new VisibleCSSLocator('formElement', '.ibexa-main-container '),
             new VisibleCSSLocator('closeButton', '.ibexa-content-edit-container__close'),
             new VisibleCSSLocator('button', '.container button'),
+            new VisibleCSSLocator('tab', '.ibexa-anchor-navigation-menu__item'),
             new VisibleCSSLocator('fieldInput', 'input'),
         ];
     }

--- a/src/lib/Behat/Page/RoleUpdatePage.php
+++ b/src/lib/Behat/Page/RoleUpdatePage.php
@@ -111,6 +111,8 @@ class RoleUpdatePage extends AdminUpdateItemPage
 
     public function assignSectionLimitation(string $limitationName): void
     {
+        $this->verifyIsLoaded();
+        $this->switchToTab('Limitations');
         $this->fillFieldWithValue('Sections', true);
         $this->getHTMLPage()->find($this->getLocator('policyAssignmentSelect'))->click();
         $this->getHTMLPage()->find($this->getLocator('ibexaDropdownSelectionInfo'))->click();
@@ -119,6 +121,8 @@ class RoleUpdatePage extends AdminUpdateItemPage
 
     public function selectLimitationForAssignment(string $itemPath)
     {
+        $this->verifyIsLoaded();
+        $this->switchToTab('Limitations');
         $this->fillFieldWithValue('Subtree', 'true');
         $this->clickButton('Select path');
         $this->universalDiscoveryWidget->verifyIsLoaded();


### PR DESCRIPTION
Fix for:
```
    And I select "Media" from Sections as role assignment limitation # Ibexa\AdminUi\Behat\BrowserContext\RolesContext::iSelectSectionLimitation()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'Sections'. Collection is empty. XPATH locator 'input': '//label/..'. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/ElementCollection.php:61
```
errors

https://github.com/ibexa/admin-ui/runs/5017417803?check_suite_focus=true

Looks like the tests have problems accessing the data in the "Limitations" tab:
https://res.cloudinary.com/ezplatformtravis/image/upload/v1643699156/screenshots/61f8dbd46ba5c463228304-vendor_ibexa_admin-ui_features_standard_roles_feature_61_p8w1fx.png

I've added directly switching into the tab to make the life easier for them.