### PR TITLE
IBX-3973: Nontranslatable and disabled fields are not greyed out in content editing UI

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
@@ -76,7 +76,9 @@
             const isEnabled = parentNode.querySelectorAll(SELECTOR_AUTHOR).length > 1;
 
             parentNode.querySelectorAll(SELECTOR_REMOVE_AUTHOR).forEach((btn) => {
-                if (isEnabled) {
+                const forceDisabled = btn.parentElement.classList.contains('ibexa-data-source__actions--disabled');
+
+                if (isEnabled && !forceDisabled) {
                     btn.removeAttribute('disabled');
                 } else {
                     btn.setAttribute('disabled', true);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -455,11 +455,23 @@
         const areCoordsSet = !!longitudeInput.value.length && !!latitudeInput.value.length;
         const locateMeBtn = field.querySelector('.ibexa-data-source__locate-me .btn');
         const searchBtn = field.querySelector('.ibexa-btn--search-by-address');
-        const mapConfig = {
+        const mapContainer = field.querySelector('.ibexa-data-source__map');
+        let mapConfig = {
             zoom: areCoordsSet ? 15 : 1,
             center: areCoordsSet ? [parseFloat(latitudeInput.value), parseFloat(longitudeInput.value)] : [0, 0],
         };
-        const map = Leaflet.map(field.querySelector('.ibexa-data-source__map'), mapConfig);
+
+        if (mapContainer.classList.contains('ibexa-data-source__map--disabled')) {
+            mapConfig = {
+                ...mapConfig,
+                zoomControl: false,
+                scrollWheelZoom: false,
+                dragging: false,
+                tap: false,
+            };
+        }
+
+        const map = Leaflet.map(mapContainer, mapConfig);
 
         maps.push(map);
         longitudeInput.value = longitudeInput.dataset.value.replace(',', '.');
@@ -598,6 +610,10 @@
 
         if (areCoordsSet) {
             updateMapState(mapConfig.center[0], mapConfig.center[1]);
+        }
+
+        if (mapContainer.classList.contains('ibexa-data-source__map--disabled')) {
+            return;
         }
 
         addressInput.addEventListener(EVENT_KEYUP, handleAddressInput, false);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
@@ -171,7 +171,9 @@
                 return;
             }
 
-            const methodName = !selectedItemsLimit || selectedItems.length < selectedItemsLimit ? 'removeAttribute' : 'setAttribute';
+            const forceDisabled = addBtn.classList.contains('ibexa-relations__table-action--disabled');
+            const methodName =
+                !forceDisabled && (!selectedItemsLimit || selectedItems.length < selectedItemsLimit) ? 'removeAttribute' : 'setAttribute';
 
             addBtn[methodName]('disabled', true);
         };

--- a/src/bundle/Resources/public/scss/_date-time-picker.scss
+++ b/src/bundle/Resources/public/scss/_date-time-picker.scss
@@ -12,7 +12,6 @@
 
         &[disabled] {
             background-color: $ibexa-color-light-300;
-            border-color: $ibexa-color-light-300;
         }
     }
 

--- a/src/bundle/Resources/public/scss/_dropdown.scss
+++ b/src/bundle/Resources/public/scss/_dropdown.scss
@@ -436,7 +436,6 @@
     &--disabled {
         .ibexa-dropdown {
             &__selection-info {
-                border-color: transparent;
                 background: $ibexa-color-light-300;
                 cursor: not-allowed;
 

--- a/src/bundle/Resources/public/scss/_dropdown.scss
+++ b/src/bundle/Resources/public/scss/_dropdown.scss
@@ -456,6 +456,18 @@
                 padding: 0 calculateRem(24px) 0 calculateRem(16px);
             }
         }
+
+        &.ibexa-dropdown--disabled {
+            .ibexa-dropdown__selection-info {
+                background-color: transparent;
+                color: $ibexa-color-dark-300;
+
+                &::before,
+                &::after {
+                    background-color: $ibexa-color-dark-300;
+                }
+            }
+        }
     }
 
     &--switcher {

--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -16,12 +16,10 @@ form:not(.form-inline) {
     .form-control:not(.flatpickr-input)[readonly] {
         color: $ibexa-color-dark-300;
         background-color: $ibexa-color-light-300;
-        border-color: $ibexa-color-light-300;
 
         &:focus {
             outline: none;
             box-shadow: none;
-            border-color: $ibexa-color-light-300;
         }
     }
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -31,10 +31,14 @@
 
     &--nontranslatable,
     &--disabled {
-        pointer-events: nonce;
+        pointer-events: nonasdae;
 
         .ibexa-label {
             color: $ibexa-color-black-300;
+        }
+
+        h2 {
+            color: $ibexa-color-dark-300;
         }
 
         &__data {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -31,7 +31,7 @@
 
     &--nontranslatable,
     &--disabled {
-        pointer-events: nonasdae;
+        pointer-events: none;
 
         .ibexa-label {
             color: $ibexa-color-black-300;

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -31,7 +31,7 @@
 
     &--nontranslatable,
     &--disabled {
-        pointer-events: none;
+        pointer-events: nonce;
 
         .ibexa-label {
             color: $ibexa-color-black-300;

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
@@ -126,4 +126,12 @@
             }
         }
     }
+
+    &.ibexa-field-edit--nontranslatable {
+        .ibexa-data-source__label-text,
+        p,
+        a {
+            color: $ibexa-color-dark-300;
+        }
+    }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
@@ -30,13 +30,4 @@
             }
         }
     }
-
-    // &.ibexa-field-edit--nontranslatable {
-    //     .ibexa-input--checkbox {
-    //         pointer-events: none;
-    //         cursor: not-allowed;
-    //         border-color: $ibexa-color-dark-200;
-    //         background-color: $ibexa-color-light;
-    //     }
-    // }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
@@ -30,4 +30,13 @@
             }
         }
     }
+
+    // &.ibexa-field-edit--nontranslatable {
+    //     .ibexa-input--checkbox {
+    //         pointer-events: none;
+    //         cursor: not-allowed;
+    //         border-color: $ibexa-color-dark-200;
+    //         background-color: $ibexa-color-light;
+    //     }
+    // }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
@@ -1,6 +1,7 @@
 .ibexa-field-edit--ezgmaplocation {
     .ibexa-data-source {
         display: flex;
+        position: relative;
 
         &__map {
             z-index: 0;
@@ -8,6 +9,19 @@
             height: calculateRem(400px);
             border-top-left-radius: $ibexa-border-radius;
             border-bottom-left-radius: $ibexa-border-radius;
+            position: relative;
+
+            &--disabled::after {
+                position: absolute;
+                background: rgba($ibexa-color-light-500, 0.8);
+                z-index: 2000;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                content: '';
+                display: block;
+            }
         }
 
         &__field--address {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
@@ -64,6 +64,10 @@
                 border-left: none;
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
+
+                &[disabled] {
+                    background-color: $ibexa-color-light-300;
+                }
             }
 
             .ibexa-btn--search-by-address {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezimageasset.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezimageasset.scss
@@ -43,6 +43,13 @@
             fill: $ibexa-color-black;
         }
     }
+
+    &.ibexa-field-edit--nontranslatable {
+        .ibexa-data-source__message--main,
+        .ibexa-data-source__btn-add {
+            color: $ibexa-color-dark-300;
+        }
+    }
 }
 
 .ibexa-field-edit--is-preview-loading {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezkeyword.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezkeyword.scss
@@ -49,4 +49,20 @@
         background: none;
         border: 0 none;
     }
+
+    &.ibexa-field-edit--nontranslatable {
+        .ibexa-data-source__taggify {
+            background-color: $ibexa-color-light-300;
+            pointer-events: none;
+
+            .taggify__tag {
+                background-color: $ibexa-color-light-400;
+                color: $ibexa-color-dark-300;
+
+                .taggify__btn--remove {
+                    color: $ibexa-color-dark-300;
+                }
+            }
+        }
+    }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezkeyword.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezkeyword.scss
@@ -56,11 +56,11 @@
             pointer-events: none;
 
             .taggify__tag {
-                background-color: $ibexa-color-light-400;
-                color: $ibexa-color-dark-300;
+                background-color: $ibexa-color-light-500;
+                color: $ibexa-color-dark-400;
 
                 .taggify__btn--remove {
-                    color: $ibexa-color-dark-300;
+                    color: $ibexa-color-dark-400;
                 }
             }
         }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezmedia.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezmedia.scss
