### PR TITLE
Changed Entrypoint in AdminExceptionListener from "ezplatform" to "ibexa"

### DIFF
--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -107,7 +107,7 @@ class AdminExceptionListener
             // rendered resources it would result in no CSS/JS on error page.
             // Thus we reset TagRenderer to prevent it from breaking error page.
             $this->encoreTagRenderer->reset();
-            $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
+            $this->entrypointLookupCollection->getEntrypointLookup('ibexa')->reset();
         }
 
         switch ($code) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4636](https://issues.ibexa.co/browse/IBX-4636)
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR replaces the no longer used "ezplatform" entry point with "ibexa".

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
