### PR TITLE
IBX-4629: Implement Meta field groups

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
@@ -29,6 +29,7 @@ class AdminUiForms extends AbstractParser
 {
     public const FORM_TEMPLATES_PARAM = 'admin_ui_forms.content_edit_form_templates';
     public const FIELD_TYPES_PARAM = 'admin_ui_forms.content_edit.fieldtypes';
+    public const META_FIELDGROUP_LIST_PARAM = 'admin_ui_forms.content_edit.meta_fieldgroup_list';
     public const CONTENT_TYPE_FIELD_TYPES_PARAM = 'admin_ui_forms.content_type_edit.field_types';
     public const CONTENT_TYPE_DEFAULT_META_FIELD_TYPE_GROUP_PARAM =
         'admin_ui_forms.content_type_edit.default_meta_field_type_group';
@@ -86,6 +87,12 @@ class AdminUiForms extends AbstractParser
                                         ->end()
                                     ->end()
                                 ->end()
+                            ->end()
+                            ->arrayNode('meta_fieldgroup_list')
+                                ->performNoDeepMerging()
+                                ->scalarPrototype()->end()
+                                ->info('List of field groups that would be placed under a meta section in a content form')
+                                ->defaultValue(['metadata'])
                             ->end()
                         ->end()
                     ->end()
@@ -156,6 +163,12 @@ class AdminUiForms extends AbstractParser
             unset($scopeSettings['admin_ui_forms']['content_edit']['fieldtypes']);
         }
 
