### PR TITLE
IBX-3799: Change default value for headline_title in table

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/component/table/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/table/table.html.twig
@@ -7,7 +7,7 @@
         {% include '@ibexadesign/ui/component/table/table_header.html.twig' with {
             headline,
             actions: actions|default(null),
-            headline_title: headline_title|default(headline|default('')),
+            headline_title: headline_title|default(''),
             notice_class: notice_class|default(''),
             notice_message: notice_message|default(''),
             notice_icon: notice_icon|default('about-info'),

--- a/src/bundle/Resources/views/themes/admin/ui/component/table/table_header.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/table/table_header.html.twig
@@ -1,7 +1,7 @@
 <div class="ibexa-table-header {{ class|default('') -}}">
     <div
         class="ibexa-table-header__headline"
-        title="{{ headline_title|default(headline|default('')) }}"
+        title="{{ headline_title|default('') }}"
     >
         {% block headline %}
             {{ headline|default('') }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3799
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

I changed the default value for the variable headline_title in the table component and the headline table. Previously, the default value was set as headline and if there is no headline, it was set to an empty string.
Currently default is always an empty string and the user must set the headline_title variable to have a tooltip because according to our design system, if we have a label somewhere, we should not have a tooltip

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