@@ -9,6 +9,7 @@
         &__file-size-wrapper,
         &__control,
         &__settings {
+            width: 10px;
             flex-basis: 50%;
             padding: calculateRem(8px);
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezmedia.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezmedia.scss
@@ -9,7 +9,6 @@
         &__file-size-wrapper,
         &__control,
         &__settings {
-            width: 10px;
             flex-basis: 50%;
             padding: calculateRem(8px);
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
@@ -68,7 +68,8 @@
     &.ibexa-field-edit--nontranslatable {
         .ibexa-relations__helper-text,
         .ibexa-relations__info-text,
-        .ibexa-relations__info-sub-text {
+        .ibexa-relations__info-sub-text,
+        .ibexa-table__cell {
             color: $ibexa-color-dark-300;
         }
     }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
@@ -64,4 +64,12 @@
             margin-right: calculateRem(4px);
         }
     }
+
+    &.ibexa-field-edit--nontranslatable {
+        .ibexa-relations__helper-text,
+        .ibexa-relations__info-text,
+        .ibexa-relations__info-sub-text {
+            color: $ibexa-color-dark-300;
+        }
+    }
 }

--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -139,6 +139,16 @@
     </div>
 {% endblock %}
 
+{%- block ezplatform_fieldtype_ezurl_widget -%}
+    {%- if form.parent is empty -%}
+        {{ form_errors(form) }}
+    {%- endif -%}
+    {% for child in form|filter(child => not child.rendered) %}
+        {{- form_row(child, { attr: { readonly: attr.readonly|default(false) }}) -}}
+    {% endfor %}
+    {{- form_rest(form) -}}
+{%- endblock ezplatform_fieldtype_ezurl_widget -%}
+
 {%- block form_widget_compound -%}
     {%- if form.parent is empty -%}
         {{ form_errors(form) }}

