### PR TITLE
IBX-4576: Added a keyup event so that set minutes and hours can be set from the keyboard

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/date.time.picker.js
+++ b/src/bundle/Resources/public/js/scripts/core/date.time.picker.js
@@ -65,10 +65,38 @@
             }
         }
 
+        onKeyUp(isMinute, event) {
+            const inputValue = event.target.value;
+
+            if (inputValue.length === 0) {
+                return;
+            }
+
+            const value = parseInt(inputValue, 10);
+
+            if (typeof value === 'number' && value >= 0) {
+                const flatpickrDate = this.flatpickrInstance.selectedDates[0];
+
+                if (isMinute) {
+                    flatpickrDate.setMinutes(value);
+                } else {
+                    flatpickrDate.setHours(value);
+                }
+
+                if (this.flatpickrConfig.minDate.getTime() > flatpickrDate.getTime()) {
+                    return;
+                }
+
+                this.flatpickrInstance.setDate(flatpickrDate, true);
+            }
+        }
+
         init() {
             this.flatpickrInstance = flatpickr(this.inputField, this.flatpickrConfig);
 
             this.inputField.addEventListener('input', this.onInput, false);
+            this.flatpickrInstance.minuteElement.addEventListener('keyup', this.onKeyUp.bind(this, true), false);
+            this.flatpickrInstance.hourElement.addEventListener('keyup', this.onKeyUp.bind(this, false), false);
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4576](https://issues.ibexa.co/browse/IBX-4576)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Related to https://github.com/ibexa/scheduler/pull/77 (merge up)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
