### PR TITLE
IBX-2760: Number input - clear X button overlaps with the number

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezinteger.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezinteger.scss
@@ -1,7 +1,13 @@
 .ibexa-field-edit--ezinteger {
-    .ibexa-data-source__input {
-        width: calculateRem(84px);
+    .ibexa-input-text-wrapper--type-number {
+        width: calculateRem(100px);
         height: calculateRem(48px);
+    }
+
+    .ibexa-data-source__input {
+        &::-webkit-inner-spin-button {
+            margin-left: calculateRem(24px);
+        }
 
         &.is-invalid {
             background-image: none;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2760
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
This solution doesn't work on Firefox - unfortunately there's no way to fix it on that browser, but it should work on other browsers (Chrome, Safari, Edge, Opera)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