--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -139,21 +139,13 @@
     </div>
 {% endblock %}
 
-{%- block ezplatform_fieldtype_ezurl_widget -%}
-    {%- if form.parent is empty -%}
-        {{ form_errors(form) }}
-    {%- endif -%}
-    {% for child in form|filter(child => not child.rendered) %}
-        {{- form_row(child, { attr: { readonly: attr.readonly|default(false) }}) -}}
-    {% endfor %}
-    {{- form_rest(form) -}}
-{%- endblock ezplatform_fieldtype_ezurl_widget -%}
-
 {%- block form_widget_compound -%}
     {%- if form.parent is empty -%}
         {{ form_errors(form) }}
     {%- endif -%}
-    {{- block('form_rows') -}}
+    {% with { attr: attr } %}
+        {{- block('form_rows') -}}
+    {% endwith %}
     {{- form_rest(form) -}}
 {%- endblock form_widget_compound -%}
 
@@ -163,3 +155,9 @@
 {%- endblock number_widget -%}
 
 {% block form_label_errors %}{% endblock %}
+
+{%- block form_rows -%}
+    {% for child in form|filter(child => not child.rendered) %}
+        {{- form_row(child, { attr: attr|default({}) }) -}}
+    {% endfor %}
+{%- endblock form_rows -%}

--- a/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
@@ -13,7 +13,7 @@
 {% set multiple = multiple|default(false) %}
 {% set no_items = choices_flat|length == 0 %}
 {% set is_dynamic = is_dynamic|default(false) %}
