### PR TITLE
IBX-2943: Section is not fully switched when editing content with multiple sections

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
@@ -1,4 +1,5 @@
 (function (global, doc) {
+    const EDIT_CONTENT_TOP_PADDING = 42;
     const formContainerNode = doc.querySelector('.ibexa-edit-content');
     const allSections = [...doc.querySelectorAll('.ibexa-anchor-navigation-sections__section')];
     const isVerticalScrollVisible = () => {
@@ -21,7 +22,7 @@
 
         if (isVerticalScrollVisible()) {
             formContainerNode.scrollTo({
-                top: targetSection.offsetTop,
+                top: targetSection.offsetTop + EDIT_CONTENT_TOP_PADDING,
                 behavior: 'smooth',
             });
         } else {

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -136,7 +136,7 @@
         if (lastSection && lastSection.offsetHeight) {
             const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
             const contentContainer = contentColumn.querySelector('.ibexa-edit-content form');
-            const header = doc.querySelector('.ibexa-edit-header');
+            const header = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
             const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
             const contentColumnBodyHeight = contentColumn.offsetHeight - header.offsetHeight;
             const heightDiff = contentColumnBodyHeight - heightFromLastSection;

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -136,9 +136,9 @@
         if (lastSection && lastSection.offsetHeight) {
             const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
             const contentContainer = contentColumn.querySelector('.ibexa-edit-content form');
-            const header = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
+            const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
             const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
-            const contentColumnBodyHeight = contentColumn.offsetHeight - header.offsetHeight;
+            const contentColumnBodyHeight = contentColumn.offsetHeight - headerContainer.offsetHeight;
             const heightDiff = contentColumnBodyHeight - heightFromLastSection;
 
             if (heightDiff > 0) {

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -131,17 +131,18 @@
         return ibexa.adminUiConfig.autosave.enabled && form.querySelector('[name="ezplatform_content_forms_content_edit[autosave]"]');
     };
     const fitSections = () => {
-        const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
         const lastSection = doc.querySelector('.ibexa-anchor-navigation-sections .ibexa-anchor-navigation-sections__section:last-child');
 
         if (lastSection && lastSection.offsetHeight) {
-            const lastSectionHeight = lastSection.offsetHeight;
-            const headerHeight = doc.querySelector('.ibexa-edit-header').offsetHeight;
-            const contentColumnBodyHeight = contentColumn.offsetHeight - headerHeight;
-            const heightDiff = contentColumnBodyHeight - lastSectionHeight;
+            const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
+            const contentContainer = contentColumn.querySelector('.ibexa-edit-content form');
+            const header = doc.querySelector('.ibexa-edit-header');
+            const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
+            const contentColumnBodyHeight = contentColumn.offsetHeight - header.offsetHeight;
+            const heightDiff = contentColumnBodyHeight - heightFromLastSection;
 
             if (heightDiff > 0) {
-                lastSection.style.paddingBottom = `${heightDiff}px`;
+                contentContainer.style.paddingBottom = `${heightDiff}px`;
             }
         }
     };


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2943
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
Additionaly it fixes problem with large gap between fields and taxonomy, as now it adds padding at the end of form.

In 4.2/main, selector `.ibexa-edit-content form` should be replaced with `.ibexa-edit-content__container`

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
