### PR TITLE
Fixed microcopy notice for Content Type Group and Groups

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -322,8 +322,8 @@
         <note>key: content_type.view.edit.notranslatable_fields_disabled</note>
       </trans-unit>
       <trans-unit id="da5f710198c48c803b3d0e2272e488903f92e569" resname="content_type.view.list.cannot_delete_notice">
-        <source>You cannot delete disabled Content Types, it is used in other places.</source>
-        <target state="new">You cannot delete disabled Content Types, it is used in other places.</target>
+        <source>You cannot delete the disabled Content Types, because Content items of those types exist.</source>
+        <target state="new">You cannot delete the disabled Content Types, because Content items of those types exist.</target>
         <note>key: content_type.view.list.cannot_delete_notice</note>
       </trans-unit>
       <trans-unit id="bef02fc3d41e74bf002af93b413a2a203a04db1a" resname="content_type.view.list.column.id">
@@ -427,8 +427,8 @@
         <note>key: content_type_group.view.list.action.edit</note>
       </trans-unit>
       <trans-unit id="5aa9caad73d044de86886dd25688b5d1267c1f6b" resname="content_type_group.view.list.cannot_delete_notice">
-        <source>You cannot delete disable content groups, it contains a Content Type.</source>
-        <target state="new">You cannot delete disable content groups, it contains a Content Type.</target>
+        <source>You cannot delete the disabled Content Type groups, because they contain Content Types.</source>
+        <target state="new">You cannot delete the disabled Content Type groups, because they contain Content Types.</target>
         <note>key: content_type_group.view.list.cannot_delete_notice</note>
       </trans-unit>
       <trans-unit id="125bee275441fe2bd28cb9388b790c634d8ae3c6" resname="content_type_group.view.list.column.content_types_count">

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
@@ -123,7 +123,7 @@
             ],
             body_rows,
             show_notice: show_table_notice,
-            notice_message: 'content_type_group.view.list.cannot_delete_notice'|trans|desc('You cannot delete disable content groups, it contains a Content Type.'),
+            notice_message: 'content_type_group.view.list.cannot_delete_notice'|trans|desc('You cannot delete the disabled Content Type groups, because they contain Content Types.'),
         } %}
             {% block header %}
                 {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}

--- a/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
@@ -88,7 +88,7 @@
         ],
         body_rows,
         show_notice: show_table_notice,
-        notice_message: 'content_type.view.list.cannot_delete_notice'|trans|desc('You cannot delete disabled Content Types, it is used in other places.'),
+        notice_message: 'content_type.view.list.cannot_delete_notice'|trans|desc('You cannot delete the disabled Content Types, because Content items of those types exist.'),
     } %}
         {% block header %}
             {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}


### PR DESCRIPTION
Follow up for https://github.com/ibexa/admin-ui/pull/556

Current status:
![obraz](https://user-images.githubusercontent.com/10993858/189617675-b0b43dbb-9ae4-4b77-a2c2-a66395fcbc3b.png)
![obraz](https://user-images.githubusercontent.com/10993858/189617719-1df1295a-c001-45df-8e89-810bab3af383.png)

I've asked @DominikaK about them and we agreed that these notices can be improved - these new suggestions come from Dominika.
