### PR TITLE
[Behat] Restore deleted ElementTextCriterion

### DIFF
--- a/src/lib/Behat/Page/ContentUpdateItemPage.php
+++ b/src/lib/Behat/Page/ContentUpdateItemPage.php
@@ -13,6 +13,7 @@ use Ibexa\AdminUi\Behat\Component\ContentActionsMenu;
 use Ibexa\AdminUi\Behat\Component\Fields\FieldTypeComponent;
 use Ibexa\AdminUi\Behat\Component\Notification;
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextFragmentCriterion;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\Behat\Browser\Page\Page;


### PR DESCRIPTION
It seems that ElementTextCriterion was removed during crossmerge :) (https://github.com/ibexa/admin-ui/pull/449/files#diff-120e25363c558247aa880bccdfbabde3541728910e8c25b3a84ec4bf8d161c98L16). It is the cause of CI failure -such as https://github.com/ibexa/commerce/runs/6679362821?check_suite_focus=true#step:12:49
