### PR TITLE
IBX-2817: Input timeout string casted to float for ibexa:encore:compile command

### DIFF
--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -57,7 +57,7 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $timeout = $input->getOption('timeout');
+        $timeout = (float)$input->getOption('timeout');
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2817
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)


Propagation of the change from this PR: https://github.com/ezsystems/ezplatform-core/pull/55 because the command has been moved to admin-ui


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