+        if (!empty($scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list'])) {
+            $scopeSettings['admin_ui_forms.content_edit.meta_fieldgroup_list'] =
+                $scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list'];
+            unset($scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list']);
+        }
+
         if (!empty($scopeSettings['admin_ui_forms']['content_type_edit']['field_types'])) {
             $scopeSettings['admin_ui_forms.content_type_edit.field_types'] =
                 $scopeSettings['admin_ui_forms']['content_type_edit']['field_types'];
@@ -179,6 +192,11 @@ class AdminUiForms extends AbstractParser
             $scopeSettings['admin_ui_forms.content_edit.fieldtypes'] ?? []
         );
         $contextualizer->setContextualParameter(
+            self::META_FIELDGROUP_LIST_PARAM,
+            $currentScope,
+            $scopeSettings['admin_ui_forms.content_edit.meta_fieldgroup_list'] ?? []
+        );
+        $contextualizer->setContextualParameter(
             self::CONTENT_TYPE_FIELD_TYPES_PARAM,
             $currentScope,
             $scopeSettings['admin_ui_forms.content_type_edit.field_types'] ?? []
@@ -197,6 +215,7 @@ class AdminUiForms extends AbstractParser
     {
         $contextualizer->mapConfigArray('admin_ui_forms.content_edit_form_templates', $config);
         $contextualizer->mapConfigArray('admin_ui_forms.content_edit.fieldtypes', $config);
+        $contextualizer->mapConfigArray('admin_ui_forms.content_edit.meta_fieldgroup_list', $config);
         $contextualizer->mapConfigArray('admin_ui_forms.content_type_edit.field_types', $config);
         $contextualizer->mapSetting('admin_ui_forms.content_type_edit.default_meta_field_type_group', $config);
     }

--- a/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
@@ -29,7 +29,7 @@ class AdminUiForms extends AbstractParser
 {
     public const FORM_TEMPLATES_PARAM = 'admin_ui_forms.content_edit_form_templates';
     public const FIELD_TYPES_PARAM = 'admin_ui_forms.content_edit.fieldtypes';
-    public const META_FIELDGROUP_LIST_PARAM = 'admin_ui_forms.content_edit.meta_fieldgroup_list';
+    public const META_FIELD_GROUPS_LIST_PARAM = 'admin_ui_forms.content_edit.meta_field_groups_list';
     public const CONTENT_TYPE_FIELD_TYPES_PARAM = 'admin_ui_forms.content_type_edit.field_types';
     public const CONTENT_TYPE_DEFAULT_META_FIELD_TYPE_GROUP_PARAM =
         'admin_ui_forms.content_type_edit.default_meta_field_type_group';
@@ -88,7 +88,7 @@ class AdminUiForms extends AbstractParser
                                     ->end()
                                 ->end()
                             ->end()
-                            ->arrayNode('meta_fieldgroup_list')
+                            ->arrayNode('meta_field_groups_list')
                                 ->performNoDeepMerging()
                                 ->scalarPrototype()->end()
                                 ->info('List of field groups that would be placed under a meta section in a content form')
@@ -163,10 +163,10 @@ class AdminUiForms extends AbstractParser
             unset($scopeSettings['admin_ui_forms']['content_edit']['fieldtypes']);
         }
 
-        if (!empty($scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list'])) {
-            $scopeSettings['admin_ui_forms.content_edit.meta_fieldgroup_list'] =
-                $scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list'];
-            unset($scopeSettings['admin_ui_forms']['content_edit']['meta_fieldgroup_list']);
+        if (!empty($scopeSettings['admin_ui_forms']['content_edit']['meta_field_groups_list'])) {
+            $scopeSettings['admin_ui_forms.content_edit.meta_field_groups_list'] =
+                $scopeSettings['admin_ui_forms']['content_edit']['meta_field_groups_list'];
+            unset($scopeSettings['admin_ui_forms']['content_edit']['meta_field_groups_list']);
         }
 
         if (!empty($scopeSettings['admin_ui_forms']['content_type_edit']['field_types'])) {
@@ -192,9 +192,9 @@ class AdminUiForms extends AbstractParser
             $scopeSettings['admin_ui_forms.content_edit.fieldtypes'] ?? []
         );
         $contextualizer->setContextualParameter(
-            self::META_FIELDGROUP_LIST_PARAM,
+            self::META_FIELD_GROUPS_LIST_PARAM,
             $currentScope,
-            $scopeSettings['admin_ui_forms.content_edit.meta_fieldgroup_list'] ?? []
+            $scopeSettings['admin_ui_forms.content_edit.meta_field_groups_list'] ?? []
         );
         $contextualizer->setContextualParameter(
             self::CONTENT_TYPE_FIELD_TYPES_PARAM,
@@ -215,7 +215,7 @@ class AdminUiForms extends AbstractParser
     {
         $contextualizer->mapConfigArray('admin_ui_forms.content_edit_form_templates', $config);
         $contextualizer->mapConfigArray('admin_ui_forms.content_edit.fieldtypes', $config);
-        $contextualizer->mapConfigArray('admin_ui_forms.content_edit.meta_fieldgroup_list', $config);
+        $contextualizer->mapConfigArray('admin_ui_forms.content_edit.meta_field_groups_list', $config);
         $contextualizer->mapConfigArray('admin_ui_forms.content_type_edit.field_types', $config);
         $contextualizer->mapSetting('admin_ui_forms.content_type_edit.default_meta_field_type_group', $config);
     }

--- a/src/bundle/Resources/config/admin_ui_forms.yaml
+++ b/src/bundle/Resources/config/admin_ui_forms.yaml
@@ -2,6 +2,8 @@ system:
     admin_group:
         admin_ui_forms:
             content_edit:
+                meta_fieldgroup_list:
+                    - metadata
                 form_templates:
                     - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }
 

--- a/src/bundle/Resources/config/admin_ui_forms.yaml
+++ b/src/bundle/Resources/config/admin_ui_forms.yaml
@@ -2,7 +2,7 @@ system:
     admin_group:
         admin_ui_forms:
             content_edit:
-                meta_fieldgroup_list:
+                meta_field_groups_list:
                     - metadata
                 form_templates:
                     - { template: '@ibexadesign/content/form_fields.html.twig', priority: 0 }

--- a/src/bundle/Resources/views/themes/admin/content/components/meta_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/components/meta_fields.html.twig
@@ -5,7 +5,7 @@
 {% block sections %}
     {% for identifier in meta_fields %}
         {% embed '@ibexadesign/ui/component/anchor_navigation/section.html.twig' with {'form': form, 'identifier': identifier} %}
-            {% set data_id = 'ibexa-edit-content-sections-meta-' ~ identifier %}
+            {% set data_id = '#ibexa-edit-content-sections-meta-' ~ identifier %}
             {% block content %}
                 {% from '@ibexadesign/content/edit_macros.html.twig' import render_form_field %}
 

--- a/src/lib/Behat/BrowserContext/ContentUpdateContext.php
+++ b/src/lib/Behat/BrowserContext/ContentUpdateContext.php
@@ -51,18 +51,9 @@ class ContentUpdateContext implements Context
     }
 
     /**
-     * @When the :fieldName field in :fieldGroup field group cannot be edited due to limitation
-     */
-    public function theFieldCannotBeEditedDueToLimitation(string $fieldName, string $fieldGroup): void
-    {
-        $this->contentUpdateItemPage->switchToFieldGroup($fieldGroup);
-        $this->contentUpdateItemPage->verifyFieldCannotBeEditedDueToLimitation($fieldName);
-    }
-
-    /**
      * @When the :fieldName field cannot be edited due to limitation
      */
-    public function FieldCannotBeEditedDueToLimitation(string $fieldName): void
+    public function fieldCannotBeEditedDueToLimitation(string $fieldName): void
     {
         $this->contentUpdateItemPage->verifyFieldCannotBeEditedDueToLimitation($fieldName);
     }

--- a/src/lib/Behat/BrowserContext/ContentUpdateContext.php
+++ b/src/lib/Behat/BrowserContext/ContentUpdateContext.php
@@ -60,6 +60,14 @@ class ContentUpdateContext implements Context
     }
 
     /**
+     * @When the :fieldName field cannot be edited due to limitation
+     */
+    public function FieldCannotBeEditedDueToLimitation(string $fieldName): void
+    {
+        $this->contentUpdateItemPage->verifyFieldCannotBeEditedDueToLimitation($fieldName);
+    }
+
+    /**
      * @When I set content fields for user
      */
     public function iSetFieldsForUser(TableNode $table): void
@@ -112,6 +120,15 @@ class ContentUpdateContext implements Context
     {
         $this->contentUpdateItemPage->verifyIsLoaded();
         $this->contentUpdateItemPage->switchToFieldGroup($tabName);
+    }
+
+    /**
+     * @When I switch to :tabName field tab
+     */
+    public function iSwitchToContentGroup(string $tabName)
+    {
+        $this->contentUpdateItemPage->verifyIsLoaded();
+        $this->contentUpdateItemPage->switchToFieldTab($tabName);
     }
 
     /**

--- a/src/lib/Behat/Page/ContentUpdateItemPage.php
+++ b/src/lib/Behat/Page/ContentUpdateItemPage.php
@@ -100,6 +100,7 @@ class ContentUpdateItemPage extends Page
             new VisibleCSSLocator('noneditableFieldClass', 'ibexa-field-edit--eznoneditable'),
             new VisibleCSSLocator('fieldOfType', '.ibexa-field-edit--%s'),
             new VisibleCSSLocator('navigationTabs', '.ibexa-anchor-navigation-menu__sections-item-btn'),
+            new VisibleCSSLocator('navigationGroups', '.ibexa-anchor-navigation-menu__section-groups-item'),
             new VisibleCSSLocator('autosaveIsOnInfo', '.ibexa-autosave__status-on'),
             new VisibleCSSLocator('autosaveSavedInfo', '.ibexa-autosave__status-saved'),
             new VisibleCSSLocator('autosaveIsOffInfo', '.ibexa-autosave__status-off'),
@@ -187,6 +188,17 @@ class ContentUpdateItemPage extends Page
         $this->getHTMLPage()
             ->setTimeout(10)
             ->waitUntilCondition(new ElementHasTextCondition($this->getHTMLPage(), new VisibleCSSLocator('activeSection', '.ibexa-anchor-navigation-menu__sections-item-btn--active'), $tabName));
+    }
+
+    public function switchToFieldTab(string $tabName): void
+    {
+        $this->getHTMLPage()->setTimeout(3)
+            ->findAll($this->getLocator('navigationGroups'))
+            ->getByCriterion(new ElementTextCriterion($tabName))
+            ->click();
+        $this->getHTMLPage()
+            ->setTimeout(10)
+            ->waitUntilCondition(new ElementHasTextCondition($this->getHTMLPage(), new VisibleCSSLocator('activeSection', '.ibexa-anchor-navigation-menu__section-groups-item--active'), $tabName));
     }
 
     public function verifyFieldCannotBeEditedDueToLimitation(string $fieldName)

--- a/src/lib/Behat/Page/ContentUpdateItemPage.php
+++ b/src/lib/Behat/Page/ContentUpdateItemPage.php
@@ -203,7 +203,7 @@ class ContentUpdateItemPage extends Page
 
     public function verifyFieldCannotBeEditedDueToLimitation(string $fieldName)
     {
-        $activeSections = $this->getHTMLPage()->findAll(new VisibleCSSLocator('activeSection', '.ibexa-anchor-navigation-menu__sections-item-btn--active'));
+        $activeSections = $this->getHTMLPage()->findAll(new VisibleCSSLocator('activeSection', '.ibexa-anchor-navigation-menu__section-groups-item--active'));
         $fieldLocator = new VisibleCSSLocator('', sprintf($this
             ->getLocator('fieldGroupNthField')->getSelector(), $activeSections->single()->getAttribute('data-target-id'), $this->getFieldPosition($fieldName)));
         $this->getHTMLPage()->find($fieldLocator)->assert()->hasClass('ibexa-field-edit--disabled');

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -85,7 +85,7 @@ class ContentEditMetaFieldsComponent implements Renderable
         );
 
         return $contentType->fieldDefinitions->filter(
-            static fn (FieldDefinition $field): bool => true === in_array($field->fieldGroup, $metaFieldGroups),
+            static fn (FieldDefinition $field): bool => in_array($field->fieldGroup, $metaFieldGroups, true),
         );
     }
 

--- a/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
+++ b/src/lib/Component/Content/ContentEditMetaFieldsComponent.php
@@ -89,6 +89,9 @@ class ContentEditMetaFieldsComponent implements Renderable
         );
     }
 
+    /**
+     * @return array<string>
+     */
     private function mapMetaFieldDefinitionCollectionToIdentifiers(
         FieldDefinitionCollection $metaFieldDefinitionCollection
     ): array {

--- a/src/lib/EventListener/SetViewParametersListener.php
+++ b/src/lib/EventListener/SetViewParametersListener.php
@@ -283,8 +283,11 @@ class SetViewParametersListener implements EventSubscriberInterface
         $metaFieldIdentifiers = array_keys(
             array_filter(
                 $fieldsData,
-                static fn (FormInterface $field): bool => true
-                    === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+                static fn (FormInterface $field): bool => in_array(
+                    $field->getData()->fieldDefinition->fieldGroup,
+                    $metaFieldGroups,
+                    true
+                )
             )
         );
 

--- a/src/lib/EventListener/SetViewParametersListener.php
+++ b/src/lib/EventListener/SetViewParametersListener.php
@@ -283,7 +283,8 @@ class SetViewParametersListener implements EventSubscriberInterface
         $metaFieldIdentifiers = array_keys(
             array_filter(
                 $fieldsData,
-                static fn (FormInterface $field): bool => true === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+                static fn (FormInterface $field): bool => true
+                    === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
             )
         );
 

--- a/src/lib/EventListener/SetViewParametersListener.php
+++ b/src/lib/EventListener/SetViewParametersListener.php
@@ -278,7 +278,7 @@ class SetViewParametersListener implements EventSubscriberInterface
         }
 
         $metaFieldGroups = $this->configResolver->getParameter(
-            'admin_ui_forms.content_edit.meta_fieldgroup_list'
+            'admin_ui_forms.content_edit.meta_field_groups_list'
         );
         $metaFieldIdentifiers = array_keys(
             array_filter(

--- a/src/lib/EventListener/SetViewParametersListener.php
+++ b/src/lib/EventListener/SetViewParametersListener.php
@@ -27,6 +27,7 @@ use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\View\View;
 use Ibexa\Core\MVC\Symfony\View\ViewEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * @todo It should use ViewEvents::FILTER_VIEW_PARAMETERS event instead.
@@ -276,7 +277,17 @@ class SetViewParametersListener implements EventSubscriberInterface
             $ignoredFieldIdentifiers[] = $fieldIdentifier;
         }
 
-        return $ignoredFieldIdentifiers;
+        $metaFieldGroups = $this->configResolver->getParameter(
+            'admin_ui_forms.content_edit.meta_fieldgroup_list'
+        );
+        $metaFieldIdentifiers = array_keys(
+            array_filter(
+                $fieldsData,
+                static fn (FormInterface $field): bool => true === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+            )
+        );
+
+        return array_merge($ignoredFieldIdentifiers, $metaFieldIdentifiers);
     }
 }
 

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -34,7 +34,8 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
         $metaFieldIdentifiers = array_keys(
             array_filter(
                 $fieldsDataForm,
-                static fn (FormInterface $field): bool => true === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+                static fn (FormInterface $field): bool => true
+                    === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
             )
         );
 

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -34,8 +34,11 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
         $metaFieldIdentifiers = array_keys(
             array_filter(
                 $fieldsDataForm,
-                static fn (FormInterface $field): bool => true
-                    === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+                static fn (FormInterface $field): bool => in_array(
+                    $field->getData()->fieldDefinition->fieldGroup,
+                    $metaFieldGroups,
+                    true
+                )
             )
         );
 
@@ -53,7 +56,7 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
                     $fieldIdentifier = $fieldData->fieldDefinition->identifier;
 
                     return !in_array($fieldTypeIdentifier, $identifiers, true)
-                        && !in_array($fieldIdentifier, $metaFieldIdentifiers);
+                        && !in_array($fieldIdentifier, $metaFieldIdentifiers, true);
                 }
             );
         }

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -42,7 +42,11 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
         foreach ($groupedFields as $group => $fields) {
             $groupedFields[$group] = array_filter(
                 $fields,
-                static function (string $fieldIdentifier) use ($fieldsDataForm, $identifiers, $metaFieldIdentifiers): bool {
+                static function (string $fieldIdentifier) use (
+                    $fieldsDataForm,
+                    $identifiers,
+                    $metaFieldIdentifiers
+                ): bool {
                     $fieldData = $fieldsDataForm[$fieldIdentifier]->getNormData();
                     $fieldTypeIdentifier = $fieldData->fieldDefinition->fieldTypeIdentifier;
                     $fieldIdentifier = $fieldData->fieldDefinition->identifier;

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -81,6 +81,6 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
      */
     private function getMetaFieldGroups(): array
     {
-        return $this->configResolver->getParameter('admin_ui_forms.content_edit.meta_fieldgroup_list');
+        return $this->configResolver->getParameter('admin_ui_forms.content_edit.meta_field_groups_list');
     }
 }

--- a/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
+++ b/src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
@@ -10,6 +10,7 @@ namespace Ibexa\AdminUi\Form\Provider;
 
 use Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Symfony\Component\Form\FormInterface;
 
 final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFieldsProviderInterface
 {
@@ -28,16 +29,26 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
     public function getGroupedFields(array $fieldsDataForm): array
     {
         $identifiers = $this->getMetaFields();
+        $metaFieldGroups = $this->getMetaFieldGroups();
+
+        $metaFieldIdentifiers = array_keys(
+            array_filter(
+                $fieldsDataForm,
+                static fn (FormInterface $field): bool => true === in_array($field->getData()->fieldDefinition->fieldGroup, $metaFieldGroups)
+            )
+        );
 
         $groupedFields = $this->innerGroupedContentFormFieldsProvider->getGroupedFields($fieldsDataForm);
         foreach ($groupedFields as $group => $fields) {
             $groupedFields[$group] = array_filter(
                 $fields,
-                static function (string $fieldIdentifier) use ($fieldsDataForm, $identifiers): bool {
+                static function (string $fieldIdentifier) use ($fieldsDataForm, $identifiers, $metaFieldIdentifiers): bool {
                     $fieldData = $fieldsDataForm[$fieldIdentifier]->getNormData();
                     $fieldTypeIdentifier = $fieldData->fieldDefinition->fieldTypeIdentifier;
+                    $fieldIdentifier = $fieldData->fieldDefinition->identifier;
 
-                    return !in_array($fieldTypeIdentifier, $identifiers, true);
+                    return !in_array($fieldTypeIdentifier, $identifiers, true)
+                        && !in_array($fieldIdentifier, $metaFieldIdentifiers);
                 }
             );
         }
@@ -58,5 +69,13 @@ final class GroupedNonMetaFormFieldsProvider implements GroupedContentFormFields
                 static fn (array $config): bool => true === $config['meta']
             )
         );
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMetaFieldGroups(): array
+    {
+        return $this->configResolver->getParameter('admin_ui_forms.content_edit.meta_fieldgroup_list');
     }
 }

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -126,8 +126,24 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
             static fn (array $config): bool => true === $config['meta']
         ));
 
+        $metaFieldGroups = $this->configResolver->getParameter(
+            'admin_ui_forms.content_edit.meta_fieldgroup_list'
+        );
+        $metaFieldDefinitionCollection = $contentType->fieldDefinitions->filter(
+            static fn (FieldDefinition $field): bool => true === in_array($field->fieldGroup, $metaFieldGroups),
+        );
+
         $items = [];
         $order = 0;
+        foreach ($metaFieldDefinitionCollection as $fieldDefinition) {
+            $order += self::ITEM_ORDER_SPAN;
+            $items[$fieldDefinition->identifier] = $this->createSecondLevelItem(
+                $fieldDefinition->identifier,
+                $fieldDefinition,
+                $order
+            );
+        }
+
         foreach ($metaFieldTypeIdentifiers as $metaFieldTypeIdentifier) {
             if (false === $contentType->hasFieldDefinitionOfType($metaFieldTypeIdentifier)) {
                 continue;
@@ -137,7 +153,9 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
             foreach ($fieldDefinitions as $fieldDefinition) {
                 $fieldDefIdentifier = $fieldDefinition->identifier;
                 $order += self::ITEM_ORDER_SPAN;
-                $items[$fieldDefIdentifier] = $this->createSecondLevelItem($fieldDefIdentifier, $fieldDefinition, $order);
+                if (!isset($items[$fieldDefIdentifier])) {
+                    $items[$fieldDefIdentifier] = $this->createSecondLevelItem($fieldDefIdentifier, $fieldDefinition, $order);
+                }
             }
         }
 

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -130,7 +130,7 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
             'admin_ui_forms.content_edit.meta_field_groups_list'
         );
         $metaFieldDefinitionCollection = $contentType->fieldDefinitions->filter(
-            static fn (FieldDefinition $field): bool => true === in_array($field->fieldGroup, $metaFieldGroups),
+            static fn (FieldDefinition $field): bool => in_array($field->fieldGroup, $metaFieldGroups, true),
         );
 
         $items = [];
@@ -153,9 +153,11 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
             foreach ($fieldDefinitions as $fieldDefinition) {
                 $fieldDefIdentifier = $fieldDefinition->identifier;
                 $order += self::ITEM_ORDER_SPAN;
-                if (!isset($items[$fieldDefIdentifier])) {
-                    $items[$fieldDefIdentifier] = $this->createSecondLevelItem($fieldDefIdentifier, $fieldDefinition, $order);
-                }
+                $items[$fieldDefIdentifier] ??= $this->createSecondLevelItem(
+                    $fieldDefIdentifier,
+                    $fieldDefinition,
+                    $order
+                );
             }
         }
 

