### PR TITLE
[Behat] IBX-1548: Added spike coverage for content item translation

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -16,6 +16,7 @@ jobs:
             project-version: '4.2.x-dev'
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'
+            test-setup-phase-2: '--profile=setup --suite=content-translation --mode=standard'
             timeout: 40
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/features/personas/ChangePassword.feature
+++ b/features/personas/ChangePassword.feature
@@ -1,4 +1,4 @@
-@javascript @changePassword
+@javascript @changePassword @IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
 Feature: Verify that an User allowed to change password can change his password
 
   Scenario: I can change my password

--- a/features/standard/ContentTranslation.feature
+++ b/features/standard/ContentTranslation.feature
@@ -1,0 +1,56 @@
+@javascript @translation @IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+Feature: Content item transation
+
+  @APIUser:admin
+  Scenario: Publish new translation based on existing translation
+    Given I create "folder" Content items in root in "eng-GB"
+      | name             | short_name       | short_description | description      |
+      | EnglishPublished | EnglishPublished | EnglishPublished  | EnglishPublished |
+    And I am logged as admin
+    And I'm on Content view Page for "EnglishPublished"
+    When I switch to "Translations" tab in Content structure
+    And I add new translation "French" basing on "English (United Kingdom)" translation
+    And I set content fields
+      | label      | value           |
+      | Name       | FrenchPublished |
+      | Short name | FrenchPublished |
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And content attributes equal
+      | label             | value            |
+      | Name              | EnglishPublished |
+      | Short name        | EnglishPublished |
+      | Short description | EnglishPublished |
+      | Description       | EnglishPublished |
+    And I choose "French" preview in Content View
+    And content attributes equal
+      | label             | value            |
+      | Name              | FrenchPublished  |
+      | Short name        | FrenchPublished  |
+      | Short description | EnglishPublished |
+      | Description       | EnglishPublished |
+
+  @APIUser:admin
+  Scenario: Publish new translation without base translation
+    Given I create "folder" Content items in root in "eng-GB"
+      | name            | short_name       | short_description | description      |
+      | NoBasePublished | NoBasePublished  | NoBasePublished   | NoBasePublished  |
+    And I am logged as admin
+    And I'm on Content view Page for "NoBasePublished"
+    When I switch to "Translations" tab in Content structure
+    And I add new translation "French" without base translation
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And content attributes equal
+      | label             | value           |
+      | Name              | NoBasePublished |
+      | Short name        | NoBasePublished |
+      | Short description | NoBasePublished |
+      | Description       | NoBasePublished |
+    And I choose "French" preview in Content View
+    And content attributes equal
+      | label             | value               | fieldTypeIdentifier |
+      | Name              | Folder              |                     |
+      | Short name        | This field is empty | ezstring            |
+      | Short description | This field is empty | ezrichtext          |
+      | Description       | This field is empty | ezrichtext          |

--- a/src/bundle/Resources/config/services/test/components.yaml
+++ b/src/bundle/Resources/config/services/test/components.yaml
@@ -15,6 +15,8 @@ services:
 
   Ibexa\AdminUi\Behat\Component\Dialog: ~
 
+  Ibexa\AdminUi\Behat\Component\TranslationDialog: ~
+
   Ibexa\AdminUi\Behat\Component\Pagination: ~
 
   Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget: ~

--- a/src/lib/Behat/BrowserContext/ContentViewContext.php
+++ b/src/lib/Behat/BrowserContext/ContentViewContext.php
@@ -68,6 +68,23 @@ class ContentViewContext implements Context
     }
 
     /**
+     * @Given I add new translation :language without base translation
+     * @Given I add new translation :language basing on :base translation
+     */
+    public function iAddNewTranslation(string $language, string $base = 'none'): void
+    {
+        $this->contentViewPage->addTranslation($language, $base);
+    }
+
+    /**
+     * @Given I choose :language preview in Content View
+     */
+    public function iChoosePreview(string $language): void
+    {
+        $this->contentViewPage->choosePreview($language);
+    }
+
+    /**
      * @Given I start creating a new User
      */
     public function startCreatingUser(): void

--- a/src/lib/Behat/Component/TranslationDialog.php
+++ b/src/lib/Behat/Component/TranslationDialog.php
@@ -8,46 +8,46 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component;
 
