### PR TITLE
IBX-2655: create/edit layout fixes

### DIFF
--- a/src/bundle/Resources/public/scss/_anchor-navigation.scss
+++ b/src/bundle/Resources/public/scss/_anchor-navigation.scss
@@ -1,7 +1,7 @@
 .ibexa-anchor-navigation-menu {
     &__header {
         height: calculateRem(87px);
-        padding: calculateRem(17px) 0 0 calculateRem(17px);
+        padding: calculateRem(20px) 0 0 calculateRem(17px);
         border-bottom: calculateRem(1px) solid $ibexa-color-light;
     }
 
@@ -22,28 +22,28 @@
 
     &__item-btn {
         display: inline-flex;
-        align-items: center;
         width: 100%;
         padding: calculateRem(11px) calculateRem(15px);
         border: calculateRem(1px) solid transparent;
         border-radius: $ibexa-border-radius;
+        text-align: left;
 
         &::before {
-            content: ' ';
-            display: inline-block;
-            width: calculateRem(16px);
-            height: calculateRem(16px);
-            margin-right: calculateRem(10px);
+            content: '';
+            display: block;
+            width: calculateRem(8px);
+            height: calculateRem(8px);
+            margin: calculateRem(8px) calculateRem(16px) 0 0;
             border-radius: 50%;
-            border: calculateRem(2px) solid transparent;
             background-color: $ibexa-color-light;
         }
 
         &::after {
             content: '*';
+            width: calculateRem(16px);
             display: inline-block;
             opacity: 0;
-            margin-left: calculateRem(4px);
+            margin: calculateRem(4px) 0 0 calculateRem(4px);
             color: $ibexa-color-danger;
             font-size: $ibexa-text-font-size-small;
         }
@@ -53,8 +53,7 @@
             font-weight: 600;
 
             &:before {
-                background-color: transparent;
-                border-color: $ibexa-color-info;
+                background-color: $ibexa-color-info;
             }
         }
 
@@ -64,8 +63,7 @@
             font-weight: 600;
 
             &:before {
-                background-color: transparent;
-                border-color: $ibexa-color-info;
+                background-color: $ibexa-color-info;
             }
         }
 
@@ -74,5 +72,9 @@
                 opacity: 1;
             }
         }
+    }
+
+    &__item-btn-label {
+        max-width: calc(100% - #{calculateRem(45px)});
     }
 }

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -1,3 +1,11 @@
 .ibexa-edit-content {
     @include edit-right-side-container;
+
+    &__container {
+        max-width: calculateRem(820px);
+
+        &--wide {
+            max-width: calculateRem(1600px);
+        }
+    }
 }