-{% set is_disabled = is_disabled|default(false) %}
+{% set is_disabled = is_disabled|default(false) or attr.readonly|default(false) %}
 {% set is_selector = is_selector|default(false) %}
 {% set has_select_all_toggler = has_select_all_toggler|default(false) %}
 {% set item_icon = item_icon|default() %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
@@ -4,10 +4,17 @@
     {% if not file_is_empty is defined %}
         {% set file_is_empty = form.parent.vars.value.value.fileName is null or form.parent.vars.value.value.fileSize is null %}
     {% endif %}
+    {% set fieldtype = form.parent %}
+    {% set translation_mode = fieldtype.vars.mainLanguageCode != fieldtype.vars.languageCode %}
+    {% set fieldtype_is_not_translatable = translation_mode and not fieldtype.vars.value.fieldDefinition.isTranslatable %}
     {% set attr = attr|merge({'data-max-file-size': max_file_size}) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ibexa-field-edit--with-preview')|trim}) %}
     {% set preview_attr = preview_attr|default({})|merge({'class': (preview_attr.class|default('') ~ ' ibexa-field-edit__preview')|trim}) %}
     {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ibexa-field-edit__data')|trim}) %}
+
+    {% if fieldtype_is_not_translatable or fieldtype.vars.disabled %}
+        {% set attr = attr|merge({'readonly': 'readonly'}) %}
+    {% endif %}
 
     {% set has_error = false %}
     {% for error in form.parent.parent.parent.vars.errors %}
@@ -34,9 +41,13 @@
     <div class="ibexa-data-source__message--main">{{ 'fieldtype.binary_base.drag_drop'|trans|desc('Drag and drop file') }}</div>
     <div class="ibexa-data-source__message--separator">{{ 'fieldtype.binary_base.drag_drop.or'|trans|desc('or') }}</div>
     <div class="ibexa-data-source__actions">
-        <div class="ibexa-data-source__btn-add btn ibexa-btn ibexa-btn--secondary">
+        <button
+            type="button"
+            class="ibexa-data-source__btn-add btn ibexa-btn ibexa-btn--secondary"
+            {{ attr.readonly|default(false) ? 'disabled' }}
+        >
             <span class="ibexa-data-source__btn-label">{{ 'fieldtype.binary_base.upload_file'|trans|desc('Upload file') }}</span>
-        </div>
+        </button>
     </div>
     {% if max_file_size is defined and max_file_size > 0 %}
         <div class="ibexa-data-source__message--filesize">{{ 'fieldtype.binary_base.max_file_size'|trans({'%size%': max_file_size|default(0)|ibexa_file_size(2)})|desc('Max file size: %size%') }}</div>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezauthor.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezauthor.html.twig
@@ -9,11 +9,14 @@
 {% endblock %}
 
 {% block ezplatform_fieldtype_ezauthor_widget %}
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-data-source__main-actions">
         <button
             type="button"
             class="btn ibexa-btn ibexa-btn--secondary ibexa-btn--small ibexa-btn--add-author"
             title="{{ 'ezauthor.action.add'|trans|desc('Add') }}"
+            {{ readonly|default(false) ? 'disabled' }}
         >
             <svg class="ibexa-icon ibexa-icon--small ibexa-icon--create">
                 <use xlink:href="{{ ibexa_icon_path('create') }}"></use>
@@ -37,21 +40,27 @@
         <label class="ibexa-label form-label">{{ 'ezauthor.Email'|trans|desc('Email') }}</label>
     </div>
     {% for child in form.authors %}
-        {{ form_row(child) }}
+        {{ form_row(child, { attr: { readonly: readonly}}) }}
     {% endfor %}
 {% endblock %}
 
 {% block ezplatform_fieldtype_ezauthor_authors_entry_row -%}
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-data-source__author form-row">
         {{- form_widget(form.id) -}}
         <div class="ibexa-data-source__checkbox">
-            <input type="checkbox" class="ibexa-input ibexa-input--checkbox" />
+            <input
+                type="checkbox"
+                class="ibexa-input ibexa-input--checkbox"
+                {{ readonly|default(false) ? 'disabled' }}
+             />
         </div>
-        {{- form_row(form.name, { label_wrapper_attr: { 'hidden': 'hidden' }}) -}}
-        {{- form_row(form.email, { label_wrapper_attr: { 'hidden': 'hidden' }, attr: {'class': 'ibexa-input--text'}}) -}}
-        <div class="ibexa-data-source__actions">
+        {{- form_row(form.name, { label_wrapper_attr: { 'hidden': 'hidden' }, attr: { readonly: readonly }}) -}}
+        {{- form_row(form.email, { label_wrapper_attr: { 'hidden': 'hidden' }, attr: {'class': 'ibexa-input--text', readonly: readonly }}) -}}
+        <div class="ibexa-data-source__actions {{ readonly ? 'ibexa-data-source__actions--disabled' }}">
             <button 
-                type="button" 
+                type="button"
                 class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text ibexa-btn--remove-author"
                 title="{{ 'ezauthor.action.delete'|trans|desc('Delete') }}"
                 disabled

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezbinaryfile.html.twig
@@ -9,18 +9,27 @@
 {%- endblock -%}
 
 {% block ezbinaryfile_preview %}
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-field-edit-preview">
         <div class="ibexa-field-edit-preview__visual">
             <div class="ibexa-field-edit-preview__media-wrapper">
                 <div class="ibexa-field-edit-preview__actions">
-                    <a class="ibexa-field-edit-preview__action--preview btn ibexa-btn ibexa-btn--ghost ibexa-btn--small" href="{{ form.parent.vars.value.value.uri }}"
-                        download>
+                    <a
+                        class="ibexa-field-edit-preview__action--preview btn ibexa-btn ibexa-btn--ghost ibexa-btn--small" href="{{ form.parent.vars.value.value.uri }}"
+                        download
+                        {{ readonly ? 'disabled' }}
+                    >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('download') }}"></use>
                         </svg>
                         <span class="ibexa-btn__label">{{ 'ezbinaryfile.action.download'|trans|desc('Download') }}</span>
                     </a>
-                    <button type="button" class="ibexa-field-edit-preview__action--remove btn ibexa-btn ibexa-btn--ghost ibexa-btn--small" >
+                    <button
+                        type="button"
+                        class="ibexa-field-edit-preview__action--remove btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
+                        {{ readonly ? 'disabled' }}
+                    >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
                         </svg>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezdate.html.twig
@@ -1,7 +1,7 @@
 {% block ezplatform_fieldtype_ezdate_widget %}
     {% include '@ibexadesign/ui/component/inputs/input_date_time_picker.html.twig' with {
         wrapper_attr: { class: 'ibexa-data-source__input-wrapper' },
-        input_attr: { class: 'ibexa-data-source__input' }
+        input_attr: { class: 'ibexa-data-source__input', disabled: attr.readonly|default(false) }
     } %}
     {% set action_type = isEditView ? 'edit' : 'create' %}
     {% set attr = attr|merge({'class': 'ibexa-data-source__input', 'hidden': 'hidden', 'data-action-type': action_type}) %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezdatetime.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezdatetime.html.twig
@@ -1,7 +1,7 @@
 {% block ezplatform_fieldtype_ezdatetime_widget %}
     {% include '@ibexadesign/ui/component/inputs/input_date_time_picker.html.twig' with {
         wrapper_attr: { class: 'ibexa-data-source__input-wrapper' },
-        input_attr: { class: 'ibexa-data-source__input' }
+        input_attr: { class: 'ibexa-data-source__input', disabled: attr.readonly|default(false) }
     } %}
     {% set attr = attr|merge({'class': 'ibexa-data-source__input', 'hidden': 'hidden'}) %}
     {{ block('form_widget') }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezgmaplocation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezgmaplocation.html.twig
@@ -3,7 +3,7 @@
 {%- block ezplatform_fieldtype_ezgmaplocation_widget -%}
     {% set readonly = attr.readonly|default(false) %}
 
-    <div class="ibexa-data-source__map"></div>
+    <div class="ibexa-data-source__map {{ readonly ? 'ibexa-data-source__map--disabled' }}"></div>
     <div class="ibexa-data-source__options">
         <div class="ibexa-data-source__field ibexa-data-source__field--address">
             <div class="ibexa-data-source__input-wrapper">

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezgmaplocation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezgmaplocation.html.twig
@@ -1,13 +1,19 @@
 {% trans_default_domain 'ezplatform_content_forms_content' %}
 
 {%- block ezplatform_fieldtype_ezgmaplocation_widget -%}
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-data-source__map"></div>
     <div class="ibexa-data-source__options">
         <div class="ibexa-data-source__field ibexa-data-source__field--address">
             <div class="ibexa-data-source__input-wrapper">
-                {{ form_widget(form.address, {'attr': {'class': 'ibexa-data-source__input', 'placeholder': 'ezgmaplocation.input.placeholder'|trans|desc('Search address')}}) }}
+                {{ form_widget(form.address, {'attr': {'class': 'ibexa-data-source__input', 'placeholder': 'ezgmaplocation.input.placeholder'|trans|desc('Search address'), readonly: readonly }}) }}
                 <div class="ibexa-data-source__locate-me">
-                    <button type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text ibexa-btn--locate-me">
+                    <button
+                        type="button"
+                        class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text ibexa-btn--locate-me"
+                        {{ readonly ? 'disabled' }}
+                    >
                         <svg class="ibexa-icon ibexa-icon--small-medium">
                             <use xlink:href="{{ ibexa_icon_path('localize') }}"></use>
                         </svg>
@@ -24,8 +30,8 @@
             {{ 'ezgmaplocation.text.info'|trans|desc('or enter geographical coordinates') }}
         </div>
         <div class="ibexa-data-source__coordinates">
-            {{ form_row(form.latitude, { 'attr': { 'data-value': form.latitude.vars.value }}) }}
-            {{ form_row(form.longitude, { 'attr': { 'data-value': form.longitude.vars.value }}) }}
+            {{ form_row(form.latitude, { 'attr': { 'data-value': form.latitude.vars.value, readonly: readonly }}) }}
+            {{ form_row(form.longitude, { 'attr': { 'data-value': form.longitude.vars.value, readonly: readonly }}) }}
         </div>
     </div>
 {%- endblock -%}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -12,6 +12,8 @@
 {% block ezimage_preview %}
     {% form_theme form '@ibexadesign/ui/field_type/edit/binary_base_fields.html.twig' %}
 
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-field-edit-preview">
         <div class="ibexa-field-edit-preview__visual">
             <div class="ibexa-field-edit-preview__media-wrapper">
@@ -19,6 +21,7 @@
                     <button
                         type="button"
                         class="ibexa-field-edit-preview__action ibexa-field-edit-preview__action--remove btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
@@ -29,6 +32,7 @@
                         class="ibexa-field-edit-preview__action ibexa-field-edit-preview__action--preview btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
                         href="{{ form.parent.vars.value.value.uri }}"
                         target="_blank"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('open-newtab') }}"></use>
@@ -39,7 +43,8 @@
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId')
+                            'contentId' : app.request.get('contentId'),
+                            'disabled': readonly ? true : false,
                         }
                     ) }}
                 </div>
