### PR TITLE
IBX-3264: Used service name based on interface instead of implementation

### DIFF
--- a/src/bundle/Resources/config/services/form_processors.yaml
+++ b/src/bundle/Resources/config/services/form_processors.yaml
@@ -41,7 +41,7 @@ services:
             - "@router"
             - '%ibexa.content_forms.form_processor.content_type.options%'
         calls:
-            - [ setGroupsList, [ '@Ibexa\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList' ] ]
+            - [ setGroupsList, [ '@Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList' ] ]
 
     Ibexa\AdminUi\Form\Processor\PreviewFormProcessor: ~
 

--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -172,7 +172,7 @@ services:
             $fieldTypeService: '@ibexa.api.service.field_type'
             $thumbnailStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy'
         calls:
-            - [setGroupsList, ['@Ibexa\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList']]
+            - [setGroupsList, ['@Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList']]
         tags:
             - { name: form.type, alias: ezplatform_content_forms_fielddefinition_update }
 

--- a/src/bundle/Resources/config/services/twig.yaml
+++ b/src/bundle/Resources/config/services/twig.yaml
@@ -12,7 +12,7 @@ services:
 
     Ibexa\Bundle\AdminUi\Templating\Twig\FieldGroupRenderingExtension:
         arguments:
-            - '@Ibexa\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList'
+            - '@Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList'
         tags:
             - { name: twig.extension }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3264
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


As we use that autowiring configuration here:
https://github.com/ibexa/core/blob/main/src/lib/Resources/settings/repository/autowire.yml#L29

https://github.com/ibexa/admin-ui/pull/549
https://github.com/ibexa/content-forms/pull/37
https://github.com/ibexa/permissions/pull/11
https://github.com/ibexa/corporate-account/pull/83
https://github.com/ibexa/compatibility-layer/pull/49

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