-use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
+use Behat\Mink\Session;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
 class TranslationDialog extends Dialog
 {
-    protected function chooseFromDropdown(string $language): void
+    private IbexaDropdown $ibexaDropdown;
+
+    public function __construct(Session $session, IbexaDropdown $ibexaDropdown)
     {
-        $this->getHTMLPage()
-            ->findAll($this->getLocator('dropdownItem'))
-            ->getByCriterion(new ElementTextCriterion($language))
-            ->click();
+        parent::__construct($session);
+        $this->ibexaDropdown = $ibexaDropdown;
     }
 
     public function selectNewTranslation(string $languageName): void
     {
         $this->getHTMLPage()->find($this->getLocator('expandNewTranslationDropdown'))->click();
-        $this->chooseFromDropdown($languageName);
+        $this->ibexaDropdown->verifyIsLoaded();
+        $this->ibexaDropdown->selectOption($languageName);
     }
 
     public function selectBaseTranslation(string $languageName): void
     {
         $this->getHTMLPage()->find($this->getLocator('expandBaseTranslationDropdown'))->click();
-        $this->chooseFromDropdown($languageName);
+        $this->ibexaDropdown->verifyIsLoaded();
+        $this->ibexaDropdown->selectOption($languageName);
     }
 
     public function verifyIsLoaded(): void
     {
         $this->getHTMLPage()->setTimeout(3)
-            ->find($this->getLocator('addTranslationPopupModalTitle'))->assert()->textEquals('Create a new translation');
+            ->find($this->getLocator('addTranslationPopupModalTitle'))
+            ->assert()->textEquals('Create a new translation');
     }
 
     protected function specifyLocators(): array
     {
-        return [
-            new VisibleCSSLocator('expandNewTranslationDropdown', '.ibexa-dropdown ibexa-dropdown--single .ibexa-dropdown__source .add-translation_language'),
-            new VisibleCSSLocator('expandBaseTranslationDropdown', '.ibexa-dropdown ibexa-dropdown--single .ibexa-dropdown__source .add-translation_base_language'),
-            new VisibleCSSLocator('dropdownItem', '.ibexa-dropdown__item .ibexa-dropdown__item-label'),
-            new VisibleCSSLocator('confirm', '.modal.show button[type="submit"],.modal.show button[data-click]'),
-            new VisibleCSSLocator('decline', '.modal.show .ibexa-btn--secondary'),
+        return array_merge(parent::specifyLocators(), [
+            new VisibleCSSLocator('expandNewTranslationDropdown', '#add-translation-modal [for="add-translation_language"] + .ibexa-dropdown .ibexa-dropdown__selection-info'),
+            new VisibleCSSLocator('expandBaseTranslationDropdown', '#add-translation-modal [for="add-translation_base_language"] + .ibexa-dropdown .ibexa-dropdown__selection-info'),
             new VisibleCSSLocator('addTranslationPopupModalTitle', '#add-translation-modal .modal-title'),
-        ];
+        ]);
     }
 }

--- a/src/lib/Behat/Component/TranslationDialog.php
+++ b/src/lib/Behat/Component/TranslationDialog.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Behat\Component;
+
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
+use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
+
+class TranslationDialog extends Dialog
+{
+    protected function chooseFromDropdown(string $language): void
+    {
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('dropdownItem'))
+            ->getByCriterion(new ElementTextCriterion($language))
+            ->click();
+    }
+
+    public function selectNewTranslation(string $languageName): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('expandNewTranslationDropdown'))->click();
+        $this->chooseFromDropdown($languageName);
+    }
+
+    public function selectBaseTranslation(string $languageName): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('expandBaseTranslationDropdown'))->click();
+        $this->chooseFromDropdown($languageName);
+    }
+
+    public function verifyIsLoaded(): void
+    {
+        $this->getHTMLPage()->setTimeout(3)
+            ->find($this->getLocator('addTranslationPopupModalTitle'))->assert()->textEquals('Create a new translation');
+    }
+
+    protected function specifyLocators(): array
+    {
+        return [
+            new VisibleCSSLocator('expandNewTranslationDropdown', '.ibexa-dropdown ibexa-dropdown--single .ibexa-dropdown__source .add-translation_language'),
+            new VisibleCSSLocator('expandBaseTranslationDropdown', '.ibexa-dropdown ibexa-dropdown--single .ibexa-dropdown__source .add-translation_base_language'),
+            new VisibleCSSLocator('dropdownItem', '.ibexa-dropdown__item .ibexa-dropdown__item-label'),
+            new VisibleCSSLocator('confirm', '.modal.show button[type="submit"],.modal.show button[data-click]'),
+            new VisibleCSSLocator('decline', '.modal.show .ibexa-btn--secondary'),
+            new VisibleCSSLocator('addTranslationPopupModalTitle', '#add-translation-modal .modal-title'),
+        ];
+    }
+}