@@ -73,11 +78,11 @@
             <div class="ibexa-field-edit-preview__image-alt">
                 {% set alternative_text_label_class = form.vars.is_alternative_text_required ? 'required' : '' %}
                 {{ form_row(form.alternativeText, {
-                    attr: { 'data-is-required': form.vars.is_alternative_text_required },
+                    attr: { 'data-is-required': form.vars.is_alternative_text_required, readonly: readonly },
                     label_attr: { 'class': alternative_text_label_class }
                 }) }}
             </div>
-            {{ form_widget(form.additionalData, {attr: {class: 'ibexa-field-edit-preview__additional-data'}}) }}
+            {{ form_widget(form.additionalData, {attr: {class: 'ibexa-field-edit-preview__additional-data', readonly: readonly }}) }}
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -21,8 +21,6 @@
 {%- endblock -%}
 
 {% block ezplatform_fieldtype_ezimageasset_widget_container %}
-
-{{dump(attr)}}
     <div class="ibexa-field-edit-spinner">
         <svg class="ibexa-icon ibexa-spin">
             <use xlink:href="{{ ibexa_icon_path('spinner') }}"></use>
@@ -66,6 +64,7 @@
     <button
         class="btn ibexa-btn ibexa-btn--secondary ibexa-data-source__btn-select"
         data-udw-config="{{ ibexa_udw_config('image_asset', {}) }}"
