### PR TITLE
[Behat] Narrowed down ContentTypePicker selector

### DIFF
--- a/src/lib/Behat/Component/ContentTypePicker.php
+++ b/src/lib/Behat/Component/ContentTypePicker.php
@@ -56,10 +56,10 @@ class ContentTypePicker extends Component
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('filterInput', '.ibexa-extra-actions__section-content--content-type .ibexa-instant-filter__input'),
-            new VisibleCSSLocator('filteredItem', '.ibexa-extra-actions__section-content--content-type .ibexa-instant-filter__group-item:not([hidden]) .form-check-label'),
-            new VisibleCSSLocator('header', '.ibexa-extra-actions--create .ibexa-extra-actions__header h2'),
-            new VisibleCSSLocator('languageDropdown', '.ibexa-dropdown__selection-info'),
+            new VisibleCSSLocator('filterInput', '.ibexa-content-menu-wrapper .ibexa-extra-actions__section-content--content-type .ibexa-instant-filter__input'),
+            new VisibleCSSLocator('filteredItem', '.ibexa-content-menu-wrapper .ibexa-extra-actions__section-content--content-type .ibexa-instant-filter__group-item:not([hidden]) .form-check-label'),
+            new VisibleCSSLocator('header', '.ibexa-content-menu-wrapper .ibexa-extra-actions--create .ibexa-extra-actions__header h2'),
+            new VisibleCSSLocator('languageDropdown', '.ibexa-content-menu-wrapper .ibexa-dropdown__selection-info'),
         ];
     }
 }


### PR DESCRIPTION
Looks like the tests slowed down after https://github.com/ibexa/admin-ui/pull/377 , this PR narrows one selector to make Behat's jobs easier. It's still not back to the level it was before, further investigation will be needed as well.

Current build (https://github.com/ibexa/experience/runs/6068980934?check_suite_focus=true):
```
 1/40	✔	21 min 2 s 781 ms	/var/www/vendor/ibexa/admin-ui/features/standard/ContentTypeFields.feature
2/40	✔	30 min 13 s 774 ms	/var/www/vendor/ibexa/form-builder/features/FormBuilderTests.feature
3/40	✔	14 min 38 s 886 ms	/var/www/vendor/ibexa/page-builder/features/DynamicLandingPage/Blocks/Blocks.feature
4/40	✔	7 min 58 s 820 ms	/var/www/vendor/ibexa/form-builder/features/FormContentItemAdministration.feature
12/40	✔	13 min 23 s 330 ms	/var/www/vendor/ibexa/form-builder/features/FormFieldConfiguration.feature
```

with the change from this PR:
```
 1/40	✔	19 min 24 s 499 ms	/var/www/vendor/ibexa/admin-ui/features/standard/ContentTypeFields.feature
2/40	✔	27 min 34 s 614 ms	/var/www/vendor/ibexa/form-builder/features/FormBuilderTests.feature
3/40	✔	12 min 38 s 461 ms	/var/www/vendor/ibexa/page-builder/features/DynamicLandingPage/Blocks/Blocks.feature
4/40	✔	7 min 20 s 467 ms	/var/www/vendor/ibexa/form-builder/features/FormContentItemAdministration.feature
11/40	✔	11 min 39 s 436 ms	/var/www/vendor/ibexa/form-builder/features/FormFieldConfiguration.feature
```
(tested in https://github.com/ibexa/experience/pull/32)
