### PR TITLE
IBX-4929: ChangeOwnerLimitationMapper: Fix phpDoc

### DIFF
--- a/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php
@@ -64,7 +64,7 @@ final class ChangeOwnerLimitationMapper implements LimitationValueMapperInterfac
     }
 
     /**
-     * @return array<?int, string>
+     * @return array<int, string>
      */
     private function getSelectionChoices(): array
     {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fix ChangeOwnerLimitationMapper::getSelectionChoices phpDoc by removing the possibility for the key to be `null`.

From phpDocumentor v3.3.1: `Unable to parse file "vendor/ibexa/admin-ui/src/lib/Limitation/Mapper/ChangeOwnerLimitationMapper.php", an error was detected: An array can have only integers or strings as keys`

- When used as a key, `null` is casted to an empty string so it can't be a key.
-  [`ChangeOwnerLimitation::LIMITATION_VALUE_SELF`](https://github.com/ibexa/core/blob/main/src/contracts/Repository/Values/User/Limitation/ChangeOwnerLimitation.php#L17) should never be `null`.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