+        {{ attr.readonly|default(false)  ? 'disabled' }}
     >
         {{ 'fieldtype.ezimageasset.select.label'|trans|desc('Select from library') }}
     </button>
@@ -74,6 +73,7 @@
 {% block ezimageasset_preview %}
     {% form_theme form '@ibexadesign/ui/field_type/edit/binary_base_fields.html.twig' %}
 
+    {% set readonly = attr.readonly|default(false) %}
     {% set destination_content_url = destination_content_url ?? '//:0' %}
     {% set destination_content_name = destination_content_name ?? '' %}
     {% set image_uri = image_uri ?? '' %}
@@ -99,6 +99,7 @@
                     <button
                         type="button"
                         class="ibexa-field-edit-preview__action--remove btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
@@ -109,6 +110,7 @@
                         class="ibexa-field-edit-preview__action--preview btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
                         href="{{ destination_content_url }}"
                         target="_blank"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('open-newtab') }}"></use>
@@ -119,7 +121,8 @@
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId')
+                            'contentId' : app.request.get('contentId'),
+                            'disabled': readonly ? true : false,
                         }
                     ) }}
                 </div>
@@ -140,7 +143,7 @@
                 </div>
             </div>
             <div class="ibexa-field-edit-preview__image-alt">
-                {{ form_row(form.alternativeText) }}
+                {{ form_row(form.alternativeText, { attr: { readonly: readonly }}) }}
             </div>
         </div>
     </div>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -21,6 +21,8 @@
 {%- endblock -%}
 
 {% block ezplatform_fieldtype_ezimageasset_widget_container %}
+
+{{dump(attr)}}
     <div class="ibexa-field-edit-spinner">
         <svg class="ibexa-icon ibexa-spin">
             <use xlink:href="{{ ibexa_icon_path('spinner') }}"></use>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezmedia.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezmedia.html.twig
