### PR TITLE
IBX-4032: Added limitation to prevent changing content ownership

### DIFF
--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -212,7 +212,6 @@ services:
     Ibexa\AdminUi\Limitation\Mapper\ChangeOwnerLimitationMapper:
         arguments:
             $translator: '@translator'
-            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
         calls:
             - [setFormTemplate, ['%ibexa.content_forms.limitation.multiple_selection.template%']]
         tags:

--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -209,6 +209,16 @@ services:
             - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: Subtree }
             - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: Subtree }
 
+    Ibexa\AdminUi\Limitation\Mapper\ChangeOwnerLimitationMapper:
+        arguments:
+            $translator: '@translator'
+            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+        calls:
+            - [setFormTemplate, ['%ibexa.content_forms.limitation.multiple_selection.template%']]
+        tags:
+            - { name: ibexa.admin_ui.limitation.mapper.form, limitationType: ChangeOwner }
+            - { name: ibexa.admin_ui.limitation.mapper.value, limitationType: ChangeOwner }
+
     Ibexa\AdminUi\Limitation\Mapper\UserPermissionsLimitationMapper:
         autowire: true
         autoconfigure: false

--- a/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
@@ -6,14 +6,19 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="0ba4dd0a3e03edbb23ad81c27bb921449e811cdc" resname="policy.limitation.identifier.changeowner">
+        <source>Change Owner</source>
+        <target>Change Owner</target>
+        <note>key: policy.limitation.identifier.changeowner</note>
+      </trans-unit>
       <trans-unit id="3742f2cc514848bd4a5eb03430e412d44f5d9ec2" resname="policy.limitation.identifier.class">
         <source>Content Type</source>
         <target>Content Type</target>
         <note>key: policy.limitation.identifier.class</note>
       </trans-unit>
       <trans-unit id="57f04cb9d7b09f4314ca3855ee020325d3195ab3" resname="policy.limitation.identifier.fieldgroup">
-        <source>FieldGroup</source>
-        <target>FieldGroup</target>
+        <source>Field Group</source>
+        <target>Field Group</target>
         <note>key: policy.limitation.identifier.fieldgroup</note>
       </trans-unit>
       <trans-unit id="76adf2a27f1ae0ab14b623729cd3f281a6e2c285" resname="policy.limitation.identifier.group">
@@ -67,13 +72,13 @@
         <note>key: policy.limitation.identifier.parentowner</note>
       </trans-unit>
       <trans-unit id="1b6a38d05e399ed640e6497fcd79ac31e4aafd73" resname="policy.limitation.identifier.personalizationaccess">
-        <source>PersonalizationAccess</source>
-        <target>PersonalizationAccess</target>
+        <source>Personalization Access</source>
+        <target>Personalization Access</target>
         <note>key: policy.limitation.identifier.personalizationaccess</note>
       </trans-unit>
       <trans-unit id="af73694f5c5e5868af7948fb04f0d6bfe7ee6ad4" resname="policy.limitation.identifier.producttype">
-        <source>ProductType</source>
-        <target>ProductType</target>
+        <source>Product Type</source>
+        <target>Product Type</target>
         <note>key: policy.limitation.identifier.producttype</note>
       </trans-unit>
       <trans-unit id="bb77b27363dad566197a200290f0f0b18baa4705" resname="policy.limitation.identifier.section">
@@ -82,8 +87,8 @@
         <note>key: policy.limitation.identifier.section</note>
       </trans-unit>
       <trans-unit id="659face270db8822838d3efd32b3a9b72a6dc5f6" resname="policy.limitation.identifier.segmentgroup">
-        <source>SegmentGroup</source>
-        <target>SegmentGroup</target>
+        <source>Segment Group</source>
+        <target>Segment Group</target>
         <note>key: policy.limitation.identifier.segmentgroup</note>
       </trans-unit>
       <trans-unit id="548bc922c693c8259cbfd3354451a3035e2fa6f6" resname="policy.limitation.identifier.siteaccess">
@@ -112,23 +117,23 @@
         <note>key: policy.limitation.identifier.taxonomy</note>
       </trans-unit>
       <trans-unit id="097f571a3c731c66c83230e465f4b3c9af811add" resname="policy.limitation.identifier.userpermissions">
-        <source>UserPermissions</source>
-        <target>UserPermissions</target>
+        <source>User Permissions</source>
+        <target>User Permissions</target>
         <note>key: policy.limitation.identifier.userpermissions</note>
       </trans-unit>
       <trans-unit id="ae8d9836b92dd7d303929104953d877fa9c14fed" resname="policy.limitation.identifier.versionlock">
-        <source>VersionLock</source>
-        <target>VersionLock</target>
+        <source>Version Lock</source>
+        <target>Version Lock</target>
         <note>key: policy.limitation.identifier.versionlock</note>
       </trans-unit>
       <trans-unit id="920f6a0525d6ba93ff83f46e22baa981ff0b483c" resname="policy.limitation.identifier.workflowstage">
