### PR TITLE
[Behat] Stability fixes

### DIFF
--- a/src/lib/Behat/Component/Fields/User.php
+++ b/src/lib/Behat/Component/Fields/User.php
@@ -8,7 +8,6 @@ namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
-use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
@@ -31,12 +30,7 @@ class User extends FieldTypeComponent
 
     public function setSpecificFieldValue(string $fieldName, string $value): void
     {
-        $fieldLocator = CSSLocatorBuilder::base($this->parentLocator)
-            ->withDescendant($this->getLocator($fieldName))
-            ->build()
-        ;
-
-        $this->getHTMLPage()->find($fieldLocator)->setValue($value);
+        $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator($fieldName))->setValue($value);
     }
 
     public function getValue(): array
@@ -49,12 +43,7 @@ class User extends FieldTypeComponent
 
     public function getSpecificFieldValue(string $fieldName): string
     {
-        $fieldLocator = CSSLocatorBuilder::base($this->parentLocator)
-            ->withDescendant($this->getLocator($fieldName))
-            ->build()
-        ;
-
-        return $this->getHTMLPage()->find($fieldLocator)->getValue();
+        return $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator($fieldName))->getValue();
     }
 
     public function verifyValue(array $value): void
@@ -95,17 +84,16 @@ class User extends FieldTypeComponent
             new VisibleCSSLocator('password', '#ezplatform_content_forms_user_create_fieldsData_user_account_value_password_first,#ezplatform_content_forms_user_update_fieldsData_user_account_value_password_first'),
             new VisibleCSSLocator('confirmPassword', '#ezplatform_content_forms_user_create_fieldsData_user_account_value_password_second,#ezplatform_content_forms_user_update_fieldsData_user_account_value_password_second'),
             new VisibleCSSLocator('email', '#ezplatform_content_forms_user_create_fieldsData_user_account_value_email,#ezplatform_content_forms_user_update_fieldsData_user_account_value_email'),
-            new CSSLocator('buttonEnabledState', '#ezplatform_content_forms_user_create_fieldsData_user_account_value_enabled,#ezplatform_content_forms_user_update_fieldsData_user_account_value_enabled'),
-            new VisibleCSSLocator('buttonEnabledToggle', '.ibexa-toggle__switcher'),
+            new VisibleCSSLocator('buttonEnabled', '.ibexa-toggle--checkbox'),
             new VisibleCSSLocator('buttonEnabledToggleConfirmation', '.ibexa-toggle--is-checked'),
         ];
     }
 
     private function setEnabledField(bool $enabled)
     {
-        $isCurrentlyEnabled = $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator('buttonEnabledState'))->getValue() === '1';
+        $isCurrentlyEnabled = $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator('buttonEnabled'))->getText() === 'On';
         if ($isCurrentlyEnabled !== $enabled) {
-            $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator('buttonEnabledToggle'))->click();
+            $this->getHTMLPage()->find($this->parentLocator)->find($this->getLocator('buttonEnabled'))->click();
             $this->getHTMLPage()
                 ->setTimeout(10)
                 ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('buttonEnabledToggleConfirmation')));

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -10,6 +10,7 @@ namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
+use Ibexa\Behat\Browser\Element\Condition\ElementHasTextCondition;
 use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
@@ -36,7 +37,13 @@ class UniversalDiscoveryWidget extends Component
 
         if ($this->isMultiSelect()) {
             $this->addItemToMultiSelection($itemName, count($pathParts));
+
+            return;
         }
+
+        $this->getHTMLPage()->setTimeout(5)->waitUntilCondition(
+            new ElementHasTextCondition($this->getHTMLPage(), $this->getLocator('selectedItemName'), $itemName)
+        );
     }
 
     public function confirm(): void
@@ -195,6 +202,7 @@ class UniversalDiscoveryWidget extends Component
             new CSSLocator('selectedTab', '.c-tab-selector__item--selected'),
             new VisibleCSSLocator('iframe', '.c-content-edit__iframe'),
             new VisibleCSSLocator('multiselect', '.m-ud .c-finder-leaf .ibexa-input--checkbox'),
+            new VisibleCSSLocator('selectedItemName', '.c-content-meta-preview__content-name'),
             // selectors for path traversal
             new CSSLocator('treeLevelFormat', '.c-finder-branch:nth-child(%d)'),
             new CSSLocator('treeLevelElementsFormat', '.c-finder-branch:nth-of-type(%d) .c-finder-leaf'),

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -142,7 +142,7 @@ class UniversalDiscoveryWidget extends Component
     {
         $this->getHTMLPage()->findAll($this->getLocator('categoryTabSelector'))
              ->getByCriterion(new ElementAttributeCriterion('data-original-title', $tabName))->click();
-        $this->getHTMLPage()->findAll($this->getLocator('selectedTab'))
+        $this->getHTMLPage()->setTimeout(3)->findAll($this->getLocator('selectedTab'))
              ->getByCriterion(new ElementAttributeCriterion('data-bs-original-title', $tabName))->assert()->isVisible();
     }
 
@@ -214,6 +214,7 @@ class UniversalDiscoveryWidget extends Component
             new CSSLocator('editButton', '.c-content-edit-button__btn'),
             // bookmarks
             new VisibleCSSLocator('bookmarkButton', '.c-content-meta-preview__toggle-bookmark-button'),
+            new VisibleCSSLocator('bookmarkPanel', '.c-bookmarks-list'),
             new VisibleCSSLocator('bookmarkedItem', '.c-bookmarks-list__item-name'),
             new VisibleCSSLocator('markedBookmarkedItem', '.c-bookmarks-list__item--marked'),
             // search


### PR DESCRIPTION
This PR tries to fix three recently common failures:

1) User Creation

Example failure:
https://github.com/ibexa/experience/actions/runs/3527356556/jobs/5916328659

```
     And I set content fields for user                                   # Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext::iSetFieldsForUser()
      | label        | Username | Password   | Confirm password | Email         | Enabled |
      | User account | testuser | Test1234pw | Test1234pw       | test@test.com | Yes     |
      Ibexa\Behat\Browser\Exception\TimeoutException: Element with CSS locator 'buttonEnabledToggleConfirmation': '.ibexa-toggle--is-checked' was not found. Timeout value: 10 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:59
```

2) Switching UDW tabs

Example failure: https://github.com/ibexa/commerce/actions/runs/3596868183/jobs/6058116401
```
     And I change the UDW tab to "Bookmarks"                    # Ibexa\AdminUi\Behat\BrowserContext\UDWContext::changeUDWTab()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element with attribute 'data-bs-original-title' matching value 'Bookmarks'. Found values:  instead. css locator 'selectedTab': '.c-tab-selector__item--selected'. in vendor/ibexa/behat/src/lib/Browser/Element/ElementCollection.php:61
```

3) Selecting items in UDW

https://github.com/ibexa/experience/actions/runs/3615226830/jobs/6092274676
```
        Failed step: When I set up block "VideoBlock" "Video" with default testing configuration
        Ibexa\Behat\Browser\Exception\TimeoutException: Element with CSS locator 'udw': '.m-ud' was found, but it should not exist. Timeout value: 3 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:59
```

This one is most likely caused by too fast actions in UDW, I was able to reproduce it locally:

https://user-images.githubusercontent.com/10993858/205723730-1d3d15ff-fc7c-4bcb-865a-64cd13ff3347.mov