--- a/src/lib/Menu/ContentEditAnchorMenuBuilder.php
+++ b/src/lib/Menu/ContentEditAnchorMenuBuilder.php
@@ -127,7 +127,7 @@ class ContentEditAnchorMenuBuilder extends AbstractBuilder implements Translatio
         ));
 
         $metaFieldGroups = $this->configResolver->getParameter(
-            'admin_ui_forms.content_edit.meta_fieldgroup_list'
+            'admin_ui_forms.content_edit.meta_field_groups_list'
         );
         $metaFieldDefinitionCollection = $contentType->fieldDefinitions->filter(
             static fn (FieldDefinition $field): bool => true === in_array($field->fieldGroup, $metaFieldGroups),

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -118,14 +118,14 @@ class AdminUiFormsTest extends TestCase
     }
 
     /**
-     * Test 'meta_fieldgroup_list' fieldtype settings are mapped.
+     * Test 'meta_field_groups_list' fieldtype settings are mapped.
      */
     public function testContentEditMetaFieldgroupListIsMapped(): void
     {
         $scopeSettings = [
             'admin_ui_forms' => [
                 'content_edit' => [
-                    'meta_fieldgroup_list' => [
+                    'meta_field_groups_list' => [
                         'metadata',
                         'seo',
                     ],
@@ -149,7 +149,7 @@ class AdminUiFormsTest extends TestCase
                     [],
                 ],
                 [
-                    AdminUiForms::META_FIELDGROUP_LIST_PARAM,
+                    AdminUiForms::META_FIELD_GROUPS_LIST_PARAM,
                     $currentScope,
                     ['metadata', 'seo'],
                 ],

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -58,7 +58,7 @@ class AdminUiFormsTest extends TestCase
         ];
 
         $this->contextualizer
-            ->expects($this->atLeast(2))
+            ->expects(self::atLeast(2))
             ->method('setContextualParameter')
             ->withConsecutive(
                 [
@@ -99,7 +99,7 @@ class AdminUiFormsTest extends TestCase
         ];
 
         $this->contextualizer
-            ->expects($this->atLeast(2))
+            ->expects(self::atLeast(2))
             ->method('setContextualParameter')
             ->withConsecutive(
                 [
@@ -135,7 +135,7 @@ class AdminUiFormsTest extends TestCase
         $currentScope = 'admin_group';
 
         $this->contextualizer
-            ->expects($this->atLeast(2))
+            ->expects(self::atLeast(2))
             ->method('setContextualParameter')
             ->withConsecutive(
                 [

--- a/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -116,6 +116,47 @@ class AdminUiFormsTest extends TestCase
 
         $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
     }
+
+    /**
+     * Test 'meta_fieldgroup_list' fieldtype settings are mapped.
+     */
+    public function testContentEditMetaFieldgroupListIsMapped(): void
+    {
+        $scopeSettings = [
+            'admin_ui_forms' => [
+                'content_edit' => [
+                    'meta_fieldgroup_list' => [
+                        'metadata',
+                        'seo',
+                    ],
+                ],
+            ],
+        ];
+        $currentScope = 'admin_group';
+
+        $this->contextualizer
+            ->expects($this->atLeast(2))
+            ->method('setContextualParameter')
+            ->withConsecutive(
+                [
+                    AdminUiForms::FORM_TEMPLATES_PARAM,
+                    $currentScope,
+                    [],
+                ],
+                [
+                    AdminUiForms::FIELD_TYPES_PARAM,
+                    $currentScope,
+                    [],
+                ],
+                [
+                    AdminUiForms::META_FIELDGROUP_LIST_PARAM,
+                    $currentScope,
+                    ['metadata', 'seo'],
+                ],
+            );
+
+        $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
+    }
 }
 
 class_alias(AdminUiFormsTest::class, 'EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Configuration\Parser\AdminUiFormsTest');

--- a/tests/lib/EventListener/SetViewParametersListenerTest.php
+++ b/tests/lib/EventListener/SetViewParametersListenerTest.php
@@ -77,7 +77,7 @@ final class SetViewParametersListenerTest extends TestCase
             ->method('getParameter')
             ->withConsecutive(
                 ['admin_ui_forms.content_edit.fieldtypes'],
-                ['admin_ui_forms.content_edit.meta_fieldgroup_list']
+                ['admin_ui_forms.content_edit.meta_field_groups_list']
             )
             ->willReturnOnConsecutiveCalls(
                 [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4629
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

A new configuration has been implemented that allows configuring fieldgroups that would be shown in the "Meta" section in the content form:
```
    system:
        admin_group:
            admin_ui_forms:
                content_edit:
                    meta_field_groups_list:
                       - metadata

```
The default value is set to `metadata`, however, one can configure it to include any of available fieldgroups or even disable this feature:
```
    system:
        admin_group:
            admin_ui_forms:
                content_edit:
                    meta_field_groups_list: []
```
The `meta_fieldgroup_list` configuration is not deeply merged so overriding it is simple.

Also, a minor bug fix was done in order to scroll to a chosen field via an anchor on the left.

Example:
Using a fresh Ibexa DXP installation and the following meta configuration:
```
    system:
        admin_group:
            admin_ui_forms:
                content_edit:
                    meta_field_groups_list:
                       - content
```
with `short_name` being changed to `Metadata` fieldgroup, and `taxonomy_entry_assignment` being set to `meta: true`, one can observe the following:
![image](https://user-images.githubusercontent.com/22300504/212874929-f9af1691-6f2a-41f0-a6d2-253ff509659b.png)

One last thing worth mentioning is that `meta: true` configuration still applies, so we should decide whether to disable it for the `taxonomy` and the `product_catalog` packages and allows developers to decide whether to apply it themselves or leave it as it is for now with an annotation in the Developer Documentation.
// Edit - will be removed from both those packages, however, this configuration still is valid.

**Short summary, both the `meta_field_groups_list` and the `meta: true` configurations are valid.**

Related PRs:
- https://github.com/ibexa/taxonomy/pull/177
- https://github.com/ibexa/product-catalog/pull/868

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
