### PR TITLE
[Behat] Added ElementTransitionHasEndedCondition to expading field container

### DIFF
--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Page;
 
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
+use Ibexa\Behat\Browser\Element\Condition\ElementTransitionHasEndedCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
@@ -32,6 +33,8 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
         $lastFieldDefinition->mouseOver();
         $lastFieldDefinition->assert()->isVisible();
         $lastFieldDefinition->click();
+        $this->getHTMLPage()->setTimeout(5)
+            ->waitUntilCondition(new ElementTransitionHasEndedCondition($this->getHTMLPage(),$fieldToggleLocator));
         $this->getHTMLPage()->setTimeout(5)
             ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator($locatorValue)));
     }

--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -34,7 +34,7 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
         $lastFieldDefinition->assert()->isVisible();
         $lastFieldDefinition->click();
         $this->getHTMLPage()->setTimeout(5)
-            ->waitUntilCondition(new ElementTransitionHasEndedCondition($this->getHTMLPage(),$fieldToggleLocator));
+            ->waitUntilCondition(new ElementTransitionHasEndedCondition($this->getHTMLPage(), $fieldToggleLocator));
         $this->getHTMLPage()->setTimeout(5)
             ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator($locatorValue)));
     }


### PR DESCRIPTION
This pr intends to fix errors like https://github.com/ibexa/oss/actions/runs/3492262326/jobs/5845848860

It seems that problem is not with drag&drop but rather with fields which are dragged to container and then are expanded.  