@@ -11,6 +11,8 @@
 {% block ezmedia_preview %}
     {% form_theme form '@ibexadesign/ui/field_type/edit/binary_base_fields.html.twig' %}
 
+    {% set readonly = attr.readonly|default(false) %}
+
     <div class="ibexa-field-edit-preview">
         <div class="ibexa-field-edit-preview__visual">
             <div class="ibexa-field-edit-preview__media-wrapper ibexa-field-edit-preview__media-wrapper--loading">
@@ -18,6 +20,7 @@
                     <button 
                         type="button" 
                         class="ibexa-field-edit-preview__action--remove btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
@@ -28,6 +31,7 @@
                         class="ibexa-field-edit-preview__action--preview btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
                         href="{{ form.parent.vars.value.value.uri }}"
                         target="_blank"
+                        {{ readonly ? 'disabled' }}
                     >
                         <svg class="ibexa-icon ibexa-icon--small">
                             <use xlink:href="{{ ibexa_icon_path('open-newtab') }}"></use>
@@ -46,8 +50,6 @@
                 </video>
             </div>
 
-
-
             <div class="ibexa-field-edit-preview__details">
                 <span class="ibexa-field-edit-preview__file-name-wrapper">
                     <label class="ibexa-label form-label">{{ 'content.field_type.ezmedia.file_name.label'|trans|desc('File name') }}</label>
@@ -59,8 +61,8 @@
                 </span>
                 <div class="ibexa-field-edit-preview__settings">
                     <div class="ibexa-field-edit-preview__dimensions">
-                        {{ form_row(form.width, {'label_attr': {'class': 'ibexa-field-edit-preview__label'}}) }}
-                        {{ form_row(form.height, {'label_attr': {'class': 'ibexa-field-edit-preview__label'}}) }}
+                        {{ form_row(form.width, {'label_attr': {'class': 'ibexa-field-edit-preview__label'}, attr: { readonly: readonly }}) }}
+                        {{ form_row(form.height, {'label_attr': {'class': 'ibexa-field-edit-preview__label'}, attr: { readonly: readonly }}) }}
                     </div>
                 </div>
                 <div class="ibexa-field-edit-preview__control">
@@ -68,9 +70,9 @@
                         {{ 'content.field_type.ezmedia.player_settings'|trans({}, 'ezplatform_content_forms_content')|desc('Player settings') }}
                     </label>
                     <div class="ibexa-field-edit-preview__toggles">
