### PR TITLE
IBX-4044: Option to use HTML in tooltips

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -112,6 +112,7 @@
                 const extraClass = tooltipNode.dataset.tooltipExtraClass ?? '';
                 const placement = tooltipNode.dataset.tooltipPlacement ?? 'bottom';
                 const trigger = tooltipNode.dataset.tooltipTrigger ?? 'hover focus';
+                const useHtml = tooltipNode.dataset.tooltipUseHtml !== undefined;
                 const container = tooltipNode.dataset.tooltipContainerSelector
                     ? tooltipNode.closest(tooltipNode.dataset.tooltipContainerSelector)
                     : 'body';
@@ -132,7 +133,7 @@
                     trigger,
                     container,
                     popperConfig: modifyPopperConfig.bind(null, iframe),
-                    html: true,
+                    html: useHtml,
                     template: `<div class="tooltip ibexa-tooltip ${extraClass}">
                                     <div class="tooltip-arrow ibexa-tooltip__arrow"></div>
                                     <div class="tooltip-inner ibexa-tooltip__inner"></div>

--- a/src/bundle/Resources/views/themes/admin/content/edit/content_header.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/content_header.html.twig
@@ -10,7 +10,11 @@
 			<div class="col-6 offset-6 ibexa-content-edit-header__column ibexa-context-menu-wrapper">
 				<div class="ibexa-content-edit-header__context-actions">
 					{% if (description is defined and description|length) or content is defined %}
-						<div class="ibexa-content-edit-header__tooltip" title="{% include '@ibexadesign/content/edit/content_header_tooltip.html.twig' %}">
+						<div
+							class="ibexa-content-edit-header__tooltip"
+							title="{% include '@ibexadesign/content/edit/content_header_tooltip.html.twig' %}"
+							data-tooltip-use-html
+						>
 							<svg class="ibexa-icon ibexa-icon--small">
 								<use xlink:href="{{ ibexa_icon_path('about') }}"></use>
 							</svg>

--- a/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
@@ -34,7 +34,11 @@
                 <h1 class="ibexa-edit-header__title">
                     {{ title }}
                     {% if (description is defined and description|length) or content is defined and content is not null %}
-                        <div class="ibexa-edit-header__tooltip" title="{% include '@ibexadesign/ui/edit_header_tooltip.html.twig' %}">
+                        <div
+                            class="ibexa-edit-header__tooltip"
+                            title="{% include '@ibexadesign/ui/edit_header_tooltip.html.twig' %}"
+							data-tooltip-use-html
+                        >
                             <svg class="ibexa-icon ibexa-icon--small">
                                 <use xlink:href="{{ ibexa_icon_path('about') }}"></use>
                             </svg>

--- a/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_header.html.twig
@@ -37,7 +37,7 @@
                         <div
                             class="ibexa-edit-header__tooltip"
                             title="{% include '@ibexadesign/ui/edit_header_tooltip.html.twig' %}"
-							data-tooltip-use-html
+                            data-tooltip-use-html
                         >
                             <svg class="ibexa-icon ibexa-icon--small">
                                 <use xlink:href="{{ ibexa_icon_path('about') }}"></use>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4044
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | maybe?
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
If he have documented using tooltips anywhere, it's probably worth adding that HTML is now switched of by default and to use HTML in tooltips `data-tooltip-use-html` parameter has to be added on node with title.

Also for QA - as default using HTML was switched off in whole system, there can be missed places where it should be switched on and I missed them, so probably that's thing worth checking as well. Sorry! 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
