### PR TITLE
[Behat] Increased go to the top timeout

### DIFF
--- a/src/lib/Behat/Component/Pagination.php
+++ b/src/lib/Behat/Component/Pagination.php
@@ -23,7 +23,10 @@ class Pagination extends Component
         $currentPage = (int) $this->getHTMLPage()->find($this->getLocator('currentPage'))->getText();
         // scroll to the bottom to avoid "Go to top" button
         $this->getHTMLPage()->executeJavaScript("document.querySelector('.ibexa-back-to-top-scroll-container').scrollTo(0, document.querySelector('.ibexa-back-to-top-scroll-container').scrollHeight)");
-        $this->getHTMLPage()->find(new VisibleCSSLocator('backToTopWithTitle', '.ibexa-back-to-top__title--visible'))->assert()->textEquals('Go to top');
+        $this->getHTMLPage()
+            ->setTimeout(3)
+            ->find(new VisibleCSSLocator('backToTopWithTitle', '.ibexa-back-to-top__title--visible'))
+            ->assert()->textEquals('Go to top');
         $this->getHTMLPage()->find($this->getLocator('nextButton'))->click();
         $this->getHTMLPage()->setTimeout(10)->waitUntil(function () use ($currentPage) {
             $activePge = (int) $this->getHTMLPage()->find($this->getLocator('currentPage'))->getText();


### PR DESCRIPTION
Tested in https://github.com/ibexa/experience/pull/26 with 3 successfull runs, the only issue that occured was:
```
     │  	[2022-03-21T22:56:25.550491+00:00] request.CRITICAL: Uncaught PHP Exception ErrorException: "Warning: mkdir(): File exists" at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php line 179 {"exception":"[object] (ErrorException(code: 0): Warning: mkdir(): File exists at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php:179)"} []
```
which is not related
