### PR TITLE
IBX-2961: Refactored Extension to rely on Encore Configuration Dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/asset": "^5.0",
         "symfony/yaml": "^5.0",
         "jms/translation-bundle": "^1.5",
-        "ibexa/core": "~4.1.0@dev",
+        "ibexa/core": "~4.1.6@dev",
         "ibexa/content-forms": "~4.1.0@dev",
         "ibexa/design-engine": "~4.1.0@dev",
         "ibexa/user": "~4.1.0@dev",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2961](https://issues.ibexa.co/browse/IBX-2961)
| **Requires**                             | ibexa/core#120
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.1`+
| **BC breaks**                          | no

This PR aligns AdminUi with the changes done in ibexa/core#120 for ibexa/fieldtype-richtext#46

### Doc

It is worth to update "[Importing assets from a bundle](https://doc.ibexa.co/en/latest/extending/import_assets_from_bundle/#configuration-from-a-bundle)" page, stating that now it's possible to place Ibexa Webpack Encore configuration in the project top-level directory `encore`. Applies to:
- `ibexa.config.js`
- `ibexa.config.manager.js`

And also:
- `ibexa.webpack.custom.config.js`
- `ibexa.config.setup.js`

but for the latter two I don't see any mention in the doc.


### QA

1. Sanity/regression check regarding custom configuration mentioned in the doc and for those 4 files.
2. Sanity/regression check of OE (e.g. by creating an Article)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage (generic coverage in core).
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review