### PR TITLE
EZP-32442: Remove setting alternativeText in multi.file.upload.service

### DIFF
--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -147,10 +147,6 @@ const prepareStruct = ({ parentInfo, config, languageCode }, data) => {
                 data: data.fileReader.result.replace(/^.*;base64,/, ''),
             };
 
-            if (data.file.type.startsWith('image/')) {
-                fileValue.alternativeText = data.file.name;
-            }
-
             const fields = [
                 { fieldDefinitionIdentifier: mapping.nameFieldIdentifier, fieldValue: data.file.name },
                 { fieldDefinitionIdentifier: mapping.contentFieldIdentifier, fieldValue: fileValue },


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32442
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Alternative text should not be set to file name
