### PR TITLE
[Behat] Removed code reliant on MutationObserver changes

### DIFF
--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -15,6 +15,7 @@ use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
@@ -146,9 +147,20 @@ class UniversalDiscoveryWidget extends Component
     {
         $this->getHTMLPage()->findAll($this->getLocator('categoryTabSelector'))
              ->getByCriterion(new ElementAttributeCriterion('data-original-title', $tabName))->click();
-        $this->getHTMLPage()->setTimeout(5)->find(
-            new VisibleCSSLocator('selectedTab', sprintf('.c-tab-selector__item--selected[data-original-title=%s]', $tabName))
-        )->assert()->isVisible();
+
+        $tabPosition = 1 + array_search(
+            $tabName,
+            $this->getHTMLPage()
+                ->findAll($this->getLocator('categoryTabSelector'))
+                ->mapBy(new ElementTextMapper()),
+            true
+        );
+
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('categoryTabSelector'))
+            ->toArray()[$tabPosition]
+            ->assert()->hasClass('c-tab-selector__item--selected')
+            ->assert()->isVisible();
     }
 
     public function selectBookmark(string $bookmarkName): void

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -15,7 +15,6 @@ use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
-use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
@@ -145,22 +144,11 @@ class UniversalDiscoveryWidget extends Component
 
     public function changeTab($tabName): void
     {
-        $this->getHTMLPage()->findAll($this->getLocator('categoryTabSelector'))
-             ->getByCriterion(new ElementAttributeCriterion('data-original-title', $tabName))->click();
-
-        $tabPosition = 1 + array_search(
-            $tabName,
-            $this->getHTMLPage()
-                ->findAll($this->getLocator('categoryTabSelector'))
-                ->mapBy(new ElementTextMapper()),
-            true
-        );
-
-        $this->getHTMLPage()
+        $tab = $this->getHTMLPage()
             ->findAll($this->getLocator('categoryTabSelector'))
-            ->toArray()[$tabPosition]
-            ->assert()->hasClass('c-tab-selector__item--selected')
-            ->assert()->isVisible();
+            ->getByCriterion(new ElementAttributeCriterion('data-original-title', $tabName));
+        $tab->click();
+        $tab->setTimeout(self::SHORT_TIMEOUT)->waitUntilCondition(new ElementExistsCondition($tab, $this->getLocator('selectedTab')));
     }
 
     public function selectBookmark(string $bookmarkName): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4483
| Bug fix?      | no (issue in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Changed the code to stop relying on `data-original-title` attribute - according to what @GrabowskiM told me it there can be a small delay before the attribute is added (because it's processed by MutationObserver).

Instead of adding a `usleep(100);` I've decided to change the way we verify the tab is loaded.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