-                        {{ form_row(form.hasController, {'label_attr': {'class': 'checkbox-inline'}}) }}
-                        {{ form_row(form.autoplay, {'label_attr': {'class': 'checkbox-inline'}}) }}
-                        {{ form_row(form.loop, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                        {{ form_row(form.hasController, {'label_attr': {'class': 'checkbox-inline'}, attr: { disabled: readonly }}) }}
+                        {{ form_row(form.autoplay, {'label_attr': {'class': 'checkbox-inline'}, attr: { disabled: readonly }}) }}
+                        {{ form_row(form.loop, {'label_attr': {'class': 'checkbox-inline'}, attr: { disabled: readonly }}) }}
                     </div>
                 </div>
             </div>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezselection.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezselection.html.twig
@@ -1,6 +1,6 @@
 {% use '@ibexadesign/ui/form_fields/dropdown_widget.html.twig' %}
 
 {%- block ezplatform_fieldtype_ezselection_widget -%}
-    {% set attr = attr|merge({'class': 'ibexa-data-source__input ibexa-data-source__input--selection'}) %}
+    {% set attr = attr|merge({'class': 'ibexa-data-source__input ibexa-data-source__input--selection', disabled: attr.readonly|default(false) }) %}
     {{ block('choice_widget') }}
 {%- endblock -%}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/eztime.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/eztime.html.twig
@@ -1,7 +1,7 @@
 {% block ezplatform_fieldtype_eztime_widget %}
     {% include '@ibexadesign/ui/component/inputs/input_date_time_picker.html.twig' with {
         wrapper_attr: { class: 'ibexa-data-source__input-wrapper' },
-        input_attr: { class: 'ibexa-data-source__input' }
+        input_attr: { class: 'ibexa-data-source__input', disabled: attr.readonly|default(false) }
     } %}
     {% set attr = attr|merge({'class': 'ibexa-data-source__input', 'hidden': 'hidden'}) %}
     {{ block('form_widget') }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
@@ -106,7 +106,7 @@
                         class="ibexa-relations__order-input ibexa-input ibexa-input--small form-control"
                         type="number"
                         value="{{ loop.index }}"
-                        {{ readonly ? 'disabled' }}
+                        {{ readonly ? 'readonly' }}
                     >
                 {% endset %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
@@ -6,6 +6,7 @@
     {% set has_relations = relations|length > 0 %}
     {% set allowed_content_types = form.parent.vars.value.fieldDefinition.fieldSettings.selectionContentTypes %}
     {% set helper = helper|default('') %}
+    {% set readonly = attr.readonly|default(false) %}
 
     {% set col_raw_checkbox_template %}
         <input type="checkbox" class="ibexa-input ibexa-input--checkbox" value="{{ '{{ content_id }}' }}">
@@ -266,6 +267,7 @@
             data-limit="{{limit}}"
             class="ibexa-relations__cta-btn btn ibexa-btn ibexa-btn--secondary"
             type="button"
+            {{ readonly|default(false) ? 'disabled' }}
         >
             <span class="ibexa-relations__cta-btn-label">
                 {{ 'ezobjectrelationlist.cta.select'|trans|desc('Select Item') }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
@@ -9,11 +9,21 @@
     {% set readonly = attr.readonly|default(false) %}
 
     {% set col_raw_checkbox_template %}
-        <input type="checkbox" class="ibexa-input ibexa-input--checkbox" value="{{ '{{ content_id }}' }}">
+        <input
+            type="checkbox"
+            class="ibexa-input ibexa-input--checkbox"
+            value="{{ '{{ content_id }}' }}"
+            {{ readonly ? 'disabled' }}
+        >
     {% endset %}
 
     {% set col_raw_order_input_template %}
-        <input class="ibexa-relations__order-input ibexa-input ibexa-input--small form-control" type="number" value="{{ '{{ order }}' }}">
+        <input
+            class="ibexa-relations__order-input ibexa-input ibexa-input--small form-control"
+            type="number"
+            value="{{ '{{ order }}' }}"
+            {{ readonly ? 'disabled' }}
+        >
     {% endset %}
 
     {% set col_raw_actions %}
@@ -21,6 +31,7 @@
             type="button"
             class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text ibexa-relations__table-action--remove-item ibexa-btn"
             title="{{ 'ezobjectrelationlist.delete_selected_relations'|trans|desc('Delete') }}"
+            {{ readonly ? 'disabled' }}
         >
             <svg class="ibexa-icon ibexa-icon--small">
                 <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
@@ -86,6 +97,7 @@
                         type="checkbox"
                         class="ibexa-input ibexa-input--checkbox"
                         value="{{ relation.contentInfo.id }}"
+                        {{ readonly ? 'disabled' }}
                     >
                 {% endset %}
 
@@ -94,6 +106,7 @@
                         class="ibexa-relations__order-input ibexa-input ibexa-input--small form-control"
                         type="number"
                         value="{{ loop.index }}"
+                        {{ readonly ? 'disabled' }}
                     >
                 {% endset %}
 
@@ -151,6 +164,7 @@
                         class="ibexa-relations__order-input ibexa-input ibexa-input--small form-control"
                         type="number"
                         value="{{ loop.index }}"
+                        {{ readonly ? 'disabled' }}
                     >
                 {% endset %}
 
@@ -231,7 +245,7 @@
                                     'allowed_content_types': allowed_content_types
                                 }) }}"
                                 type="button"
-                                class="btn ibexa-btn ibexa-btn--secondary ibexa-btn--small ibexa-relations__table-action--create ibexa-btn"
+                                class="btn ibexa-btn ibexa-btn--secondary ibexa-btn--small ibexa-relations__table-action--create ibexa-btn {{ readonly ? 'ibexa-relations__table-action--disabled' }}"
                                 disabled
                                 {% if not has_relations %}hidden="true"{% endif %}
                             >

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields/toggle_widget.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields/toggle_widget.html.twig
@@ -20,7 +20,7 @@
         {% set main_class = main_class ~ ' ibexa-toggle--is-checked' %}
         {% set attr = attr|merge({ 'checked': 'checked' }) %}
     {% endif %}
-    {% if disabled|default(false) %}
+    {% if disabled|default(false) or attr.readonly|default(false) %}
         {% set main_class = main_class ~ ' ibexa-toggle--is-disabled' %}
     {% endif %}
     {% if value is defined %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3973
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
