### PR TITLE
IBX-3523: Introduced tabs to left sidebar in Content Edit interface

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
@@ -28,7 +28,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 class AdminUiForms extends AbstractParser
 {
     public const FORM_TEMPLATES_PARAM = 'admin_ui_forms.content_edit_form_templates';
-    public const FIELDTYPES_PARAM = 'admin_ui_forms.content_edit.fieldtypes';
+    public const FIELD_TYPES_PARAM = 'admin_ui_forms.content_edit.fieldtypes';
 
     /**
      * Adds semantic configuration definition.
@@ -114,7 +114,7 @@ class AdminUiForms extends AbstractParser
             $scopeSettings['admin_ui_forms.content_edit_form_templates'] ?? []
         );
         $contextualizer->setContextualParameter(
-            static::FIELDTYPES_PARAM,
+            static::FIELD_TYPES_PARAM,
             $currentScope,
             $scopeSettings['admin_ui_forms.content_edit.fieldtypes'] ?? []
         );

--- a/src/bundle/Resources/config/admin_ui_forms.yaml
+++ b/src/bundle/Resources/config/admin_ui_forms.yaml
@@ -1,8 +1,9 @@
 system:
     admin_group:
         admin_ui_forms:
-            content_edit_form_templates:
-                - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }
+            content_edit:
+                form_templates:
+                    - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }
 
         field_templates:
             - { template: '@ibexadesign/ui/field_type/preview/content_fields.html.twig', priority: 20 }

--- a/src/bundle/Resources/config/services/components/content/edit.yaml
+++ b/src/bundle/Resources/config/services/components/content/edit.yaml
@@ -7,3 +7,7 @@ services:
     Ibexa\AdminUi\Component\Content\PreviewUnavailableTwigComponent:
         tags:
             - { name: ibexa.admin_ui.component, group: 'content-edit-form-before' }
+
+    Ibexa\AdminUi\Component\Content\ContentEditMetaFieldsComponent:
+        tags:
+            - { name: ibexa.admin_ui.component, group: 'content-edit-sections' }

--- a/src/bundle/Resources/config/services/events.yaml
+++ b/src/bundle/Resources/config/services/events.yaml
@@ -27,7 +27,7 @@ services:
         arguments:
             - '%ibexa.site_access.groups%'
         tags:
-            - {name: kernel.event_subscriber}
+            - { name: kernel.event_subscriber }
 
     Ibexa\AdminUi\EventListener\AdminExceptionListener:
         arguments:
@@ -41,7 +41,7 @@ services:
 
     Ibexa\AdminUi\EventListener\MenuPermissionsListener:
         tags:
-            - {name: kernel.event_subscriber, priority: -250}
+            - { name: kernel.event_subscriber, priority: -250 }
 
     Ibexa\AdminUi\EventListener\ViewTemplatesListener:
         tags:
@@ -51,4 +51,10 @@ services:
         arguments:
             $siteAccessGroups: '%ibexa.site_access.groups%'
         tags:
-            - {name: kernel.event_subscriber}
+            - { name: kernel.event_subscriber }
+
+    Ibexa\AdminUi\EventListener\SetViewParametersListener:
+        arguments:
+            $groupedContentFormFieldsProvider: '@Ibexa\AdminUi\Form\Provider\GroupedNonMetaFormFieldsProvider'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -401,3 +401,7 @@ services:
     Ibexa\AdminUi\Form\Type\ContentType\FieldDefinitionsCollectionType:
         tags:
             - { name: form.type }
+
+    Ibexa\AdminUi\Form\Provider\GroupedNonMetaFormFieldsProvider:
+        arguments:
+            $innerGroupedContentFormFieldsProvider: '@Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface'

--- a/src/bundle/Resources/config/services/menu.yaml
+++ b/src/bundle/Resources/config/services/menu.yaml
@@ -45,6 +45,11 @@ services:
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.content_edit.sidebar_right }
 
+    Ibexa\AdminUi\Menu\ContentEditAnchorMenuBuilder:
+        public: true
+        tags:
+            - { name: knp_menu.menu_builder, method: build, alias: ibexa.admin_ui.menu.content_edit.anchor_menu }
+
     Ibexa\AdminUi\Menu\ContentCreateRightSidebarBuilder:
         public: true
         tags:

--- a/src/bundle/Resources/encore/ibexa.js.config.js
+++ b/src/bundle/Resources/encore/ibexa.js.config.js
@@ -55,6 +55,7 @@ const layout = [
     path.resolve(__dirname, '../public/js/scripts/autogenerate.identifier.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.back.to.top.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.middle.ellipsis.js'),
+    path.resolve(__dirname, '../public/js/scripts/admin.anchor.sections.navigation'),
 ];
 const fieldTypes = [];
 

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
@@ -1,4 +1,8 @@
 (function (global, doc) {
+    if (doc.querySelector('.ibexa-navigation-menu')) {
+        return;
+    }
+
     const EDIT_CONTENT_TOP_PADDING = 42;
     const formContainerNode = doc.querySelector('.ibexa-edit-content');
     const allSections = [...doc.querySelectorAll('.ibexa-anchor-navigation-sections__section')];

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
@@ -23,7 +23,7 @@
         contentContainer.style.paddingBottom = '0px';
 
         if (!firstSection.isSameNode(lastSection) && lastSection && lastSection.offsetHeight) {
-            const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
+            const headerContainer = doc.querySelector('.ibexa-edit-header__container');
             const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
             const contentColumnBodyHeight = contentColumn.offsetHeight - headerContainer.offsetHeight;
             const heightDiff = contentColumnBodyHeight - heightFromLastSection;
@@ -67,7 +67,7 @@
         items.forEach((item) => item.classList.toggle('ibexa-navigation-menu__secondary--active', item.isSameNode(node)));
     };
     const onSelectPrimaryMenuList = (event) => {
-        const { targetId } = event.target.dataset;
+        const { targetId } = event.currentTarget.dataset;
         const secondaryMenuNode = doc.querySelector(`.ibexa-navigation-menu__secondary[data-id="${targetId}"]`);
         const primaryMenuItems = doc.querySelectorAll('.ibexa-navigation-menu__primary--list .ibexa-navigation-menu__primary-item');
 
@@ -81,7 +81,7 @@
         }
     };
     const onSelectPrimaryMenuDropdown = (event) => {
-        const targetId = event.target.value;
+        const targetId = event.currentTarget.value;
         const secondaryMenuNode = doc.querySelector(`.ibexa-navigation-menu__secondary[data-id="${targetId}"]`);
 
         showPrimarySection(targetId);
@@ -116,7 +116,7 @@
     };
     const bindScrollContainerEvents = () => {
         const allSections = [...doc.querySelectorAll('.ibexa-edit-content__secondary-section')];
-        const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
+        const headerContainer = doc.querySelector('.ibexa-edit-header__container');
         let previousFirstVisibleSection = null;
 
         if (formContainerNode && allSections.length) {

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
@@ -18,13 +18,13 @@
     const fitSecondarySections = () => {
         const primarySection = doc.querySelector('.ibexa-edit-content__primary-section--active');
         const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
-        const firstSection = primarySection.querySelector('.ibexa-edit-content__secondary-section:first-child');
-        const lastSection = primarySection.querySelector('.ibexa-edit-content__secondary-section:last-child');
+        const firstSection = primarySection.firstElementChild;
+        const lastSection = primarySection.lastElementChild;
         const contentContainer = contentColumn.querySelector('.ibexa-edit-content__container');
 
         contentContainer.style.paddingBottom = '0px';
 
-        if (!firstSection.isSameNode(lastSection) && lastSection && lastSection.offsetHeight) {
+        if (!firstSection.isSameNode(lastSection) && lastSection.offsetHeight) {
             const headerContainer = doc.querySelector('.ibexa-edit-header__container');
             const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
             const contentColumnBodyHeight = contentColumn.offsetHeight - headerContainer.offsetHeight;
@@ -74,7 +74,7 @@
         const primaryMenuItems = doc.querySelectorAll('.ibexa-navigation-menu__primary--list .ibexa-navigation-menu__primary-item');
 
         primaryMenuItems.forEach((item) => {
-            item.classList.toggle('ibexa-navigation-menu__primary-item--active', item.isSameNode(event.target));
+            item.classList.toggle('ibexa-navigation-menu__primary-item--active', item.isSameNode(event.currentTarget));
         });
         showPrimarySection(targetId);
 
@@ -97,12 +97,12 @@
 
         navigateTo(targetId);
     };
-    const bindPrimaryMenuListEvents = () => {
+    const attachPrimaryMenuListEvents = () => {
         const items = doc.querySelectorAll('.ibexa-navigation-menu__primary--list .ibexa-navigation-menu__primary-item');
 
         items.forEach((item) => item.addEventListener('click', onSelectPrimaryMenuList, false));
     };
-    const bindPrimaryMenuDropdownEvents = () => {
+    const attachPrimaryMenuDropdownEvents = () => {
         const sourceSelect = doc.querySelector('.ibexa-navigation-menu__primary--dropdown .ibexa-dropdown__source .ibexa-input');
 
         if (!sourceSelect) {
@@ -111,14 +111,14 @@
 
         sourceSelect.addEventListener('change', onSelectPrimaryMenuDropdown, false);
     };
-    const bindSecondaryMenuEvents = () => {
+    const attachSecondaryMenuEvents = () => {
         const items = doc.querySelectorAll('.ibexa-navigation-menu .ibexa-navigation-menu__secondary-item-btn');
 
         items.forEach((item) => item.addEventListener('click', onSelectSecondaryMenu, false));
     };
-    const bindScrollContainerEvents = () => {
-        const allSections = [...doc.querySelectorAll('.ibexa-edit-content__secondary-section')];
-        const headerContainer = doc.querySelector('.ibexa-edit-header__container');
+    const attachScrollContainerEvents = () => {
+        const allSections = [...formContainerNode.querySelectorAll('.ibexa-edit-content__secondary-section')];
+        const headerContainer = formContainerNode.querySelector('.ibexa-edit-header__container');
         let previousFirstVisibleSection = null;
 
         if (formContainerNode && allSections.length) {
@@ -150,10 +150,10 @@
         }
     };
 
-    bindPrimaryMenuListEvents();
-    bindPrimaryMenuDropdownEvents();
-    bindSecondaryMenuEvents();
-    bindScrollContainerEvents();
+    attachPrimaryMenuListEvents();
+    attachPrimaryMenuDropdownEvents();
+    attachSecondaryMenuEvents();
+    attachScrollContainerEvents();
     fitSecondarySections();
     ibexa.helpers.tooltips.parse(navigationMenu);
 })(window, window.document, window.ibexa);

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
@@ -1,0 +1,156 @@
+(function (global, doc) {
+    if (!doc.querySelector('.ibexa-navigation-menu')) {
+        return;
+    }
+
+    const SECTION_ADJUST_MARGIN_TOP = 20;
+    const formContainerNode = doc.querySelector('.ibexa-edit-content');
+    const getSecondarySectionActiveItems = () => {
+        const secondarySectionItems = formContainerNode.querySelectorAll(
+            '.ibexa-edit-content__primary-section--active .ibexa-edit-content__secondary-section',
+        );
+
+        return [...secondarySectionItems];
+    };
+    let currentlyVisibleSections = getSecondarySectionActiveItems();
+    const fitSecondarySections = () => {
+        const primarySection = doc.querySelector('.ibexa-edit-content__primary-section--active');
+        const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
+        const firstSection = primarySection.querySelector('.ibexa-edit-content__secondary-section:first-child');
+        const lastSection = primarySection.querySelector('.ibexa-edit-content__secondary-section:last-child');
+        const contentContainer = contentColumn.querySelector('.ibexa-edit-content__container');
+
+        contentContainer.style.paddingBottom = '0px';
+
+        if (!firstSection.isSameNode(lastSection) && lastSection && lastSection.offsetHeight) {
+            const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
+            const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
+            const contentColumnBodyHeight = contentColumn.offsetHeight - headerContainer.offsetHeight;
+            const heightDiff = contentColumnBodyHeight - heightFromLastSection;
+
+            if (heightDiff > 0) {
+                contentContainer.style.paddingBottom = `${heightDiff}px`;
+            }
+        }
+    };
+    const navigateTo = (targetId) => {
+        const secondarySectionNode = formContainerNode.querySelector(`.ibexa-edit-content__secondary-section[data-id="${targetId}"]`);
+
+        formContainerNode.scrollTo({
+            top: secondarySectionNode.offsetTop,
+            behavior: 'smooth',
+        });
+    };
+    const setActiveSecondaryMenu = (node) => {
+        const secondaryMenuItems = doc.querySelectorAll(
+            '.ibexa-navigation-menu__secondary--active .ibexa-navigation-menu__secondary-item-btn',
+        );
+
+        secondaryMenuItems.forEach((item) => {
+            item.classList.toggle('ibexa-navigation-menu__secondary-item-btn--active', item.isSameNode(node));
+        });
+    };
+    const showPrimarySection = (id) => {
+        const primarySectionItems = formContainerNode.querySelectorAll('.ibexa-edit-content__primary-section');
+
+        primarySectionItems.forEach((item) => {
+            item.classList.toggle('ibexa-edit-content__primary-section--active', item.dataset.id === id);
+        });
+
+        currentlyVisibleSections = getSecondarySectionActiveItems();
+
+        fitSecondarySections();
+    };
+    const showSecondaryMenu = (node) => {
+        const items = doc.querySelectorAll('.ibexa-navigation-menu__secondary');
+
+        items.forEach((item) => item.classList.toggle('ibexa-navigation-menu__secondary--active', item.isSameNode(node)));
+    };
+    const onSelectPrimaryMenuList = (event) => {
+        const { targetId } = event.target.dataset;
+        const secondaryMenuNode = doc.querySelector(`.ibexa-navigation-menu__secondary[data-id="${targetId}"]`);
+        const primaryMenuItems = doc.querySelectorAll('.ibexa-navigation-menu__primary--list .ibexa-navigation-menu__primary-item');
+
+        primaryMenuItems.forEach((item) => {
+            item.classList.toggle('ibexa-navigation-menu__primary-item--active', item.isSameNode(event.target));
+        });
+        showPrimarySection(targetId);
+
+        if (secondaryMenuNode) {
+            showSecondaryMenu(secondaryMenuNode);
+        }
+    };
+    const onSelectPrimaryMenuDropdown = (event) => {
+        const targetId = event.target.value;
+        const secondaryMenuNode = doc.querySelector(`.ibexa-navigation-menu__secondary[data-id="${targetId}"]`);
+
+        showPrimarySection(targetId);
+
+        if (secondaryMenuNode) {
+            showSecondaryMenu(secondaryMenuNode);
+        }
+    };
+    const onSelectSecondaryMenu = (event) => {
+        const { targetId } = event.currentTarget.dataset;
+
+        navigateTo(targetId);
+    };
+    const bindPrimaryMenuListEvents = () => {
+        const items = doc.querySelectorAll('.ibexa-navigation-menu__primary--list .ibexa-navigation-menu__primary-item');
+
+        items.forEach((item) => item.addEventListener('click', onSelectPrimaryMenuList, false));
+    };
+    const bindPrimaryMenuDropdownEvents = () => {
+        const sourceSelect = doc.querySelector('.ibexa-navigation-menu__primary--dropdown .ibexa-dropdown__source .ibexa-input');
+
+        if (!sourceSelect) {
+            return;
+        }
+
+        sourceSelect.addEventListener('change', onSelectPrimaryMenuDropdown, false);
+    };
+    const bindSecondaryMenuEvents = () => {
+        const items = doc.querySelectorAll('.ibexa-navigation-menu .ibexa-navigation-menu__secondary-item-btn');
+
+        items.forEach((item) => item.addEventListener('click', onSelectSecondaryMenu, false));
+    };
+    const bindScrollContainerEvents = () => {
+        const allSections = [...doc.querySelectorAll('.ibexa-edit-content__secondary-section')];
+        const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
+        let previousFirstVisibleSection = null;
+
+        if (formContainerNode && allSections.length) {
+            formContainerNode.addEventListener('scroll', () => {
+                let firstVisibleSection = currentlyVisibleSections.find((section) => {
+                    const { top, height } = section.getBoundingClientRect();
+
+                    return top + height >= headerContainer.offsetHeight + SECTION_ADJUST_MARGIN_TOP;
+                });
+
+                if (!firstVisibleSection) {
+                    firstVisibleSection = currentlyVisibleSections.at(-1);
+                }
+
+                if (previousFirstVisibleSection === firstVisibleSection) {
+                    return;
+                }
+
+                previousFirstVisibleSection = firstVisibleSection;
+
+                const targetId = firstVisibleSection.dataset.id;
+
+                const secondaryMenuNode = doc.querySelector(
+                    `.ibexa-navigation-menu__secondary--active .ibexa-navigation-menu__secondary-item-btn[data-target-id="${targetId}"]`,
+                );
+
+                setActiveSecondaryMenu(secondaryMenuNode);
+            });
+        }
+    };
+
+    bindPrimaryMenuListEvents();
+    bindPrimaryMenuDropdownEvents();
+    bindSecondaryMenuEvents();
+    bindScrollContainerEvents();
+    fitSecondarySections();
+})(window, window.document);

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
@@ -118,7 +118,7 @@
     };
     const attachScrollContainerEvents = () => {
         const allSections = [...formContainerNode.querySelectorAll('.ibexa-edit-content__secondary-section')];
-        const headerContainer = formContainerNode.querySelector('.ibexa-edit-header__container');
+        const headerContainer = doc.querySelector('.ibexa-edit-header__container');
         let previousFirstVisibleSection = null;
 
         if (formContainerNode && allSections.length) {

--- a/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.sections.navigation.js
@@ -1,5 +1,7 @@
-(function (global, doc) {
-    if (!doc.querySelector('.ibexa-navigation-menu')) {
+(function (global, doc, ibexa) {
+    const navigationMenu = doc.querySelector('.ibexa-navigation-menu');
+
+    if (!navigationMenu) {
         return;
     }
 
@@ -153,4 +155,5 @@
     bindSecondaryMenuEvents();
     bindScrollContainerEvents();
     fitSecondarySections();
-})(window, window.document);
+    ibexa.helpers.tooltips.parse(navigationMenu);
+})(window, window.document, window.ibexa);

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -130,22 +130,6 @@
     const isAutosaveEnabled = () => {
         return ibexa.adminUiConfig.autosave.enabled && form.querySelector('[name="ezplatform_content_forms_content_edit[autosave]"]');
     };
-    const fitSections = () => {
-        const lastSection = doc.querySelector('.ibexa-anchor-navigation-sections .ibexa-anchor-navigation-sections__section:last-child');
-
-        if (lastSection && lastSection.offsetHeight) {
-            const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
-            const contentContainer = contentColumn.querySelector('.ibexa-edit-content__container');
-            const headerContainer = doc.querySelector('.ibexa-edit-header .ibexa-edit-header__container');
-            const heightFromLastSection = contentContainer.offsetHeight - lastSection.offsetTop;
-            const contentColumnBodyHeight = contentColumn.offsetHeight - headerContainer.offsetHeight;
-            const heightDiff = contentColumnBodyHeight - heightFromLastSection;
-
-            if (heightDiff > 0) {
-                contentContainer.style.paddingBottom = `${heightDiff}px`;
-            }
-        }
-    };
 
     if (isAutosaveEnabled()) {
         const AUTOSAVE_SUBMIT_BUTTON_NAME = 'ezplatform_content_forms_content_edit[autosave]';
@@ -231,8 +215,6 @@
         btn.dataset.isFormValid = 0;
         btn.addEventListener('click', clickHandler, false);
     });
-
-    fitSections();
 
     menuButtonsToValidate.forEach((btn) => {
         btn.addEventListener('click', validateHandler, false);

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -8,4 +8,12 @@
             max-width: calculateRem(1600px);
         }
     }
+
+    &__primary-section {
+        display: none;
+
+        &--active {
+            display: block;
+        }
+    }
 }

--- a/src/bundle/Resources/public/scss/_main-container.scss
+++ b/src/bundle/Resources/public/scss/_main-container.scss
@@ -16,8 +16,8 @@
     &--without-anchor-menu-items {
         .ibexa-main-container {
             &__side-column {
-                width: 15%;
-                max-width: calculateRem(200px);
+                min-width: calculateRem(240px);
+                max-width: calculateRem(240px);
             }
 
             &__content-column {

--- a/src/bundle/Resources/public/scss/_main-container.scss
+++ b/src/bundle/Resources/public/scss/_main-container.scss
@@ -30,7 +30,8 @@
         .ibexa-main-container {
             &__side-column {
                 width: 25%;
-                max-width: calculateRem(350px);
+                min-width: calculateRem(300px);
+                max-width: calculateRem(400px);
             }
 
             &__content-column {

--- a/src/bundle/Resources/public/scss/_navigation-menu.scss
+++ b/src/bundle/Resources/public/scss/_navigation-menu.scss
@@ -1,0 +1,96 @@
+.ibexa-navigation-menu {
+    padding: calculateRem(25px);
+    font-size: $ibexa-text-font-size-medium;
+
+    &__primary {
+        height: calculateRem(48px);
+        padding: calculateRem(4px);
+        border-radius: $ibexa-border-radius;
+        background-color: $ibexa-color-light-300;
+        display: flex;
+    }
+
+    &__primary-item {
+        height: calculateRem(40px);
+        padding: calculateRem(10px);
+        border-radius: $ibexa-border-radius;
+        border: 0;
+        flex-basis: 100%;
+        text-align: center;
+
+        &--active {
+            background-color: $ibexa-color-white;
+            font-weight: 600;
+        }
+    }
+
+    &__secondary {
+        margin: calculateRem(24px) 0 0;
+        padding: calculateRem(24px) 0 0;
+        list-style: none;
+        display: none;
+        border-top: calculateRem(1px) solid $ibexa-color-light;
+
+        &--active {
+            display: block;
+        }
+    }
+
+    &__secondary-item-btn {
+        display: inline-flex;
+        width: 100%;
+        padding: calculateRem(11px) calculateRem(15px);
+        border: calculateRem(1px) solid transparent;
+        border-radius: $ibexa-border-radius;
+        text-align: left;
+
+        &::before {
+            content: '';
+            display: block;
+            width: calculateRem(8px);
+            height: calculateRem(8px);
+            margin: calculateRem(8px) calculateRem(16px) 0 0;
+            border-radius: 50%;
+            background-color: $ibexa-color-light;
+        }
+
+        &::after {
+            content: '*';
+            width: calculateRem(16px);
+            display: inline-block;
+            opacity: 0;
+            margin: calculateRem(4px) 0 0 calculateRem(4px);
+            color: $ibexa-color-danger;
+            font-size: $ibexa-text-font-size-small;
+        }
+
+        &:hover {
+            color: $ibexa-color-info;
+            font-weight: 600;
+
+            &:before {
+                background-color: $ibexa-color-info;
+            }
+        }
+
+        &--active {
+            color: $ibexa-color-info;
+            background: $ibexa-color-info-100;
+            font-weight: 600;
+
+            &:before {
+                background-color: $ibexa-color-info;
+            }
+        }
+
+        &--invalid {
+            &:after {
+                opacity: 1;
+            }
+        }
+    }
+
+    &__secondary-item-label {
+        max-width: calc(100% - #{calculateRem(45px)});
+    }
+}

--- a/src/bundle/Resources/public/scss/_navigation-menu.scss
+++ b/src/bundle/Resources/public/scss/_navigation-menu.scss
@@ -17,6 +17,7 @@
         border: 0;
         flex-basis: 100%;
         text-align: center;
+        overflow: hidden;
 
         &--active {
             background-color: $ibexa-color-white;
@@ -92,5 +93,10 @@
 
     &__secondary-item-label {
         max-width: calc(100% - #{calculateRem(45px)});
+    }
+
+    &__item-label {
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 }

--- a/src/bundle/Resources/public/scss/_navigation-menu.scss
+++ b/src/bundle/Resources/public/scss/_navigation-menu.scss
@@ -69,7 +69,7 @@
             color: $ibexa-color-info;
             font-weight: 600;
 
-            &:before {
+            &::before {
                 background-color: $ibexa-color-info;
             }
         }
@@ -79,13 +79,13 @@
             background: $ibexa-color-info-100;
             font-weight: 600;
 
-            &:before {
+            &::before {
                 background-color: $ibexa-color-info;
             }
         }
 
         &--invalid {
-            &:after {
+            &::after {
                 opacity: 1;
             }
         }

--- a/src/bundle/Resources/public/scss/ibexa.scss
+++ b/src/bundle/Resources/public/scss/ibexa.scss
@@ -118,3 +118,4 @@
 @import 'user-group-invitation';
 @import 'user-invitation-modal';
 @import 'default-location';
+@import 'navigation-menu';

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -76,6 +76,16 @@
         <target state="new">Save</target>
         <note>key: content_create__sidebar_right__save_draft</note>
       </trans-unit>
+      <trans-unit id="89b456c2ec176d6a0878d0992424a2a41d89b3ba" resname="content_edit__anchor_menu__content">
+        <source>Content</source>
+        <target state="new">Content</target>
+        <note>key: content_edit__anchor_menu__content</note>
+      </trans-unit>
+      <trans-unit id="84cd0d095ea2a1c6f98c298609a49adca5c3b663" resname="content_edit__anchor_menu__meta">
+        <source>Meta</source>
+        <target state="new">Meta</target>
+        <note>key: content_edit__anchor_menu__meta</note>
+      </trans-unit>
       <trans-unit id="af459eaf05dedc87eb0c462732e59da18bedb340" resname="content_edit__sidebar_right__cancel">
         <source>Delete draft</source>
         <target state="new">Delete draft</target>

--- a/src/bundle/Resources/views/themes/admin/content/components/meta_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/components/meta_fields.html.twig
@@ -1,0 +1,15 @@
+{% extends '@ibexadesign/ui/component/anchor_navigation/primary_section.html.twig' %}
+
+{% set data_id = 'ibexa-edit-content-sections-meta' %}
+
+{% block sections %}
+    {% for identifier in meta_fields %}
+        {% embed '@ibexadesign/ui/component/anchor_navigation/secondary_section.html.twig' with {'form': form, 'identifier': identifier} %}
+            {% set data_id = 'ibexa-edit-content-sections-meta-' ~ identifier %}
+            {% block content %}
+                {% import '@ibexadesign/content/edit_base.html.twig' as edit_base %}
+                {{ edit_base.renderFormField(form.fieldsData[identifier]) }}
+            {% endblock %}
+        {% endembed %}
+    {% endfor %}
+{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -51,6 +51,23 @@
     </div>
 {% endblock %}
 
+{% block anchor_menu %}
+    {% set content_edit_anchor_menu = knp_menu_get('ibexa.admin_ui.menu.content_edit.anchor_menu', [], {
+        'content': content,
+        'content_type': content_type,
+        'location': location,
+        'parent_location': parent_location,
+        'language': language,
+        'grouped_fields': grouped_fields,
+    }) %}
+
+    {% embed '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+        {% block navigation_menu_body %}
+            {{ knp_menu_render(content_edit_anchor_menu, { 'template': '@ibexadesign/ui/menu/anchor_menu.html.twig' }) }}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
 {% block content_sections %}
     {{ ibexa_render_component_group('content-edit-sections', {
         'form': form,

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -51,6 +51,17 @@
     </div>
 {% endblock %}
 
+{% block content_sections %}
+    {{ ibexa_render_component_group('content-edit-sections', {
+        'form': form,
+        'content': content,
+        'content_type': content_type,
+        'location': location,
+        'parent_location': parent_location,
+        'language': language
+    }) }}
+{% endblock %}
+
 {% block form_after %}
     {{ ibexa_render_component_group('content-edit-form-after', {
         'content': content,

--- a/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
@@ -61,21 +61,21 @@
                     data-id="ibexa-edit-content-sections-content-fields"
                 >
                     {% block form_fields %}
-                            <div class="ibexa-anchor-navigation-sections">
-                                {% for key, group in grouped_fields %}
-                                    {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
-                                        anchor_section_key: 'ibexa-edit-content-sections-content-fields-' ~ key|lower,
-                                        parent_self: _self,
-                                    } %}
-                                        {% trans_default_domain 'content_edit' %}
-                                        {% import parent_self as parent_self %}
+                        <div class="ibexa-anchor-navigation-sections">
+                            {% for key, group in grouped_fields %}
+                                {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
+                                    anchor_section_key: 'ibexa-edit-content-sections-content-fields-' ~ key|lower,
+                                    parent_self: _self,
+                                } %}
+                                    {% trans_default_domain 'content_edit' %}
+                                    {% import parent_self as parent_self %}
 
-                                        {% block anchor_section_body %}
-                                            {{ parent_self.renderFieldGroup(group, form) }}
-                                        {% endblock %}
-                                    {% endembed %}
-                                {% endfor %}
-                            </div>
+                                    {% block anchor_section_body %}
+                                        {{ parent_self.renderFieldGroup(group, form) }}
+                                    {% endblock %}
+                                {% endembed %}
+                            {% endfor %}
+                        </div>
                     {% endblock %}
                 </div>
                 {% block content_sections %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
@@ -20,7 +20,20 @@
         }) %}
     {% endif %}
 
-    {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+    {% set content_edit_anchor_menu = knp_menu_get('ibexa.admin_ui.menu.content_edit.anchor_menu', [], {
+        'content': content,
+        'content_type': content_type,
+        'location': location,
+        'parent_location': parent_location,
+        'language': language,
+        'grouped_fields': grouped_fields,
+    }) %}
+
+    {% embed '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+        {% block navigation_menu_body %}
+            {{ knp_menu_render(content_edit_anchor_menu, { 'template': '@ibexadesign/ui/menu/anchor_menu.html.twig' }) }}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}
 
 {% macro renderFormField(formField) -%}
@@ -53,29 +66,31 @@
 
         {% block form %}
             {{ form_start(form, {'attr': {'class': 'ibexa-form-validate ibexa-form'}}) }}
-                {% block form_fields %}
-                    {% if grouped_fields|length > 1 %}
-                        <div class="ibexa-anchor-navigation-sections">
-                            {% for key, group in grouped_fields %}
-                                {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
-                                    anchor_section_key: key,
-                                    parent_self: _self,
-                                } %}
-                                    {% trans_default_domain 'content_edit' %}
-                                    {% import parent_self as parent_self %}
+            <div class="ibexa-edit-content__sections">
+                <div
+                    class="ibexa-edit-content__primary-section ibexa-edit-content__primary-section--active"
+                    data-id="ibexa-edit-content-sections-content-fields"
+                >
+                    {% block form_fields %}
+                            <div class="ibexa-anchor-navigation-sections">
+                                {% for key, group in grouped_fields %}
+                                    {% embed '@ibexadesign/ui/anchor_navigation_section.html.twig' with {
+                                        anchor_section_key: 'ibexa-edit-content-sections-content-fields-' ~ key|lower,
+                                        parent_self: _self,
+                                    } %}
+                                        {% trans_default_domain 'content_edit' %}
+                                        {% import parent_self as parent_self %}
 
-                                    {% block anchor_section_body %}
-                                        {{ parent_self.renderFieldGroup(group, form) }}
-                                    {% endblock %}
-                                {% endembed %}
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        {% for formField in form.fieldsData %}
-                            {{ _self.renderFormField(formField) }}
-                        {%- endfor %}
-                    {% endif %}
-                {% endblock %}
+                                        {% block anchor_section_body %}
+                                            {{ parent_self.renderFieldGroup(group, form) }}
+                                        {% endblock %}
+                                    {% endembed %}
+                                {% endfor %}
+                            </div>
+                    {% endblock %}
+                </div>
+                {% block content_sections %}{% endblock %}
+            </div>
             {{ form_end(form) }}
         {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit_base.html.twig
@@ -20,20 +20,9 @@
         }) %}
     {% endif %}
 
-    {% set content_edit_anchor_menu = knp_menu_get('ibexa.admin_ui.menu.content_edit.anchor_menu', [], {
-        'content': content,
-        'content_type': content_type,
-        'location': location,
-        'parent_location': parent_location,
-        'language': language,
-        'grouped_fields': grouped_fields,
-    }) %}
-
-    {% embed '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
-        {% block navigation_menu_body %}
-            {{ knp_menu_render(content_edit_anchor_menu, { 'template': '@ibexadesign/ui/menu/anchor_menu.html.twig' }) }}
-        {% endblock %}
-    {% endembed %}
+    {% block anchor_menu %}
+        {% include '@ibexadesign/ui/anchor_navigation_menu.html.twig' with anchor_params %}
+    {% endblock %}
 {% endblock %}
 
 {% macro renderFormField(formField) -%}

--- a/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
@@ -23,9 +23,9 @@
                         {% set sanitized_item = item|slug %}
                         <li class="ibexa-anchor-navigation-menu__item">
                             <button
-                                    type="button"
-                                    class="ibexa-anchor-navigation-menu__item-btn {% if loop.first %}ibexa-anchor-navigation-menu__item-btn--active{% endif %}"
-                                    data-anchor-target-section-id="#{{ sanitized_item }}"
+                                type="button"
+                                class="ibexa-anchor-navigation-menu__item-btn {% if loop.first %}ibexa-anchor-navigation-menu__item-btn--active{% endif %}"
+                                data-anchor-target-section-id="#{{ sanitized_item }}"
                             >
                                 <span class="ibexa-anchor-navigation-menu__item-btn-label">{{ item }}</span>
                             </button>

--- a/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_menu.html.twig
@@ -16,22 +16,23 @@
     </div>
 
     <div class="ibexa-anchor-navigation-menu__body">
-        {% if items|default([])|length > 1 %}
-            <ul class="ibexa-anchor-navigation-menu__items">
-                {% for item in items %}
-                    {% set sanitized_item = item|slug %}
-
-                    <li class="ibexa-anchor-navigation-menu__item">
-                        <button
-                            type="button"
-                            class="ibexa-anchor-navigation-menu__item-btn {% if loop.first %}ibexa-anchor-navigation-menu__item-btn--active{% endif %}" 
-                            data-anchor-target-section-id="#{{ sanitized_item }}"
-                        >
-                            <span class="ibexa-anchor-navigation-menu__item-btn-label">{{ item }}</span>
-                        </button>
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
+        {% block navigation_menu_body %}
+            {% if items|default([])|length > 1 %}
+                <ul class="ibexa-anchor-navigation-menu__items">
+                    {% for item in items %}
+                        {% set sanitized_item = item|slug %}
+                        <li class="ibexa-anchor-navigation-menu__item">
+                            <button
+                                    type="button"
+                                    class="ibexa-anchor-navigation-menu__item-btn {% if loop.first %}ibexa-anchor-navigation-menu__item-btn--active{% endif %}"
+                                    data-anchor-target-section-id="#{{ sanitized_item }}"
+                            >
+                                <span class="ibexa-anchor-navigation-menu__item-btn-label">{{ item }}</span>
+                            </button>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endblock %}
     </div>
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/anchor_navigation_section.html.twig
@@ -1,6 +1,6 @@
  <div
-    data-anchor-section-id="#{{ anchor_section_key|slug }}"
-    class="row ibexa-anchor-navigation-sections__section {{ anchor_section_class|default('') }}"
+     data-id="{{ anchor_section_key|slug }}"
+     class="ibexa-edit-content__secondary-section {{ anchor_section_class|default('') }}"
 >
     {% block anchor_section_content %}
         {% block anchor_section_header %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/primary_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/primary_section.html.twig
@@ -1,0 +1,8 @@
+<div
+        class="ibexa-edit-content__primary-section"
+        data-id="{{ data_id }}"
+>
+    <div class="ibexa-anchor-navigation-sections">
+        {% block sections %}{% endblock %}
+    </div>
+</div>

--- a/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/primary_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/primary_section.html.twig
@@ -1,6 +1,6 @@
 <div
-        class="ibexa-edit-content__primary-section"
-        data-id="{{ data_id }}"
+    class="ibexa-edit-content__primary-section"
+    data-id="{{ data_id }}"
 >
     <div class="ibexa-anchor-navigation-sections">
         {% block sections %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/secondary_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/secondary_section.html.twig
@@ -1,6 +1,6 @@
 <div
-        data-id="{{ data_id }}"
-        class="ibexa-edit-content__secondary-section"
+    data-id="{{ data_id }}"
+    class="ibexa-edit-content__secondary-section"
 >
     {% block content %}{% endblock %}
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/secondary_section.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/anchor_navigation/secondary_section.html.twig
@@ -1,0 +1,6 @@
+<div
+        data-id="{{ data_id }}"
+        class="ibexa-edit-content__secondary-section"
+>
+    {% block content %}{% endblock %}
+</div>

--- a/src/bundle/Resources/views/themes/admin/ui/menu/anchor_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/anchor_menu.html.twig
@@ -133,7 +133,9 @@
     {%- set itemTagElement = itemTagElement|default('button') %}
 
     <{{ itemTagElement }}{{ knp_menu.attributes(attributes) }}>
-    {{ block('label') }}
+        <div class="ibexa-navigation-menu__item-label" title="{{ block('label')|raw }}">
+            {{ block('label') }}
+        </div>
     </{{ itemTagElement }}>
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/menu/anchor_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/anchor_menu.html.twig
@@ -1,0 +1,178 @@
+{% extends '@KnpMenu/menu.html.twig' %}
+
+{% block anchor_menu_list %}
+    {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
+        {% import _self as knp_menu %}
+        <{{ tagElement }}{{ knp_menu.attributes(listAttributes) }}>
+        {{ block('anchor_menu_children') }}
+        </{{ tagElement }}>
+    {% endif %}
+{% endblock %}
+
+{% block anchor_menu_children %}
+    {# save current variables #}
+    {% set currentOptions = options %}
+    {% set currentItem = item %}
+    {# update the depth for children #}
+    {% if options.depth is not none %}
+        {% set options = options|merge({'depth': currentOptions.depth - 1}) %}
+    {% endif %}
+    {# update the matchingDepth for children #}
+    {% if options.matchingDepth is not none and options.matchingDepth > 0 %}
+        {% set options = options|merge({'matchingDepth': currentOptions.matchingDepth - 1}) %}
+    {% endif %}
+
+    {{ block(innerChildrenBlock|default('children')) }}
+
+    {# restore current variables #}
+    {% set item = currentItem %}
+    {% set options = currentOptions %}
+{% endblock %}
+
+{% block children_1st_level %}
+    {% for item in currentItem.children %}
+        {%- set itemClass = 'ibexa-navigation-menu__primary-item' %}
+        {%- if loop.first %}
+            {%- set itemClass = itemClass ~ ' ibexa-navigation-menu__primary-item--active' %}
+        {%- endif %}
+        {%- do item.setAttribute('class', (item.getAttribute('class') ~ ' ' ~ itemClass)|trim) -%}
+        {%- do item.setAttribute('type', 'button') -%}
+        {{ block('anchor_menu_item') }}
+    {% endfor %}
+{% endblock %}
+
+{% block children_1st_level_dropdown %}
+    {% for item in currentItem.children %}
+        {%- set itemClass = 'ibexa-navigation-menu__primary-item' %}
+        {%- if loop.first %}
+            {%- set itemClass = itemClass ~ ' ibexa-navigation-menu__primary-item--active' %}
+        {%- endif %}
+        {%- do item.setAttribute('class', (item.getAttribute('class') ~ ' ' ~ itemClass)|trim) -%}
+        {%- do item.setAttribute('type', 'button') -%}
+    {% endfor %}
+
+    {% set value = '' %}
+    {% set choices = [] %}
+    {% for item in currentItem.children %}
+        {% if loop.first %}
+            {% set value = item.getAttribute('data-target-id') %}
+        {% endif %}
+        {% set choices = choices|merge([{
+            value: item.getAttribute('data-target-id'),
+            label: block('label'),
+        }]) %}
+    {% endfor %}
+
+    {% set source %}
+        <select class="form-control ibexa-input">
+            {% for item in currentItem.children %}
+                <option value="{{ item.getAttribute('data-target-id') }}">
+                    {{ block('label') }}
+                </option>
+            {% endfor %}
+        </select>
+    {% endset %}
+
+    {% include '@ibexadesign/ui/component/dropdown/dropdown.html.twig' with {
+        source: source,
+        choices: choices,
+        value: value,
+    } %}
+{% endblock %}
+
+{% block children_2nd_level %}
+    {% for item in currentItem.children %}
+        {%- set itemClass = 'ibexa-navigation-menu__secondary-item-btn' %}
+        {%- if loop.first %}
+            {%- set itemClass = itemClass ~ ' ibexa-navigation-menu__secondary-item-btn--active' %}
+        {%- endif %}
+        {%- do item.setAttribute('class', (item.getAttribute('class') ~ ' ' ~ itemClass)|trim) -%}
+        {%- do item.setAttribute('type', 'button') -%}
+        {%- do item.setLabelAttribute('class', 'ibexa-navigation-menu__secondary-item-btn-label') -%}
+        {{ block('anchor_menu_item') }}
+    {% endfor %}
+{% endblock %}
+
+{% block anchor_menu_item %}
+    {% if item.displayed %}
+        {# building the class of the item #}
+        {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
+        {%- if matcher.isCurrent(item) %}
+            {%- set classes = classes|merge([options.currentClass]) %}
+        {%- elseif matcher.isAncestor(item, options.matchingDepth) %}
+            {%- set classes = classes|merge([options.ancestorClass]) %}
+        {%- endif %}
+        {%- if item.actsLikeFirst %}
+            {%- set classes = classes|merge([options.firstClass]) %}
+        {%- endif %}
+        {%- if item.actsLikeLast %}
+            {%- set classes = classes|merge([options.lastClass]) %}
+        {%- endif %}
+
+        {# Mark item as "leaf" (no children) or as "branch" (has children that are displayed) #}
+        {% if item.hasChildren and options.depth is not same as(0) %}
+            {% if options.branch_class is not empty and item.displayChildren %}
+                {%- set classes = classes|merge([options.branch_class]) %}
+            {% endif %}
+        {% elseif options.leaf_class is not empty %}
+            {%- set classes = classes|merge([options.leaf_class]) %}
+        {%- endif %}
+
+        {%- set attributes = item.attributes %}
+        {%- if classes is not empty %}
+            {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
+        {%- endif %}
+
+        {{ block(innerItemBlock|default('item')) }}
+    {% endif %}
+{% endblock %}
+
+{% block item_1st_level %}
+    {% import _self as knp_menu %}
+
+    {%- set itemTagElement = itemTagElement|default('button') %}
+
+    <{{ itemTagElement }}{{ knp_menu.attributes(attributes) }}>
+    {{ block('label') }}
+    </{{ itemTagElement }}>
+{% endblock %}
+
+{% block item_2nd_level %}
+    {% import _self as knp_menu %}
+
+    {%- set itemTagElement = itemTagElement|default('button') %}
+
+    <li class="ibexa-navigation-menu__secondary-item">
+        <{{ itemTagElement }}{{ knp_menu.attributes(attributes) }}>
+            <span{{ knp_menu.attributes(item.labelAttributes) }}>{{ block('label') }}</span>
+        </{{ itemTagElement }}>
+    </li>
+{% endblock %}
+
+{% block root %}
+    <div class="ibexa-navigation-menu">
+        {% if item.count() < 4 %}
+            {% set listAttributes = item.childrenAttributes|merge({'class': (listAttributes.class|default('') ~ ' ibexa-navigation-menu__primary ibexa-navigation-menu__primary--list')|trim}) %}
+            {% set innerChildrenBlock = 'children_1st_level' %}
+            {% set innerItemBlock = 'item_1st_level' %}
+            {% set tagElement = 'div' %}
+            {% set itemTagElement = 'button' %}
+        {% else %}
+            {% set listAttributes = item.childrenAttributes|merge({'class': (listAttributes.class|default('') ~ ' ibexa-navigation-menu__dropdown-wrapper ibexa-navigation-menu__primary--dropdown')|trim}) %}
+            {% set innerChildrenBlock = 'children_1st_level_dropdown' %}
+            {% set tagElement = 'div' %}
+        {% endif %}
+        {{ block('anchor_menu_list') -}}
+
+        <div class="ibexa-navigation-menu__secondary-wrapper">
+            {% for item in item.children %}
+                {% set listAttributes = {'class': 'ibexa-navigation-menu__secondary' ~ (loop.first ? ' ibexa-navigation-menu__secondary--active' : ''), 'data-id': item.getAttribute('data-target-id')} %}
+                {% set innerChildrenBlock = 'children_2nd_level' %}
+                {% set innerItemBlock = 'item_2nd_level' %}
+                {% set tagElement = 'ul' %}
+                {% set itemTagElement = 'button' %}
+                {{ block('anchor_menu_list') -}}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -47,7 +47,7 @@ class ContentEditMetaFieldsComponent implements Renderable
         $parameters['meta_fields'] = [];
         foreach ($metaFieldTypeIdentifiers as $identifier) {
             $fields = $contentType->getFieldDefinitionsOfType($identifier);
-            $parameters['meta_fields'] += array_column($fields->toArray(), 'identifier');
+            $parameters['meta_fields'] = array_merge($parameters['meta_fields'], array_column($fields->toArray(), 'identifier'));
         }
 
         return $this->twig->render(

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -63,6 +63,11 @@ class ContentEditMetaFieldsComponent implements Renderable
     {
         $fieldTypeConfig = $this->configResolver->getParameter('admin_ui_forms.content_edit.fieldtypes');
 
-        return array_keys(array_filter($fieldTypeConfig, static fn (array $config) => true === $config['meta']));
+        return array_keys(
+            array_filter(
+                $fieldTypeConfig,
+                static fn (array $config): bool => true === $config['meta']
+            )
+        );
     }
 }

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Component\Content;
+
+use Ibexa\Contracts\AdminUi\Component\Renderable;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Twig\Environment;
+
+class ContentEditMetaFieldsComponent implements Renderable
+{
+    private const NO_CONTENT = '';
+
+    private Environment $twig;
+
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(
+        Environment $twig,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->twig = $twig;
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @return string
+     */
+    public function render(array $parameters = []): string
+    {
+        /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType */
+        $contentType = $parameters['content_type'];
+
+        $metaFieldTypeIdentifiers = $this->getMetaFieldTypeIdentifiers();
+
+        if (empty($metaFieldTypeIdentifiers)) {
+            return self::NO_CONTENT;
+        }
+
+        $parameters['meta_fields'] = [];
+        foreach ($metaFieldTypeIdentifiers as $identifier) {
+            $fields = $contentType->getFieldDefinitionsOfType($identifier);
+            $parameters['meta_fields'] = $parameters['meta_fields'] + array_column($fields->toArray(), 'identifier');
+        }
+
+        return $this->twig->render(
+            '@ibexadesign/content/components/meta_fields.html.twig',
+            $parameters
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMetaFieldTypeIdentifiers(): array
+    {
+        $fieldTypeConfig = $this->configResolver->getParameter('admin_ui_forms.content_edit.fieldtypes');
+
+        return array_keys(array_filter($fieldTypeConfig, static fn (array $config) => true === $config['meta']));
+    }
+}

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -47,7 +47,7 @@ class ContentEditMetaFieldsComponent implements Renderable
         $parameters['meta_fields'] = [];
         foreach ($metaFieldTypeIdentifiers as $identifier) {
             $fields = $contentType->getFieldDefinitionsOfType($identifier);
-            $parameters['meta_fields'] = $parameters['meta_fields'] + array_column($fields->toArray(), 'identifier');
+            $parameters['meta_fields'] += array_column($fields->toArray(), 'identifier');
         }
 
         return $this->twig->render(

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -52,6 +52,11 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
     {
         $fieldTypesConfig = $this->configResolver->getParameter('admin_ui_forms.content_edit.fieldtypes');
 
-        return array_keys(array_filter($fieldTypesConfig, static fn (array $config) => true === $config['meta']));
+        return array_keys(
+            array_filter(
+                $fieldTypesConfig,
+                static fn (array $config): bool => true === $config['meta']
+            )
+        );
     }
 }

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Form\Provider;
+
+use Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
+final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFieldsProviderInterface
+{
+    private GroupedContentFormFieldsProviderInterface $innerGroupedContentFormFieldsProvider;
+
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(
+        GroupedContentFormFieldsProviderInterface $innerGroupedContentFormFieldsProvider,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->innerGroupedContentFormFieldsProvider = $innerGroupedContentFormFieldsProvider;
+        $this->configResolver = $configResolver;
+    }
+
+    public function getGroupedFields(array $fieldsDataForm): array
+    {
+        $identifiers = $this->getMetaFields();
+
+        $groupedFields = $this->innerGroupedContentFormFieldsProvider->getGroupedFields($fieldsDataForm);
+        foreach ($groupedFields as $group => $fields) {
+            $groupedFields[$group] = array_filter(
+                $fields,
+                static function (string $fieldIdentifier) use ($fieldsDataForm, $identifiers): bool {
+                    $fieldData = $fieldsDataForm[$fieldIdentifier]->getNormData();
+                    $fieldTypeIdentifier = $fieldData->fieldDefinition->fieldTypeIdentifier;
+
+                    return !in_array($fieldTypeIdentifier, $identifiers, true);
+                }
+            );
+        }
+
+        return array_filter($groupedFields);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMetaFields(): array
+    {
+        $fieldTypesConfig = $this->configResolver->getParameter('admin_ui_forms.content_edit.fieldtypes');
+
+        return array_keys(array_filter($fieldTypesConfig, static fn (array $config) => true === $config['meta']));
+    }
+}

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -128,6 +128,7 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
             static fn (array $config) => true === $config['meta']
         ));
 
+        $items = [];
         $order = 0;
         foreach ($metaFieldTypeIdentifiers as $metaFieldTypeIdentifier) {
             if (false === $contentType->hasFieldDefinitionOfType($metaFieldTypeIdentifier)) {

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\AdminUi\Menu;
+
+use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
+use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\Repository\Values\ContentType\ContentType;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ContentEditAnchorMenuBuilder extends AbstractBuilder implements TranslationContainerInterface
+{
+    public const ITEM__CONTENT = 'content_edit__anchor_menu__content';
+    public const ITEM__META = 'content_edit__anchor_menu__meta';
+
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(
+        MenuItemFactory $factory,
+        EventDispatcherInterface $eventDispatcher,
+        ConfigResolverInterface $configResolver
+    ) {
+        parent::__construct($factory, $eventDispatcher);
+
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getConfigureEventName(): string
+    {
+        return ConfigureMenuEvent::CONTENT_EDIT_ANCHOR_MENU;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function createStructure(array $options): ItemInterface
+    {
+        /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */
+        $menu = $this->factory->createItem('root');
+
+        /** @var \Ibexa\Core\Repository\Values\ContentType\ContentType $contentType */
+        $contentType = $options['content_type'];
+
+        /** @var array<string, array<string>> $groupedFields */
+        $groupedFields = $options['grouped_fields'];
+
+        $items = [
+            self::ITEM__CONTENT => $this->createMenuItem(
+                self::ITEM__CONTENT,
+                [
+                    'attributes' => ['data-target-id' => 'ibexa-edit-content-sections-content-fields'],
+                    'extras' => [
+                        'orderNumber' => 10,
+                    ],
+                ]
+            ),
+        ];
+
+        $items[self::ITEM__CONTENT]->setChildren(
+            $this->getContentFieldGroupItems($groupedFields)
+        );
+
+        $metaFields = $this->getMetaFieldItems($contentType);
+
+        if (!empty($metaFields)) {
+            $items[self::ITEM__META] = $this->createMenuItem(
+                self::ITEM__META,
+                [
+                    'attributes' => ['data-target-id' => 'ibexa-edit-content-sections-meta'],
+                    'extras' => [
+                        'orderNumber' => 50,
+                    ],
+                ]
+            );
+
+            $items[self::ITEM__META]->setChildren($metaFields);
+        }
+
+        $menu->setChildren($items);
+
+        return $menu;
+    }
+
+    /**
+     * @param array<string, array<string>> $groupedFields
+     *
+     * @return array<\Knp\Menu\ItemInterface>
+     */
+    private function getContentFieldGroupItems(array $groupedFields): array
+    {
+        $items = [];
+        $order = 0;
+        foreach ($groupedFields as $group => $fields) {
+            $order = $order + 10;
+            $items[$group] = $this->createMenuItem($group, [
+                'attributes' => [
+                    'data-target-id' => sprintf('ibexa-edit-content-sections-content-fields-%s', mb_strtolower($group)),
+                ],
+                'extras' => [
+                    'orderNumber' => $order,
+                ],
+            ]);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, array<string>> $groupedFields
+     *
+     * @return array<\Knp\Menu\ItemInterface>
+     */
+    private function getMetaFieldItems(ContentType $contentType): array
+    {
+        $fieldTypeSettings = $this->configResolver->getParameter('admin_ui_forms.content_edit.fieldtypes');
+        $metaFieldTypeIdentifiers = array_keys(array_filter(
+            $fieldTypeSettings,
+            static fn (array $config) => true === $config['meta']
+        ));
+
+        $order = 0;
+        foreach ($metaFieldTypeIdentifiers as $metaFieldTypeIdentifier) {
+            if (false === $contentType->hasFieldDefinitionOfType($metaFieldTypeIdentifier)) {
+                continue;
+            }
+
+            $fieldDefinitions = $contentType->getFieldDefinitionsOfType($metaFieldTypeIdentifier);
+            foreach ($fieldDefinitions as $fieldDefinition) {
+                $fieldDefIdentifier = $fieldDefinition->identifier;
+                $order = $order + 10;
+                $items[$fieldDefIdentifier] = $this->createMenuItem(
+                    $fieldDefIdentifier,
+                    [
+                        'label' => $fieldDefinition->getName(),
+                        'attributes' => [
+                            'data-target-id' => sprintf('ibexa-edit-content-sections-meta-%s', $fieldDefIdentifier),
+                        ],
+                        'extras' => [
+                            'orderNumber' => $order,
+                        ],
+                    ]
+                );
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<\JMS\TranslationBundle\Model\Message>
+     */
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message(self::ITEM__CONTENT, 'menu'))->setDesc('Content'),
+            (new Message(self::ITEM__META, 'menu'))->setDesc('Meta'),
+        ];
+    }
+}

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -32,9 +32,6 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
         $this->configResolver = $configResolver;
     }
 
-    /**
-     * @return string
-     */
     protected function getConfigureEventName(): string
     {
         return ConfigureMenuEvent::CONTENT_EDIT_ANCHOR_MENU;
@@ -116,8 +113,6 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
     }
 
     /**
-     * @param array<string, array<string>> $groupedFields
-     *
      * @return array<\Knp\Menu\ItemInterface>
      */
     private function getMetaFieldItems(ContentType $contentType): array

--- a/src/lib/Menu/Event/ConfigureMenuEvent.php
+++ b/src/lib/Menu/Event/ConfigureMenuEvent.php
@@ -21,6 +21,7 @@ class ConfigureMenuEvent extends Event
     public const USER_MENU = 'ezplatform_admin_ui.menu_configure.user_menu';
     public const CONTENT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.content_sidebar_right';
     public const CONTENT_EDIT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.content_edit_sidebar_right';
+    public const CONTENT_EDIT_ANCHOR_MENU = 'ibexa.admin_ui.menu_configure.content_edit_anchor_menu';
     public const CONTENT_CREATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.content_create_sidebar_right';
     public const CONTENT_SIDEBAR_LEFT = 'ezplatform_admin_ui.menu_configure.content_sidebar_left';
     public const TRASH_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.trash_sidebar_right';

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -79,7 +79,7 @@ class AdminUiFormsTest extends TestCase
     /**
      * Test given fieldtype settings are mapped.
      */
-    public function testContentEditFieldTypesAreMapped()
+    public function testContentEditFieldTypesAreMapped(): void
     {
         $scopeSettings = [
             'admin_ui_forms' => [

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -40,10 +40,12 @@ class AdminUiFormsTest extends TestCase
     {
         $scopeSettings = [
             'admin_ui_forms' => [
-                'content_edit_form_templates' => [
-                    ['template' => 'my_template-01.html.twig', 'priority' => 1],
-                    ['template' => 'my_template-02.html.twig', 'priority' => 0],
-                    ['template' => 'my_template-03.html.twig', 'priority' => 2],
+                'content_edit' => [
+                    'form_templates' => [
+                        ['template' => 'my_template-01.html.twig', 'priority' => 1],
+                        ['template' => 'my_template-02.html.twig', 'priority' => 0],
+                        ['template' => 'my_template-03.html.twig', 'priority' => 2],
+                    ],
                 ],
             ],
         ];
@@ -56,12 +58,60 @@ class AdminUiFormsTest extends TestCase
         ];
 
         $this->contextualizer
-            ->expects($this->once())
+            ->expects($this->atLeast(2))
             ->method('setContextualParameter')
-            ->with(
-                AdminUiForms::FORM_TEMPLATES_PARAM,
-                $currentScope,
-                $expectedTemplatesList
+            ->withConsecutive(
+                [
+                    AdminUiForms::FORM_TEMPLATES_PARAM,
+                    $currentScope,
+                    $expectedTemplatesList,
+                ],
+                [
+                    AdminUiForms::FIELDTYPES_PARAM,
+                    $currentScope,
+                    [],
+                ],
+            );
+
+        $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
+    }
+
+    /**
+     * Test given fieldtype settings are mapped.
+     */
+    public function testContentEditFieldTypesAreMapped()
+    {
+        $scopeSettings = [
+            'admin_ui_forms' => [
+                'content_edit' => [
+                    'fieldtypes' => [
+                        'my_fieldtype' => ['meta' => true],
+                        'my_fieldtype_2' => ['meta' => false],
+                    ],
+                ],
+            ],
+        ];
+        $currentScope = 'admin_group';
+
+        $expectedFieldTypeSettings = [
+            'my_fieldtype' => ['meta' => true],
+            'my_fieldtype_2' => ['meta' => false],
+        ];
+
+        $this->contextualizer
+            ->expects($this->atLeast(2))
+            ->method('setContextualParameter')
+            ->withConsecutive(
+                [
+                    AdminUiForms::FORM_TEMPLATES_PARAM,
+                    $currentScope,
+                    [],
+                ],
+                [
+                    AdminUiForms::FIELDTYPES_PARAM,
+                    $currentScope,
+                    $expectedFieldTypeSettings,
+                ],
             );
 
         $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -67,7 +67,7 @@ class AdminUiFormsTest extends TestCase
                     $expectedTemplatesList,
                 ],
                 [
-                    AdminUiForms::FIELDTYPES_PARAM,
+                    AdminUiForms::FIELD_TYPES_PARAM,
                     $currentScope,
                     [],
                 ],
@@ -108,7 +108,7 @@ class AdminUiFormsTest extends TestCase
                     [],
                 ],
                 [
-                    AdminUiForms::FIELDTYPES_PARAM,
+                    AdminUiForms::FIELD_TYPES_PARAM,
                     $currentScope,
                     $expectedFieldTypeSettings,
                 ],

--- a/tests/lib/EventListener/SetViewParametersListenerTest.php
+++ b/tests/lib/EventListener/SetViewParametersListenerTest.php
@@ -73,7 +73,7 @@ final class SetViewParametersListenerTest extends TestCase
         );
     }
 
-    public function testSetViewTemplateParameters()
+    public function testSetViewTemplateParameters(): void
     {
         $locationA = new Core\Location(['id' => self::EXAMPLE_LOCATION_A_ID]);
         $locationB = new Core\Location(['id' => self::EXAMPLE_LOCATION_B_ID]);
@@ -115,7 +115,7 @@ final class SetViewParametersListenerTest extends TestCase
         return new Core\Location(['id' => 3, 'parentLocationId' => $parentLocationId]);
     }
 
-    public function testSetViewTemplateParametersWithMainLocationId()
+    public function testSetViewTemplateParametersWithMainLocationId(): void
     {
         $mainLocationId = 123;
         $parentLocationId = 456;
@@ -153,7 +153,7 @@ final class SetViewParametersListenerTest extends TestCase
         $this->assertSame(reset($parentLocations), $contentView->getParameter('parent_location'));
     }
 
-    public function testSetViewTemplateParametersWithoutContentEditViewInstance()
+    public function testSetViewTemplateParametersWithoutContentEditViewInstance(): void
     {
         $contentView = $this->createMock(View::class);
 
@@ -167,7 +167,7 @@ final class SetViewParametersListenerTest extends TestCase
         );
     }
 
-    public function testSetUserUpdateViewTemplateParametersWithoutUserUpdateViewInstance()
+    public function testSetUserUpdateViewTemplateParametersWithoutUserUpdateViewInstance(): void
     {
         $view = $this->createMock(View::class);
 
@@ -181,7 +181,7 @@ final class SetViewParametersListenerTest extends TestCase
         );
     }
 
-    public function testSetUserUpdateViewTemplateParameters()
+    public function testSetUserUpdateViewTemplateParameters(): void
     {
         $ownerId = 42;
 
@@ -202,7 +202,7 @@ final class SetViewParametersListenerTest extends TestCase
         $this->assertSame($user, $userUpdateView->getParameter('creator'));
     }
 
-    public function testSetGroupedFieldsParameter()
+    public function testSetGroupedFieldsParameter(): void
     {
         $fieldsDataChildren = [
             'name' => $this->createMock(FormInterface::class),
@@ -237,7 +237,7 @@ final class SetViewParametersListenerTest extends TestCase
         $this->assertSame($groupedFields, $contentEditView->getParameter('grouped_fields'));
     }
 
-    public function testSubscribedEvents()
+    public function testSubscribedEvents(): void
     {
         $this->locationService
             ->expects(self::never())


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3523
| Complementary PR | https://github.com/ibexa/taxonomy/pull/142
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![image](https://user-images.githubusercontent.com/10212760/182614539-4010175f-4b54-4f02-923d-d8dedb4a1506.png)

This PR changes sidebar menu in content editing interface to use tabs. Idea behind this is to separate typical fieldtypes from fieldtypes enriching content with new functionality. Good example is SEO - it isn't a field per se but rather a fieldtype handling functionality for the whole Content object. Taxonomy is another good example. Items assigned to Meta tabs are configured using semantic configuration:

```yaml
ibexa:
    system:
        admin_group:
            admin_ui_forms:
                content_edit:
                    fieldtypes:
                        ibexa_taxonomy_entry_assignment: 	# fieldtype identifier
                            meta: true 						# put this fieldtype under Meta tab
```

## Extending the menu

```php
<?php

use Ibexa\AdminUi\Menu\ContentEditAnchorMenuBuilder;
use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class MyMenuListener implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [ConfigureMenuEvent::CONTENT_EDIT_ANCHOR_MENU => 'onAnchorMenuConfigure'];
    }

    public function onAnchorMenuConfigure(ConfigureMenuEvent $event): void
    {
        $menu = $event->getMenu(); // root
        
        $menu[ContentEditAnchorMenuBuilder::ITEM__CONTENT]; // Content tab
        
        $menu[ContentEditAnchorMenuBuilder::ITEM__META]; // Meta tab
        
        // add new tab
        $menu->addChild('item', ['attributes' => ['data-target-id' => 'ibexa-edit-content-sections-item']]); // data-target-id has to match with component
        
        // add 2nd level menu
        $menu['item']->addChild('item_2', ['attributes' => ['data-target-id' => 'ibexa-edit-content-sections-item-item_2']]); // data-target-id has to match with secondary section id's
    }
}
```

For new tabs it's also required to render its section in content editing form. This is done with UI Component:
```yaml
    app.my_component:
        parent: Ibexa\AdminUi\Component\TwigComponent
        arguments:
            $template: 'my_component.html.twig'
        tags:
            - { name: ibexa.admin_ui.component, group: 'content-edit-sections' } # note the group name
```
```twig
# my_component.html.twig

{% extends '@ibexadesign/ui/component/anchor_navigation/primary_section.html.twig' %}

{% set data_id = 'ibexa-edit-content-sections-item' %}

{% block sections %}
    {% embed '@ibexadesign/ui/component/anchor_navigation/secondary_section.html.twig' %}
        {% set data_id = 'ibexa-edit-content-sections-item-item_2' %}
        {% block content %}
			Contents of 'item_2' secondary section
        {% endblock %}
    {% endembed %}
{% endblock %}

```

## Deprecations
I've deprecated `admin_ui_forms.content_edit_form_templates` config setting in favor of making `content_edit` an array where we can add more settings related to content editing form (i.e. `content_edit.fieldtypes` as in this PR) 
```yaml
system:
    admin_group:
        admin_ui_forms:

            # deprecated setting:
            content_edit_form_templates: 
                    - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }
            
            # use config below instead:
            content_edit:
                form_templates:
                    - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }
```

Both notations will work until deprecation is removed in 5.0. Matching siteaccess aware parameters have not been renamed as it's more difficult to provide backwards compatibility on those.



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
