### PR TITLE
Add #[\ReturnTypeWillChange] to disable PHP 8.1 deprecation warnings

### DIFF
--- a/src/lib/UI/Config/ConfigWrapper.php
+++ b/src/lib/UI/Config/ConfigWrapper.php
@@ -23,26 +23,31 @@ class ConfigWrapper implements \ArrayAccess, \JsonSerializable
         $this->config = $config;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->config[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->config[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new RuntimeException('Configuration is readonly');
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new RuntimeException('Configuration is readonly');
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->config;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Disables PHP return type deprecation notices when running the site on PHP 8.1

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
