### PR TITLE
IBX-2779: Unify ghost dropdown caret icon

### DIFF
--- a/src/bundle/Resources/public/scss/_dropdown.scss
+++ b/src/bundle/Resources/public/scss/_dropdown.scss
@@ -358,23 +358,6 @@
             &__selection-info {
                 border: none;
                 padding: 0 calculateRem(16px);
-
-                &::before {
-                    display: none;
-                }
-
-                &:after {
-                    content: '';
-                    position: absolute;
-                    right: calculateRem(8px);
-                    width: 0;
-                    height: 0;
-                    border-style: solid;
-                    border-width: calculateRem(6px) calculateRem(3px) 0 calculateRem(3px);
-                    border-color: $ibexa-color-dark transparent transparent transparent;
-                    transform: translate(0, -50%);
-                    background: none;
-                }
             }
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2779
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
Unification of caret icon in dropdown, as eralier it was different in whole system

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