--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -14,6 +14,7 @@ use Ibexa\AdminUi\Behat\Component\ContentActionsMenu;
 use Ibexa\AdminUi\Behat\Component\ContentItemAdminPreview;
 use Ibexa\AdminUi\Behat\Component\ContentTypePicker;
 use Ibexa\AdminUi\Behat\Component\Dialog;
+use Ibexa\AdminUi\Behat\Component\IbexaDropdown;
 use Ibexa\AdminUi\Behat\Component\LanguagePicker;
 use Ibexa\AdminUi\Behat\Component\SubItemsList;
 use Ibexa\AdminUi\Behat\Component\TranslationDialog;
@@ -84,6 +85,9 @@ class ContentViewPage extends Page
     /** @var \Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget */
     private $universalDiscoveryWidget;
 
+    /** @var \Ibexa\AdminUi\Behat\Component\IbexaDropdown */
+    private $ibexaDropdown;
+
     public function __construct(
         Session $session,
         Router $router,
@@ -99,7 +103,8 @@ class ContentViewPage extends Page
         ContentItemAdminPreview $contentItemAdminPreview,
         UserUpdatePage $userUpdatePage,
         ArgumentParser $argumentParser,
-        UniversalDiscoveryWidget $universalDiscoveryWidget
+        UniversalDiscoveryWidget $universalDiscoveryWidget,
+        IbexaDropdown $ibexaDropdown
     ) {
         parent::__construct($session, $router);
 
@@ -116,6 +121,7 @@ class ContentViewPage extends Page
         $this->repository = $repository;
         $this->argumentParser = $argumentParser;
         $this->universalDiscoveryWidget = $universalDiscoveryWidget;
+        $this->ibexaDropdown = $ibexaDropdown;
     }
 
     public function startCreatingContent(string $contentTypeName, string $language = null)
@@ -137,8 +143,21 @@ class ContentViewPage extends Page
 
     public function switchToTab(string $tabName): void
     {
-        $this->getHTMLPage()
+        $tabs = $this->getHTMLPage()
             ->findAll($this->getLocator('tab'))
+            ->filterBy(new ElementTextCriterion($tabName));
+
+        if ($tabs->any()) {
+            $tab = $tabs->first();
+            $tab->click();
+
+            return;
+        }
+
+        $this->getHTMLPage()->find($this->getLocator('moreTab'))->click();
+
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('popupMenuItem'))
             ->getByCriterion(new ElementTextCriterion($tabName))
             ->click();
     }
@@ -164,11 +183,9 @@ class ContentViewPage extends Page
 
     public function choosePreview(string $language): void
     {
-        $this->getHTMLPage()->find($this->getLocator('previewDropdown'))->click();
-        $this->getHTMLPage()
-            ->findAll($this->getLocator('previewLanguage'))
-            ->getByCriterion(new ElementTextCriterion($language))
-            ->click();
+        $this->getHTMLPage()->find($this->getLocator('ibexaDropdownPreview'))->click();
+        $this->ibexaDropdown->verifyIsLoaded();
+        $this->ibexaDropdown->selectOption($language);
         $this->verifyIsLoaded();
     }
 
@@ -286,8 +303,9 @@ class ContentViewPage extends Page
             new VisibleCSSLocator('bookmarkButton', '.ibexa-add-to-bookmarks'),
             new VisibleCSSLocator('isBookmarked', '.ibexa-add-to-bookmarks--checked'),
             new VisibleCSSLocator('addTranslationButton', '#ibexa-tab-location-view-translations .ibexa-table-header__actions .ibexa-btn--add-translation'),
-            new VisibleCSSLocator('previewDropdown', '.ibexa-location-language-change'),
-            new VisibleCSSLocator('previewLanguage', '.ibexa-location-language-change .ibexa-dropdown__item-label'),
+            new VisibleCSSLocator('ibexaDropdownPreview', '.ibexa-raw-content-title__language-form .ibexa-dropdown__selection-info'),
+            new VisibleCSSLocator('moreTab', '.ibexa-tabs__tab--more'),
+            new VisibleCSSLocator('popupMenuItem', '.ibexa-popup-menu__item .ibexa-popup-menu__item-content'),
         ];
     }
 

