### PR TITLE
IBX-4028: Set default background of ibexa-card to transparent

### DIFF
--- a/src/bundle/Resources/public/scss/_card.scss
+++ b/src/bundle/Resources/public/scss/_card.scss
@@ -1,6 +1,6 @@
 .ibexa-card {
     border: none;
-    background-color: $ibexa-color-white;
+    background-color: transparent;
 
     .form-group {
         width: 70%;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4028
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
