### PR TITLE
[Behat] IBX-2693: Cover UDW search (4.1)

### DIFF
--- a/features/standard/SearchContent.feature
+++ b/features/standard/SearchContent.feature
@@ -12,3 +12,17 @@ Feature: Searching for a Content item
     And I open "Dashboard" page in admin SiteAccess
     When I search for a Content named "Searched folder"
     Then I should see in search results an item named "Searched folder"
+
+  @javascript @APIUser:admin
+  Scenario: Content can be searched for in UDW
+    Given I create "folder" Content items in root in "eng-GB"
+      | name      | short_name  |
+      | folderUDW | folderUDW   |
+    And I am logged as admin
+    And I open "Dashboard" page in admin SiteAccess
+    And I open UWD from Dashboard
+    When I open Search from UDW
+    And I search for content item "folderUDW" through UDW
+    And I select "folderUDW" item in search results through UDW
+    And I edit selected content
+    Then I should be on Content update page for "folderUDW"

--- a/src/lib/Behat/BrowserContext/UDWContext.php
+++ b/src/lib/Behat/BrowserContext/UDWContext.php
@@ -52,6 +52,14 @@ class UDWContext implements Context
         $this->universalDiscoveryWidget->cancel();
     }
 
+    /**
+     * @When I open Search from UDW
+     */
+    public function iOpenSearchUDW(): void
+    {
+        $this->universalDiscoveryWidget->openSearch();
+    }
+
     /** @When I confirm the selection in UDW */
     public function iConfirmSelection(): void
     {
@@ -96,5 +104,21 @@ class UDWContext implements Context
     public function editSelectedContent(): void
     {
         $this->universalDiscoveryWidget->editSelectedContent();
+    }
+
+    /**
+     * @Given I search for content item :item through UDW
+     */
+    public function searchForContentItem(string $item): void
+    {
+        $this->universalDiscoveryWidget->searchForContent($item);
+    }
+
+    /**
+     * @Given I select :item (content) item in search results through UDW
+     */
+    public function selectItemInSearchResults(string $item): void
+    {
+        $this->universalDiscoveryWidget->selectInSearchResults($item);
     }
 }

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -52,6 +52,11 @@ class UniversalDiscoveryWidget extends Component
         $this->getHTMLPage()->find($this->getLocator('cancelButton'))->click();
     }
 
+    public function openSearch(): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('searchButton'))->click();
+    }
+
     public function verifyIsLoaded(): void
     {
         $this->getHTMLPage()->find($this->getLocator('udw'))->assert()->isVisible();
@@ -155,6 +160,25 @@ class UniversalDiscoveryWidget extends Component
         $this->getSession()->switchToIFrame('editIframe');
     }
 
+    public function searchForContent(string $name): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('inputField'))->setValue($name);
+        $this->getHTMLPage()->find($this->getLocator('searchButton'))->click();
+
+        $this->getHTMLPage()
+            ->setTimeout(self::SHORT_TIMEOUT)
+            ->find($this->getLocator('searchResults'))
+            ->assert()->textContains('Results for');
+    }
+
+    public function selectInSearchResults(string $name): void
+    {
+        $this->getHTMLPage()
+            ->find($this->getLocator('targetResult'))
+            ->assert()->textEquals($name)
+            ->click();
+    }
+
     protected function specifyLocators(): array
     {
         return [
@@ -180,6 +204,11 @@ class UniversalDiscoveryWidget extends Component
             new VisibleCSSLocator('bookmarkButton', '.c-content-meta-preview__toggle-bookmark-button'),
             new VisibleCSSLocator('bookmarkedItem', '.c-bookmarks-list__item-name'),
             new VisibleCSSLocator('markedBookmarkedItem', '.c-bookmarks-list__item--marked'),
+            // search
+            new VisibleCSSLocator('inputField', '.c-top-menu-search-input__search-input'),
+            new VisibleCSSLocator('searchButton', '.c-top-menu-search-input__search-btn'),
+            new VisibleCSSLocator('searchResults', '.c-search__table-title'),
+            new VisibleCSSLocator('targetResult', '.ibexa-table__row td:nth-child(2)'),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-2693](https://issues.ibexa.co/browse/IBX-2693)
| Bug fix?      | no
| New feature?  | tests
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This adds a simple scenario covering Search in UDW adjusted for v4.

The v4 changes are:
- UDW is opened from Dashboard, there is no Browse in Content structure
- Search is no longer an UDW tab, it is opened via the Search button
- The search result is edited instead of previewed, the default UDW configuration does not include the preview button

v3 PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/2049

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