--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -16,6 +16,7 @@ use Ibexa\AdminUi\Behat\Component\ContentTypePicker;
 use Ibexa\AdminUi\Behat\Component\Dialog;
 use Ibexa\AdminUi\Behat\Component\LanguagePicker;
 use Ibexa\AdminUi\Behat\Component\SubItemsList;
+use Ibexa\AdminUi\Behat\Component\TranslationDialog;
 use Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget;
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
@@ -57,6 +58,9 @@ class ContentViewPage extends Page
     /** @var \Ibexa\AdminUi\Behat\Component\Dialog */
     private $dialog;
 
+    /** @var \Ibexa\AdminUi\Behat\Component\TranslationDialog */
+    private $translationDialog;
+
     private $route;
 
     /** @var \Ibexa\AdminUi\Behat\Component\Breadcrumb */
@@ -89,6 +93,7 @@ class ContentViewPage extends Page
         ContentUpdateItemPage $contentUpdatePage,
         LanguagePicker $languagePicker,
         Dialog $dialog,
+        TranslationDialog $translationDialog,
         Repository $repository,
         Breadcrumb $breadcrumb,
         ContentItemAdminPreview $contentItemAdminPreview,
@@ -104,6 +109,7 @@ class ContentViewPage extends Page
         $this->contentUpdatePage = $contentUpdatePage;
         $this->languagePicker = $languagePicker;
         $this->dialog = $dialog;
+        $this->translationDialog = $translationDialog;
         $this->breadcrumb = $breadcrumb;
         $this->contentItemAdminPreview = $contentItemAdminPreview;
         $this->userUpdatePage = $userUpdatePage;
@@ -143,6 +149,27 @@ class ContentViewPage extends Page
         $this->universalDiscoveryWidget->verifyIsLoaded();
         $this->universalDiscoveryWidget->selectContent($newLocationPath);
         $this->universalDiscoveryWidget->confirm();
+    }
+
+    public function addTranslation(string $language, string $base): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('addTranslationButton'))->click();
+        $this->translationDialog->verifyIsLoaded();
+        $this->translationDialog->selectNewTranslation($language);
+        if ($base != 'none') {
+            $this->translationDialog->selectBaseTranslation($base);
+        }
+        $this->translationDialog->confirm();
+    }
+
+    public function choosePreview(string $language): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('previewDropdown'))->click();
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('previewLanguage'))
+            ->getByCriterion(new ElementTextCriterion($language))
+            ->click();
+        $this->verifyIsLoaded();
     }
 
     public function goToSubItem(string $contentItemName): void
@@ -258,6 +285,9 @@ class ContentViewPage extends Page
             new VisibleCSSLocator('addLocationButton', '#ibexa-tab-location-view-locations .ibexa-table-header__actions .ibexa-btn--udw-add'),
             new VisibleCSSLocator('bookmarkButton', '.ibexa-add-to-bookmarks'),
             new VisibleCSSLocator('isBookmarked', '.ibexa-add-to-bookmarks--checked'),
+            new VisibleCSSLocator('addTranslationButton', '#ibexa-tab-location-view-translations .ibexa-table-header__actions .ibexa-btn--add-translation'),
+            new VisibleCSSLocator('previewDropdown', '.ibexa-location-language-change'),
+            new VisibleCSSLocator('previewLanguage', '.ibexa-location-language-change .ibexa-dropdown__item-label'),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1548](https://issues.ibexa.co/browse/IBX-1548)
| Bug fix?      | no
| New feature?  | tests
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


v4 version of https://github.com/ezsystems/ezplatform-admin-ui/pull/2057.

TODO:
- [x] add check if pop-up is loaded: https://github.com/ibexa/behat/actions/runs/2979496913/jobs/4775481037 / 
https://res.cloudinary.com/ezplatformtravis/image/upload/v1662127615/screenshots/63120dff7dc4a843666517-vendor_ibexa_admin-ui_features_standard_contenttranslation_feature_5_d72aqq.png ([IBX-3872](https://issues.ibexa.co/browse/IBX-3872) surfaced)
- [x] handle "More tabs" tab
- [x] switch to ibexa dropdown
- [x] remove TMP commit

Regression builds:
- https://github.com/ibexa/oss/pull/72
- https://github.com/ibexa/commerce/pull/132

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
