### PR TITLE
[Behat] Make sure Content Type Update Page is loaded before further interactions

### DIFF
--- a/src/lib/Behat/BrowserContext/ContentTypeContext.php
+++ b/src/lib/Behat/BrowserContext/ContentTypeContext.php
@@ -117,6 +117,7 @@ class ContentTypeContext implements Context
      */
     public function iSelectCategory(string $categoryName): void
     {
+        $this->contentTypeUpdatePage->verifyIsLoaded();
         $this->contentTypeUpdatePage->clickAddButton();
         $this->contentTypeUpdatePage->selectContentTypeCategory($categoryName);
     }


### PR DESCRIPTION
Failure:
https://github.com/ibexa/commerce/runs/7242133030?check_suite_focus=true
```
     And I select "Content" category to Content Type definition                  # Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext::iSelectCategory()
      Ibexa\Behat\Browser\Exception\TimeoutException: Element with CSS locator 'contentTypeCategoryList': ' div.ibexa-content-type-edit__add-field-definitions-group > ul > li:nth-child(n):not(.ibexa-popup-menu__item-action--disabled)' was not found. Timeout value: 3 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:59
      Stack trace:
      #0 vendor/ibexa/admin-ui/src/lib/Behat/Page/ContentTypeUpdatePage.php(86): Ibexa\Behat\Browser\Element\BaseElement->waitUntilCondition()
      #1 vendor/ibexa/admin-ui/src/lib/Behat/BrowserContext/ContentTypeContext.php(120): Ibexa\AdminUi\Behat\Page\ContentTypeUpdatePage->clickAddButton()
    │
```