### PR TITLE
IBX-4717: Fixed PolicyChoiceType translation domain configuration

### DIFF
--- a/src/lib/Form/Type/Policy/PolicyChoiceType.php
+++ b/src/lib/Form/Type/Policy/PolicyChoiceType.php
@@ -70,6 +70,7 @@ class PolicyChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'translation_domain' => 'forms',
             'choices' => $this->policyChoices,
         ]);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4717
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR fixes issues with missing role translations on edit limitation page. Caused by missing defaults translation domain configuration.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