--- a/src/bundle/Resources/public/scss/_content-type-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-type-edit.scss
@@ -16,7 +16,29 @@
     }
 
     &__section {
+        display: flex;
+        flex-wrap: wrap;
         margin: 0 0 calculateRem(50px) 0;
+
+        &--one-column-layout {
+            .ibexa-content-type-edit__section-column {
+                &--left-col {
+                    width: 100%;
+                }
+            }
+        }
+    }
+
+    &__section-column {
+        margin: 0 0 calculateRem(50px) 0;
+
+        &--left-col {
+            width: 60%;
+        }
+
+        &--right-col {
+            width: 40%;
+        }
     }
 
     &__section-column-header {

--- a/src/bundle/Resources/public/scss/_edit-header.scss
+++ b/src/bundle/Resources/public/scss/_edit-header.scss
@@ -12,6 +12,7 @@
     &__container {
         display: flex;
         flex-direction: column;
+        padding: 0 calculateRem(36px);
     }
 
     &__title {
@@ -118,7 +119,6 @@
 
     &__bottom-row-line {
         margin-top: auto;
-        width: 75%;
         border-bottom: calculateRem(1px) solid $ibexa-color-light;
     }
 

--- a/src/bundle/Resources/public/scss/_main-container.scss
+++ b/src/bundle/Resources/public/scss/_main-container.scss
@@ -16,11 +16,12 @@
     &--without-anchor-menu-items {
         .ibexa-main-container {
             &__side-column {
-                width: calculateRem(200px);
+                width: 15%;
+                max-width: calculateRem(200px);
             }
 
             &__content-column {
-                width: calc(100% - #{calculateRem(200px)});
+                width: 100%;
             }
         }
     }
@@ -28,11 +29,12 @@
     &--with-anchor-menu-items {
         .ibexa-main-container {
             &__side-column {
-                width: calculateRem(350px);
+                width: 25%;
+                max-width: calculateRem(350px);
             }
 
             &__content-column {
-                width: calc(100% - #{calculateRem(350px)});
+                width: 100%;
             }
         }
     }

--- a/src/bundle/Resources/public/scss/mixins/_containers.scss
+++ b/src/bundle/Resources/public/scss/mixins/_containers.scss
@@ -1,7 +1,7 @@
 @mixin edit-right-side-container {
     flex-grow: 1;
     position: relative;
-    padding-top: calculateRem(42px);
+    padding: calculateRem(42px) calculateRem(32px) 0 calculateRem(32px);
     overflow-y: auto;
     border-bottom-left-radius: $ibexa-border-radius;
     border-width: 0 calculateRem(1px) calculateRem(1px);

--- a/src/bundle/Resources/views/themes/admin/account/change_password/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/change_password/index.html.twig
@@ -19,20 +19,18 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {{ form_start(form_change_user_password, {'attr': {'class': 'ibexa-form-validate'}}) }}
-                <section>
-                    <div class="card ibexa-card ibexa-card--light">
-                        <div class="card-body">
-                            {{ form_row(form_change_user_password.oldPassword) }}
-                            {{ form_row(form_change_user_password.newPassword) }}
-                        </div>
+    <div class="ibexa-edit-content__container">
+        {{ form_start(form_change_user_password, {'attr': {'class': 'ibexa-form-validate'}}) }}
+            <section>
+                <div class="card ibexa-card ibexa-card--light">
+                    <div class="card-body">
+                        {{ form_row(form_change_user_password.oldPassword) }}
+                        {{ form_row(form_change_user_password.newPassword) }}
                     </div>
-                </section>
-                {{ form_widget(form_change_user_password.change, {'attr': {'hidden': 'hidden'}}) }}
-            {{ form_end(form_change_user_password) }}
-        </div>
+                </div>
+            </section>
+            {{ form_widget(form_change_user_password.change, {'attr': {'hidden': 'hidden'}}) }}
+        {{ form_end(form_change_user_password) }}
     </div>
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/account/settings/update.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/settings/update.html.twig
@@ -22,20 +22,18 @@
 {% block content %}
     {% form_theme form '@ibexadesign/ui/form_fields.html.twig' '@ibexadesign/account/settings/update_datetime_format.html.twig' %}
 
-    <div class="row">
-        <div class="col col-6 offset-1">
-            {{ form_start(form) }}
-                {{ form_widget(form.identifier, {'attr': {'hidden': 'hidden'}}) }}
-                {% include '@ibexadesign/ui/component/table/table_header.html.twig' with {
-                    headline: user_setting_group.name
-                } %}
-                {% for user_setting in user_setting_group.settings %}
-                    <div>
-                        {{ form_widget(attribute(form, user_setting.identifier)) }}
-                    </div>
-                {% endfor %}
-                {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
-            {{ form_end(form) }}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {{ form_start(form) }}
+            {{ form_widget(form.identifier, {'attr': {'hidden': 'hidden'}}) }}
+            {% include '@ibexadesign/ui/component/table/table_header.html.twig' with {
+                headline: user_setting_group.name
+            } %}
+            {% for user_setting in user_setting_group.settings %}
+                <div>
+                    {{ form_widget(attribute(form, user_setting.identifier)) }}
+                </div>
+            {% endfor %}
+            {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
+        {{ form_end(form) }}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -41,16 +41,14 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container">
-        <div class="card ibexa-card ibexa-card--light">
-            <div class="card-body">
-                {{ parent() }}
-                {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
-                {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
-                {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
-            </div>
+    <div class="card ibexa-card ibexa-card--light">
+        <div class="card-body">
+            {{ parent() }}
+            {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
+            {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
+            {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
         </div>
-    </section>
+    </div>
 {% endblock %}
 
 {% block form_after %}

--- a/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
@@ -24,73 +24,65 @@
 {% endblock %}
 
 {% block content %}
-    <section class="container">
-        <div class="row">
-            <div class="{{ is_full_width|default(false) ? 'col-12' : 'col-7 offset-1' }}">
-                {% block form_before %}{% endblock %}
-            </div>
-        </div>
-    </section>
+    <div class="ibexa-edit-content__container">
+        {% block form_before %}{% endblock %}
 
-    {% block form %}
-        {{ form_start(form, {'attr': {'class': 'ibexa-form-validate ibexa-form'}}) }}
-            {% block form_fields %}
-                {% if grouped_fields|length > 1 %}
-                    <div class="ibexa-anchor-navigation-sections">
-                        {% for key, group in grouped_fields %}
-                            {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
-                                anchor_section_key: key
-                            } %}
-                                {% trans_default_domain 'content_edit' %}
+        {% block form %}
+            {{ form_start(form, {'attr': {'class': 'ibexa-form-validate ibexa-form'}}) }}
+                {% block form_fields %}
+                    {% if grouped_fields|length > 1 %}
+                        <div class="ibexa-anchor-navigation-sections">
+                            {% for key, group in grouped_fields %}
+                                {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
+                                    anchor_section_key: key
+                                } %}
+                                    {% trans_default_domain 'content_edit' %}
 
-                                {% block anchor_section_body %}
-                                    {% for field in group %}
-                                        {% set formField = form.fieldsData[field] %}
+                                    {% block anchor_section_body %}
+                                        {% for field in group %}
+                                            {% set formField = form.fieldsData[field] %}
 
-                                        {% if not formField.rendered %}
-                                            {% if formField.value is defined %}
-                                                {{- form_widget(formField) -}}
-                                            {% else %}
-                                                <div class="ibexa-field-edit ibexa-field-edit--eznoneditable">
-                                                    {{- form_label(formField) -}}
-                                                    <p class="non-editable">
-                                                        {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
-                                                    </p>
-                                                    {% do formField.setRendered() %}
-                                                </div>
+                                            {% if not formField.rendered %}
+                                                {% if formField.value is defined %}
+                                                    {{- form_widget(formField) -}}
+                                                {% else %}
+                                                    <div class="ibexa-field-edit ibexa-field-edit--eznoneditable">
+                                                        {{- form_label(formField) -}}
+                                                        <p class="non-editable">
+                                                            {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
+                                                        </p>
+                                                        {% do formField.setRendered() %}
+                                                    </div>
+                                                {% endif %}
                                             {% endif %}
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endblock %}
-                            {% endembed %}
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <div class="row">
-                        <div class="{{ is_full_width|default(false) ? 'col-12' : 'col-7 offset-1' }}">
-                            {% for field in form.fieldsData %}
-                                {% if not field.rendered %}
-                                    {% if field.value is defined %}
-                                        {{- form_widget(field) -}}
-                                    {% else %}
-                                        <div class="ibexa-field-edit ibexa-field-edit--eznoneditable">
-                                            {{- form_label(field) -}}
-                                            <p class="non-editable">
-                                                {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
-                                            </p>
-                                            {% do field.setRendered() %}
-                                        </div>
-                                    {% endif %}
-                                {% endif %}
-                            {%- endfor %}
+                                        {% endfor %}
+                                    {% endblock %}
+                                {% endembed %}
+                            {% endfor %}
                         </div>
-                    </div>
-                {% endif %}
-            {% endblock %}
-        {{ form_end(form) }}
-    {% endblock %}
+                    {% else %}
+                        {% for field in form.fieldsData %}
+                            {% if not field.rendered %}
+                                {% if field.value is defined %}
+                                    {{- form_widget(field) -}}
+                                {% else %}
+                                    <div class="ibexa-field-edit ibexa-field-edit--eznoneditable">
+                                        {{- form_label(field) -}}
+                                        <p class="non-editable">
+                                            {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
+                                        </p>
+                                        {% do field.setRendered() %}
+                                    </div>
+                                {% endif %}
+                            {% endif %}
+                        {%- endfor %}
+                    {% endif %}
+                {% endblock %}
+            {{ form_end(form) }}
+        {% endblock %}
 
-    {% block form_after %}{% endblock %}
+        {% block form_after %}{% endblock %}
+    </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/base.html.twig
@@ -13,9 +13,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
@@ -27,49 +27,56 @@
         }
     }) }}
         <div
-            class="ibexa-content-type-edit__sections ibexa-anchor-navigation-sections container"
+            class="ibexa-content-type-edit__sections ibexa-anchor-navigation-sections"
             data-language-code="{{ language_code }}"
             data-content-type-group-id="{{ content_type_group.id }}"
             data-content-type-id="{{ content_type.id }}"
         >
             {% block form_sections %}
-                {% embed "@ibexadesign/content_type/edit_section.html.twig" with { section_id: '#Global-properties',  is_active: true } %}
-                    {% block title %}
-                        {{ 'content_type.view.edit.global_properties'|trans|desc('Global properties') }}
-                    {% endblock %}
+                <div class="ibexa-edit-content__container">
+                    {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
+                        section_id: '#Global-properties',
+                        is_active: true,
+                        one_column_layout: true,
+                    } %}
+                        {% block title %}
+                            {{ 'content_type.view.edit.global_properties'|trans|desc('Global properties') }}
+                        {% endblock %}
 
-                    {% block left_column %}
-                        {{ form_row(form.name) }}
-                        {{ form_row(form.identifier) }}
-                        {{ form_row(form.description) }}
-                        {{ form_row(form.nameSchema) }}
-                        {{ form_row(form.urlAliasSchema) }}
-                        {{ form_row(form.isContainer) }}
-                        {{ form_row(form.defaultSortField) }}
-                        {{ form_row(form.defaultSortOrder) }}
-                        {{ form_row(form.defaultAlwaysAvailable) }}
-                    {% endblock %}
-                {% endembed %}
+                        {% block left_column %}
+                            {{ form_row(form.name) }}
+                            {{ form_row(form.identifier) }}
+                            {{ form_row(form.description) }}
+                            {{ form_row(form.nameSchema) }}
+                            {{ form_row(form.urlAliasSchema) }}
+                            {{ form_row(form.isContainer) }}
+                            {{ form_row(form.defaultSortField) }}
+                            {{ form_row(form.defaultSortOrder) }}
+                            {{ form_row(form.defaultAlwaysAvailable) }}
+                        {% endblock %}
+                    {% endembed %}
+                </div>
 
-                {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
-                    section_id: '#Field-definitions',
-                    left_column_class: 'ibexa-content-type-edit__section-column--field-definitions'
-                } %}
-                    {% block title %}
-                        {{ 'content_type.view.edit.content_field_definitions'|trans|desc('Field definitions') }}
-                    {% endblock %}
+                <div class="ibexa-edit-content__container ibexa-edit-content__container--wide">
+                    {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
+                        section_id: '#Field-definitions',
+                        left_column_class: 'ibexa-content-type-edit__section-column--field-definitions'
+                    } %}
+                        {% block title %}
+                            {{ 'content_type.view.edit.content_field_definitions'|trans|desc('Field definitions') }}
+                        {% endblock %}
 
-                    {% block left_column %}
-                        {{ include('@ibexadesign/content_type/field_definitions.html.twig', { grouped_field_defintions: form.fieldDefinitionsData }) }}
-                    {% endblock %}
+                        {% block left_column %}
+                            {{ include('@ibexadesign/content_type/field_definitions.html.twig', { grouped_field_defintions: form.fieldDefinitionsData }) }}
+                        {% endblock %}
 
-                    {% block right_column %}
-                        {{ include('@ibexadesign/content_type/available_field_types.html.twig') }}
-                    {% endblock %}
-                {% endembed %}
+                        {% block right_column %}
+                            {{ include('@ibexadesign/content_type/available_field_types.html.twig') }}
+                        {% endblock %}
+                    {% endembed %}
+                </div>
             {% endblock %}
         </div>
-
         {{ form_widget(form.saveContentType, { attr: { hidden: 'hidden' }}) }}
         {{ form_widget(form.publishContentType, { attr: { class: 'ibexa-content-type-edit__publish-content-type', hidden: 'hidden' }}) }}
 

--- a/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
@@ -20,70 +20,78 @@
 {% endblock %}
 
 {% block form %}
-    {{ form_start(form, {
-        attr: {
-            class: 'ibexa-content-type-edit-form ibexa-form',
-            novalidate: 'novalidate',
-        }
-    }) }}
-        {% set is_translation = form.vars.data.languageCode != content_type.mainLanguageCode %}
-        {% set is_draggable = is_translation == false %}
+        {{ form_start(form, {
+            attr: {
+                class: 'ibexa-content-type-edit-form ibexa-form',
+                novalidate: 'novalidate',
+            }
+        }) }}
+            {% set is_translation = form.vars.data.languageCode != content_type.mainLanguageCode %}
+            {% set is_draggable = is_translation == false %}
 
-        {% if is_translation %}
-            {% include '@ibexadesign/content_type/part/nontranslatable_fields_disabled.html.twig' %}
-        {% endif %}
+            {% if is_translation %}
+                {% include '@ibexadesign/content_type/part/nontranslatable_fields_disabled.html.twig' %}
+            {% endif %}
 
-        <div
-            class="ibexa-content-type-edit__sections ibexa-anchor-navigation-sections container"
-            data-language-code="{{ language_code }}"
-            data-content-type-group-id="{{ content_type_group.id }}"
-            data-content-type-id="{{ content_type.id }}"
-        >
-            {% block form_sections %}
-                {% embed "@ibexadesign/content_type/edit_section.html.twig" with { section_id: '#Global-properties', is_active: true } %}
-                    {% block title %}
-                        {{ 'content_type.view.edit.global_properties'|trans|desc('Global properties') }}
-                    {% endblock %}
+            <div
+                class="ibexa-content-type-edit__sections ibexa-anchor-navigation-sections"
+                data-language-code="{{ language_code }}"
+                data-content-type-group-id="{{ content_type_group.id }}"
+                data-content-type-id="{{ content_type.id }}"
+            >
+                {% block form_sections %}
+                    <div class="ibexa-edit-content__container">
+                        {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
+                            section_id: '#Global-properties',
+                            is_active: true,
+                            one_column_layout: true,
+                        } %}
+                            {% block title %}
+                                {{ 'content_type.view.edit.global_properties'|trans|desc('Global properties') }}
+                            {% endblock %}
 
-                    {% block left_column %}
-                        {{ form_row(form.name) }}
-                        {{ form_row(form.identifier) }}
-                        {{ form_row(form.description) }}
-                        {{ form_row(form.nameSchema) }}
-                        {{ form_row(form.urlAliasSchema) }}
-                        {{ form_row(form.isContainer) }}
-                        {{ form_row(form.defaultSortField) }}
-                        {{ form_row(form.defaultSortOrder) }}
-                        {{ form_row(form.defaultAlwaysAvailable) }}
-                    {% endblock %}
-                {% endembed %}
+                            {% block left_column %}
+                                {{ form_row(form.name) }}
+                                {{ form_row(form.identifier) }}
+                                {{ form_row(form.description) }}
+                                {{ form_row(form.nameSchema) }}
+                                {{ form_row(form.urlAliasSchema) }}
+                                {{ form_row(form.isContainer) }}
+                                {{ form_row(form.defaultSortField) }}
+                                {{ form_row(form.defaultSortOrder) }}
+                                {{ form_row(form.defaultAlwaysAvailable) }}
+                            {% endblock %}
+                        {% endembed %}
+                    </div>
 
-                {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
-                    section_id: '#Field-definitions',
-                    left_column_class: 'ibexa-content-type-edit__section-column--field-definitions',
-                    right_column_class: 'ibexa-content-type-edit__section-column--available-fields'
-                } %}
-                    {% block title %}
-                        {{ 'content_type.view.edit.content_field_definitions'|trans|desc('Field definitions') }}
-                    {% endblock %}
+                    <div class="ibexa-edit-content__container ibexa-edit-content__container--wide">
+                        {% embed "@ibexadesign/content_type/edit_section.html.twig" with {
+                            section_id: '#Field-definitions',
+                            left_column_class: 'ibexa-content-type-edit__section-column--field-definitions',
+                            right_column_class: 'ibexa-content-type-edit__section-column--available-fields'
+                        } %}
+                            {% block title %}
+                                {{ 'content_type.view.edit.content_field_definitions'|trans|desc('Field definitions') }}
+                            {% endblock %}
 
-                    {% block left_column %}
-                        {{ include('@ibexadesign/content_type/field_definitions.html.twig', {
-                            grouped_field_defintions: form.fieldDefinitionsData,
-                            is_draggable
-                        }) }}
-                    {% endblock %}
+                            {% block left_column %}
+                                {{ include('@ibexadesign/content_type/field_definitions.html.twig', {
+                                    grouped_field_defintions: form.fieldDefinitionsData,
+                                    is_draggable
+                                }) }}
+                            {% endblock %}
 
-                    {% block right_column %}
-                        {{ include('@ibexadesign/content_type/available_field_types.html.twig', { is_draggable }) }}
-                    {% endblock %}
-                {% endembed %}
-            {% endblock %}
-        </div>
+                            {% block right_column %}
+                                {{ include('@ibexadesign/content_type/available_field_types.html.twig', { is_draggable }) }}
+                            {% endblock %}
+                        {% endembed %}
+                    </div>
+                {% endblock %}
+            </div>
 
-        {{ form_widget(form.publishContentType, { attr: { class: 'ibexa-content-type-edit__publish-content-type', hidden: 'hidden' }}) }}
-        {{ form_widget(form.removeDraft, {'attr': { 'hidden': 'hidden' }}) }}
+            {{ form_widget(form.publishContentType, { attr: { class: 'ibexa-content-type-edit__publish-content-type', hidden: 'hidden' }}) }}
+            {{ form_widget(form.removeDraft, {'attr': { 'hidden': 'hidden' }}) }}
 
-        {{ form_widget(form._token) }}
-    {{ form_end(form, {'render_rest': false }) }}
+            {{ form_widget(form._token) }}
+        {{ form_end(form, {'render_rest': false }) }}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content_type/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit_base.html.twig
@@ -16,11 +16,7 @@
 {% block main_container_class %}{{ parent() }} ibexa-content-type-edit ibexa-main-container--with-anchor-menu-items{% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
-    </div>
+    {% block form %}{% endblock %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/themes/admin/content_type/edit_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit_section.html.twig
@@ -1,17 +1,21 @@
 {% extends '@ibexadesign/ui/edit_section.html.twig' %}
 
-{% set attr = { class: 'ibexa-content-type-edit__section' } %}
+{% set one_column_layout = one_column_layout|default(false) %}
+{% set attr = { class: 'ibexa-content-type-edit__section ' ~ (one_column_layout ? 'ibexa-content-type-edit__section--one-column-layout') } %}
 
 {% block content %}
-    <div class="col-8 ibexa-content-type-edit__section-column {{ left_column_class|default('') }}">
+    <div class="ibexa-content-type-edit__section-column ibexa-content-type-edit__section-column--left-col {{ left_column_class|default('') }}">
         <h2 class="ibexa-content-type-edit__section-column-header">{% block title %}{% endblock %}</h2>
         <div class="ibexa-content-type-edit__section-column-body">
             {% block left_column %}{% endblock %}
         </div>
     </div>
-    <div class="col-4 ibexa-content-type-edit__section-column {{ right_column_class|default('') }}">
-        <div class="ibexa-content-type-edit__section-column-body">
-            {% block right_column %}{% endblock %}
+
+    {% if not one_column_layout %}
+        <div class="ibexa-content-type-edit__section-column ibexa-content-type-edit__section-column--right-col {{ right_column_class|default('') }}">
+            <div class="ibexa-content-type-edit__section-column-body">
+                {% block right_column %}{% endblock %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/language/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/base.html.twig
@@ -13,9 +13,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/edit.html.twig
@@ -19,19 +19,17 @@
 {% endblock %}
 
 {%- block content -%}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {{ form_start(form) }}
-                {{ form_errors(form) }}
-                <section>
-                    <div class="card ibexa-card ibexa-card--light">
-                        <div class="card-body">
-                            {{ form_row(form.url) }}
-                        </div>
+    <div class="ibexa-edit-content__container">
+        {{ form_start(form) }}
+            {{ form_errors(form) }}
+            <section>
+                <div class="card ibexa-card ibexa-card--light">
+                    <div class="card-body">
+                        {{ form_row(form.url) }}
                     </div>
-                </section>
-                <button id="url-update" type="submit" hidden></button>
-            {{ form_end(form) }}
-        </div>
+                </div>
+            </section>
+            <button id="url-update" type="submit" hidden></button>
+        {{ form_end(form) }}
     </div>
 {%- endblock -%}

--- a/src/bundle/Resources/views/themes/admin/object_state/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/object_state/base.html.twig
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/object_state/object_state_group/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/object_state/object_state_group/base.html.twig
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/section/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/section/base.html.twig
@@ -6,14 +6,14 @@
     close_href: path('ibexa.section.list'),
 } %}
 
+{% set is_narrow_content = true %}
+
 {% block header %}
     {% block header_admin %}{% endblock %}
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/section/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/section/create.html.twig
@@ -16,14 +16,12 @@
 
 {% block form %}
     {{ form_start(form_section_create) }}
-        <section>
-            <div class="card ibexa-card ibexa-card--light">
-                <div class="card-body">
-                    {{ form_row(form_section_create.name, {'attr': {'autofocus': 'autofocus'}}) }}
-                    {{ form_row(form_section_create.identifier) }}
-                </div>
+        <div class="card ibexa-card ibexa-card--light">
+            <div class="card-body">
+                {{ form_row(form_section_create.name, {'attr': {'autofocus': 'autofocus'}}) }}
+                {{ form_row(form_section_create.identifier) }}
             </div>
-        </section>
+        </div>
         {{ form_widget(form_section_create.create, {'attr': {'hidden': 'hidden'}}) }}
     {{ form_end(form_section_create) }}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
@@ -27,7 +27,7 @@
                             class="ibexa-anchor-navigation-menu__item-btn {% if loop.first %}ibexa-anchor-navigation-menu__item-btn--active{% endif %}" 
                             data-anchor-target-section-id="#{{ sanitized_item }}"
                         >
-                            {{ item }}
+                            <span class="ibexa-anchor-navigation-menu__item-btn-label">{{ item }}</span>
                         </button>
                     </li>
                 {% endfor %}

--- a/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_section.html.twig
@@ -3,10 +3,8 @@
     class="row ibexa-anchor-navigation-sections__section {{ anchor_section_class|default('') }}"
 >
     {% block anchor_section_content %}
-        <div class="offset-1 col-7">
-            {% block anchor_section_header %}{% endblock %}
-            {% block anchor_section_body %}{% endblock %}
-            {% block anchor_section_footer %}{% endblock %}
-        </div>
+        {% block anchor_section_header %}{% endblock %}
+        {% block anchor_section_body %}{% endblock %}
+        {% block anchor_section_footer %}{% endblock %}
     {% endblock %}
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -20,9 +20,7 @@
         {% block header %}{% endblock %}
 
         <div class="ibexa-edit-content">
-            <div class="container">
-                {% block content %}{% endblock %}
-            </div>
+            {% block content %}{% endblock %}
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
@@ -1,8 +1,8 @@
 {% set show_extra_bottom_content = show_extra_bottom_content|default(false) %}
 
 <div class="ibexa-edit-header {{ show_extra_bottom_content ? 'ibexa-edit-header--has-extra-content' }}">
-    <div class="container ibexa-edit-header__container">
-        <div class="offset-1 ibexa-edit-header__row ibexa-edit-header__row--top">
+    <div class="ibexa-edit-header__container">
+        <div class="ibexa-edit-header__row ibexa-edit-header__row--top">
             <div class="ibexa-edit-header__column ibexa-edit-header__column--main">
                 <div class="ibexa-edit-header__action-name-container">
                     {% if icon_name is defined %}
@@ -28,8 +28,8 @@
 
     <div class="ibexa-edit-header__separate-div"></div>
 
-    <div class="container ibexa-edit-header__container">
-        <div class="offset-1 ibexa-edit-header__row ibexa-edit-header__row--bottom">
+    <div class="ibexa-edit-header__container">
+        <div class="ibexa-edit-header__row ibexa-edit-header__row--bottom">
             <div class="ibexa-edit-header__column ibexa-edit-header__column--left">
                 <h1 class="ibexa-edit-header__title">
                     {{ title }}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_section.html.twig
@@ -2,7 +2,7 @@
 
 {% set attr = attr|default({})|merge({
     class: (attr.class|default('')
-            ~ ' ibexa-anchor-navigation-sections__section row'
+            ~ ' ibexa-anchor-navigation-sections__section'
         )|trim,
     'data-anchor-section-id': section_id,
 }) %}

--- a/src/bundle/Resources/views/themes/admin/user/policy/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/policy/base.html.twig
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/user/role/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/role/base.html.twig
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-10 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/user/role_assignment/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/role_assignment/base.html.twig
@@ -15,9 +15,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col col-6 offset-1">
-            {% block form %}{% endblock %}
-        </div>
+    <div class="ibexa-edit-content__container">
+        {% block form %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/lib/Behat/Page/RoleUpdatePage.php
+++ b/src/lib/Behat/Page/RoleUpdatePage.php
@@ -31,6 +31,7 @@ class RoleUpdatePage extends AdminUpdateItemPage
         parent::__construct($session, $router, $contentActionsMenu);
         $this->universalDiscoveryWidget = $universalDiscoveryWidget;
         $this->ibexaDropdown = $ibexaDropdown;
+        $this->locators->replace(new VisibleCSSLocator('button', '.ibexa-edit-content__container button'));
     }
 
     public function selectLimitationValues(string $selectName, array $values): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2655
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Fixed create/edit layout by removing boostrap class `row` and `col-`. All content should be aligned to the left sidebar

1. 1376px width
![1376](https://user-images.githubusercontent.com/24355391/161953948-8c6f27a5-387e-4fb6-9190-da6ea76d7f05.png)


2. 1920px width
![1920](https://user-images.githubusercontent.com/24355391/161953957-4424e610-6508-46d6-8178-3d8fea987941.png)


3. > 1920px width
![2560](https://user-images.githubusercontent.com/24355391/161953970-0a11b999-2843-45fc-b393-4c3cfe2c4ffb.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
