### PR TITLE
IBX-4273: Missing translation for field_definition in content type (and wrong domain)

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -306,10 +306,20 @@
         <target state="new">another user</target>
         <note>key: content_type.user_name.can_not_be_fetched</note>
       </trans-unit>
+      <trans-unit id="a7184ac693722bff0fedf65c45c914509af2b17f" resname="content_type.view.edit.add">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note>key: content_type.view.edit.add</note>
+      </trans-unit>
       <trans-unit id="94367a951b897bc2964d0c45286b560c59ebb996" resname="content_type.view.edit.content_field_definitions">
         <source>Field definitions</source>
         <target state="new">Field definitions</target>
         <note>key: content_type.view.edit.content_field_definitions</note>
+      </trans-unit>
+      <trans-unit id="74aead78c735bbbce032dc9b00f9ca7a3632f166" resname="content_type.view.edit.default_header">
+        <source>New field type</source>
+        <target state="new">New field type</target>
+        <note>key: content_type.view.edit.default_header</note>
       </trans-unit>
       <trans-unit id="a32a5e3d2d67da43b4c5f0f5574c90520868b36a" resname="content_type.view.edit.global_properties">
         <source>Global properties</source>

--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -1,3 +1,5 @@
+{% trans_default_domain 'content_type' %}
+
 <div class="ibexa-content-type-edit__field-definitions-group">
     {% set extra_actions = [
         {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4273
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
