### PR TITLE
IBX-2939: Field order in CT edit is incorrectly saved on refresh

### DIFF
--- a/src/bundle/Controller/FieldDefinitionController.php
+++ b/src/bundle/Controller/FieldDefinitionController.php
@@ -12,6 +12,7 @@ use Exception;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Contracts\Rest\Exceptions;
@@ -61,11 +62,7 @@ final class FieldDefinitionController extends RestController
             $language->languageCode => 'New field type',
         ];
 
-        if (!$contentTypeDraft->fieldDefinitions->isEmpty()) {
-            $fieldDefinitionCreateStruct->position = $contentTypeDraft->fieldDefinitions->last()->position;
-        } else {
-            $fieldDefinitionCreateStruct->position = 0;
-        }
+        $fieldDefinitionCreateStruct->position = $input->position ?? $this->getNextFieldPosition($contentTypeDraft);
 
         $this->contentTypeService->addFieldDefinition(
             $contentTypeDraft,
@@ -160,5 +157,14 @@ final class FieldDefinitionController extends RestController
         }
 
         return new Values\OK();
+    }
+
+    private function getNextFieldPosition(ContentType $contentType): int
+    {
+        if (!$contentType->fieldDefinitions->isEmpty()) {
+            return $contentType->fieldDefinitions->last()->position + 1;
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://issues.ibexa.co/browse/IBX-2939](https://issues.ibexa.co/browse/IBX-2939)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->




#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
