### PR TITLE
IBX-2299: Added `config-name` option to ibexa:encore:compile command

### DIFF
--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -35,7 +35,15 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
                 InputOption::VALUE_OPTIONAL,
                 'Timeout in seconds',
                 300
-            );
+            )
+            ->addOption(
+                'config-name',
+                'c',
+                InputOption::VALUE_OPTIONAL,
+                'Config name passed to webpack encore',
+                null
+            )
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -51,12 +59,17 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
     {
         $timeout = $input->getOption('timeout');
         $env = $input->getOption('env');
+        $configName = $input->getOption('config-name');
 
         $output->writeln(sprintf('Compiling all <comment>%s</comment> assets.', $env));
         $output->writeln('');
 
         $encoreEnv = $env === 'prod' ? 'prod' : 'dev';
         $yarnEncoreCommand = "yarn encore {$encoreEnv}";
+
+        if (!empty($configName)) {
+            $yarnEncoreCommand .= " --config-name {$configName}";
+        }
 
         $debugFormatter = $this->getHelper('debug_formatter');
 

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -39,7 +39,7 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
             ->addOption(
                 'config-name',
                 'c',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Config name passed to webpack encore',
                 null
             )


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2299
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
