### PR TITLE
IBX-2240: Default field type name on CT create

### DIFF
--- a/src/bundle/Controller/FieldDefinitionController.php
+++ b/src/bundle/Controller/FieldDefinitionController.php
@@ -58,7 +58,7 @@ final class FieldDefinitionController extends RestController
 
         $fieldDefinitionCreateStruct->fieldGroup = $input->fieldGroupIdentifier;
         $fieldDefinitionCreateStruct->names = [
-            $language->languageCode => "New $fieldDefinitionCreateStruct->fieldTypeIdentifier field definition",
+            $language->languageCode => "New field type",
         ];
 
         if (!$contentTypeDraft->fieldDefinitions->isEmpty()) {

--- a/src/bundle/Controller/FieldDefinitionController.php
+++ b/src/bundle/Controller/FieldDefinitionController.php
@@ -58,7 +58,7 @@ final class FieldDefinitionController extends RestController
 
         $fieldDefinitionCreateStruct->fieldGroup = $input->fieldGroupIdentifier;
         $fieldDefinitionCreateStruct->names = [
-            $language->languageCode => "New field type",
+            $language->languageCode => 'New field type',
         ];
 
         if (!$contentTypeDraft->fieldDefinitions->isEmpty()) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-2240](https://issues.ibexa.co/browse/IBX-2240)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Changed default field type name on content type create


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
