### PR TITLE
[Behat] Scrolled to the bottom to avoid "Go to the top" button

### DIFF
--- a/src/lib/Behat/Page/ContentTypeGroupPage.php
+++ b/src/lib/Behat/Page/ContentTypeGroupPage.php
@@ -52,6 +52,7 @@ class ContentTypeGroupPage extends Page
 
     public function edit(string $contentTypeName): void
     {
+        $this->getHTMLPage()->find($this->getLocator('scrollableContainer'))->scrollToBottom($this->getSession());
         $this->table->getTableRow(['Name' => $contentTypeName])->edit();
     }
 
@@ -133,6 +134,7 @@ class ContentTypeGroupPage extends Page
             new VisibleCSSLocator('deleteButton', '.ibexa-icon--trash,button[data-original-title^="Delete"]'),
             new VisibleCSSLocator('tableItem', '.ibexa-main-container tbody tr'),
             new VisibleCSSLocator('contentTypeLabel', '.ibexa-table__cell > a'),
+            new VisibleCSSLocator('scrollableContainer', '.ibexa-back-to-top-scroll-container'),
         ];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Example error:
https://github.com/ibexa/commerce/actions/runs/3215686319/jobs/5257026001

```
     And I start editing Content Type "CustomLaunchModeLandingPage"                                                             # Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext::iStartEditingItem()
      WebDriver\Exception\ElementClickIntercepted: element click intercepted: Element <a href="/admin/contenttypegroup/1/contenttype/92/edit" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text" data-original-title="Edit" aria-label="Edit" data-bs-original-title="Edit">...</a> is not clickable at point (1339, 930). Other element would receive the click: <div class="ibexa-back-to-top">...</div>
        (Session info: chrome=94.0.4606.61)
        (Driver info: chromedriver=94.0.4606.61 (418b78f5838ed0b1c69bb4e51ea0252171854915-refs/branch-heads/4606@{#1204}),platform=Linux 5.15.0-1020-azure x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:198
```

![obraz](https://user-images.githubusercontent.com/10993858/194807086-8d18c4bc-39f7-4f88-9fe5-f28f4d11da97.png)

Scrolling to the bottom allows us to avoid clicking on the go to the top button

Tested in https://github.com/ibexa/experience/pull/92

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