-        <source>WorkflowStage</source>
-        <target>WorkflowStage</target>
+        <source>Workflow Stage</source>
+        <target>Workflow Stage</target>
         <note>key: policy.limitation.identifier.workflowstage</note>
       </trans-unit>
       <trans-unit id="017b3370e919f545dbf4e889252c00419fde6fde" resname="policy.limitation.identifier.workflowtransition">
-        <source>WorkflowTransition</source>
-        <target>WorkflowTransition</target>
+        <source>Workflow Transition</source>
+        <target>Workflow Transition</target>
         <note>key: policy.limitation.identifier.workflowtransition</note>
       </trans-unit>
     </body>

--- a/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="0ba4dd0a3e03edbb23ad81c27bb921449e811cdc" resname="policy.limitation.identifier.changeowner">
+        <source>ChangeOwner</source>
+        <target>ChangeOwner</target>
+        <note>key: policy.limitation.identifier.changeowner</note>
+      </trans-unit>
       <trans-unit id="3742f2cc514848bd4a5eb03430e412d44f5d9ec2" resname="policy.limitation.identifier.class">
         <source>Content Type</source>
         <target>Content Type</target>

--- a/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
@@ -6,11 +6,6 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="0ba4dd0a3e03edbb23ad81c27bb921449e811cdc" resname="policy.limitation.identifier.changeowner">
-        <source>ChangeOwner</source>
-        <target>ChangeOwner</target>
-        <note>key: policy.limitation.identifier.changeowner</note>
-      </trans-unit>
       <trans-unit id="3742f2cc514848bd4a5eb03430e412d44f5d9ec2" resname="policy.limitation.identifier.class">
         <source>Content Type</source>
         <target>Content Type</target>

--- a/src/bundle/Resources/translations/ibexa_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_forms_policies.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="0ba4dd0a3e03edbb23ad81c27bb921449e811cdc" resname="policy.limitation.identifier.changeowner">
+        <source>Change Owner</source>
+        <target state="new">Change Owner</target>
+        <note>key: policy.limitation.identifier.changeowner</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/ibexa_content_forms_role.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_forms_role.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="57d5902302017c54f7a0965ff6bcd69a3dc03458" resname="policy.limitation.change_owner.forbid">
+        <source>Forbid</source>
+        <target state="new">Forbid</target>
+        <note>key: policy.limitation.change_owner.forbid</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
@@ -36,6 +36,12 @@
 {% endapply %}
 {% endblock %}
 
+{% block ez_limitation_changeowner_value %}
+    {% apply spaceless %}
+        {{ values|join(', ') }}
+    {% endapply %}
+{% endblock %}
+
 {% block ez_limitation_parentowner_value %}
 {% apply spaceless %}
     {{ values|join(', ') }}

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -11,7 +11,7 @@ use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
 use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
-use Ibexa\Core\Limitation\ChangeOwnerLimitationType;
+use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -66,7 +66,7 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
     private function getSelectionChoices(): array
     {
         return [
-            ChangeOwnerLimitationType::LIMITATION_VALUE_SELF => $this->translator->trans(/** @Desc("Forbid") */
+            ChangeOwnerLimitation::LIMITATION_VALUE_SELF => $this->translator->trans(/** @Desc("Forbid") */
                 'policy.limitation.change_owner.forbid',
                 [],
                 'ibexa_content_forms_role'

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -11,6 +11,7 @@ use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
 use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
+use Ibexa\Core\Limitation\ChangeOwnerLimitationType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -65,7 +66,7 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
     private function getSelectionChoices(): array
     {
         return [
-            -1 => $this->translator->trans(/** @Desc("Forbid") */
+            ChangeOwnerLimitationType::LIMITATION_VALUE_SELF => $this->translator->trans(/** @Desc("Forbid") */
                 'policy.limitation.change_owner.forbid',
                 [],
                 'ibexa_content_forms_role'

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -13,11 +13,13 @@ use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
 use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterface, LimitationFormMapperInterface
+final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterface, LimitationFormMapperInterface, TranslationContainerInterface
 {
     private TranslatorInterface $translator;
 
@@ -80,5 +82,16 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
     public function setFormTemplate(string $formTemplate): void
     {
         $this->formTemplate = $formTemplate;
+    }
+
+    /**
+     * @return \JMS\TranslationBundle\Model\Message[]
+     */
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message('policy.limitation.identifier.changeowner', 'ibexa_content_forms_policies'))
+                ->setDesc('Change Owner'),
+        ];
     }
 }

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\AdminUi\Limitation\Mapper;
+
+use Ibexa\AdminUi\Limitation\LimitationFormMapperInterface;
+use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
+use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterface, LimitationFormMapperInterface
+{
+    private TranslatorInterface $translator;
+
+    private PermissionResolver $permissionResolver;
+
+    private ?string $formTemplate = null;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        PermissionResolver $permissionResolver
+    ) {
+        $this->translator = $translator;
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    public function mapLimitationValue(Limitation $limitation): array
+    {
+        return $limitation->limitationValues;
+    }
+
+    public function mapLimitationForm(FormInterface $form, Limitation $data)
+    {
+        $options = [
+            'multiple' => true,
+            'expanded' => false,
+            'required' => false,
+            'label' => LimitationTranslationExtractor::identifierToLabel($data->getIdentifier()),
+            'choices' => array_flip($this->getSelectionChoices()),
+        ];
+
+        $form->add('limitationValues', ChoiceType::class, $options);
+    }
+
+    public function getFormTemplate(): ?string
+    {
+        return $this->formTemplate;
+    }
+
+    public function filterLimitationValues(Limitation $limitation): array
+    {
+        return $limitation->limitationValues;
+    }
+
+    /**
+     * @return array<?int, string>
+     */
+    private function getSelectionChoices(): array
+    {
+        return [
+            -1 => $this->translator->trans(/** @Desc("Forbid") */
+                'policy.limitation.change_owner.forbid',
+                [],
+                'ibexa_content_forms_role'
+            ),
+        ];
+    }
+
+    public function setFormTemplate(string $formTemplate): void
+    {
+        $this->formTemplate = $formTemplate;
+    }
+}

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -4,12 +4,13 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\AdminUi\Limitation\Mapper;
 
 use Ibexa\AdminUi\Limitation\LimitationFormMapperInterface;
 use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
 use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
-use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -20,24 +21,23 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
 {
     private TranslatorInterface $translator;
 
-    private PermissionResolver $permissionResolver;
-
     private ?string $formTemplate = null;
 
     public function __construct(
-        TranslatorInterface $translator,
-        PermissionResolver $permissionResolver
+        TranslatorInterface $translator
     ) {
         $this->translator = $translator;
-        $this->permissionResolver = $permissionResolver;
     }
 
+    /**
+     * @return int[]
+     */
     public function mapLimitationValue(Limitation $limitation): array
     {
         return $limitation->limitationValues;
     }
 
-    public function mapLimitationForm(FormInterface $form, Limitation $data)
+    public function mapLimitationForm(FormInterface $form, Limitation $data): void
     {
         $options = [
             'multiple' => true,
@@ -55,6 +55,9 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
         return $this->formTemplate;
     }
 
+    /**
+     * @return int[]
+     */
     public function filterLimitationValues(Limitation $limitation): array
     {
         return $limitation->limitationValues;

--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -13,13 +13,11 @@ use Ibexa\AdminUi\Limitation\LimitationValueMapperInterface;
 use Ibexa\AdminUi\Translation\Extractor\LimitationTranslationExtractor;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
-use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterface, LimitationFormMapperInterface, TranslationContainerInterface
+final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterface, LimitationFormMapperInterface
 {
     private TranslatorInterface $translator;
 
@@ -82,16 +80,5 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
     public function setFormTemplate(string $formTemplate): void
     {
         $this->formTemplate = $formTemplate;
-    }
-
-    /**
-     * @return \JMS\TranslationBundle\Model\Message[]
-     */
-    public static function getTranslationMessages(): array
-    {
-        return [
-            (new Message('policy.limitation.identifier.changeowner', 'ibexa_content_forms_policies'))
-                ->setDesc('Change Owner'),
-        ];
     }
 }

--- a/src/lib/Translation/Extractor/LimitationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/LimitationTranslationExtractor.php
@@ -43,7 +43,7 @@ class LimitationTranslationExtractor implements ExtractorInterface
             $message = new Message\XliffMessage($id, self::MESSAGE_DOMAIN);
             $message->setNew(false);
             $message->setMeaning($limitationType);
-            $message->setDesc($limitationType);
+            $message->setDesc($this->getReadableName($limitationType));
             $message->setLocaleString($limitationType);
             $message->addNote('key: ' . $id);
 
@@ -86,6 +86,22 @@ class LimitationTranslationExtractor implements ExtractorInterface
         }
 
         return $limitationTypes;
+    }
+
+    private function getReadableName(string $input): string
+    {
+        $parts = preg_split(
+            '/(^[^A-Z]+|[A-Z][^A-Z]+)/',
+            $input,
+            -1,
+            PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
+        );
+
+        if (!is_array($parts)) {
+            return $input;
+        }
+
+        return implode(' ', $parts);
     }
 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4032](https://issues.ibexa.co/browse/IBX-4032)
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Admin UI Interface (form mapper) for new `ChangeOwner` limitation added to `ibexa/core`.

### Depends on: https://github.com/ibexa/core/pull/162

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
