### PR TITLE
IBX-4922: [Product type] Missing translation for validation message for identifier field and notification message

### DIFF
--- a/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
@@ -81,15 +81,15 @@
         <target>Personalization Access</target>
         <note>key: policy.limitation.identifier.personalizationaccess</note>
       </trans-unit>
-      <trans-unit id="9f2e53e094725bbc243ad777547724ab923a31d1" resname="policy.limitation.identifier.role">
-        <source>Role</source>
-        <target>Role</target>
-        <note>key: policy.limitation.identifier.role</note>
-      </trans-unit>
       <trans-unit id="af73694f5c5e5868af7948fb04f0d6bfe7ee6ad4" resname="policy.limitation.identifier.producttype">
         <source>Product Type</source>
         <target>Product Type</target>
         <note>key: policy.limitation.identifier.producttype</note>
+      </trans-unit>
+      <trans-unit id="9f2e53e094725bbc243ad777547724ab923a31d1" resname="policy.limitation.identifier.role">
+        <source>Role</source>
+        <target>Role</target>
+        <note>key: policy.limitation.identifier.role</note>
       </trans-unit>
       <trans-unit id="bb77b27363dad566197a200290f0f0b18baa4705" resname="policy.limitation.identifier.section">
         <source>Section</source>

--- a/src/bundle/Resources/translations/validators.en.xliff
+++ b/src/bundle/Resources/translations/validators.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Content Type identifier may only contain letters from "a" to "z", numbers and underscores.</target>
         <note>key: ez.content_type.identifier.pattern</note>
       </trans-unit>
+      <trans-unit id="e03cdf7df4e43a891269e0bbe734e7bab5cc61eb" resname="ez.content_type.identifier.unique">
+        <source>The Content Type identifier "%identifier%" is used by another Content Type. Enter a unique identifier.</source>
+        <target state="new">The Content Type identifier "%identifier%" is used by another Content Type. Enter a unique identifier.</target>
+        <note>key: ez.content_type.identifier.unique</note>
+      </trans-unit>
       <trans-unit id="7ecfa6bd2c1993d18d067f3abe3acebeb9c2458c" resname="ez.content_type.names">
         <source>Content Type name cannot be blank and cannot be longer than 255 characters.</source>
         <target state="new">Content Type name cannot be blank and cannot be longer than 255 characters.</target>
@@ -25,6 +30,11 @@
         <source>Field definition description cannot be longer than 255 characters.</source>
         <target state="new">Field definition description cannot be longer than 255 characters.</target>
         <note>key: ez.field_definition.descriptions</note>
+      </trans-unit>
+      <trans-unit id="3c8e362f900d886ce75b34d0fd952128612a2b12" resname="ez.field_definition.identifier.unique">
+        <source>The Field definition identifier "%identifier%" is used by another Field definition. Enter a unique identifier.</source>
+        <target state="new">The Field definition identifier "%identifier%" is used by another Field definition. Enter a unique identifier.</target>
+        <note>key: ez.field_definition.identifier.unique</note>
       </trans-unit>
       <trans-unit id="0f7d936836760a506042c4d25cd38c5a30c3d9de" resname="ez.field_definition.names">
         <source>Field definition name cannot be blank cannot be longer than 255 characters.</source>

--- a/src/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
+++ b/src/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
@@ -6,12 +6,14 @@
  */
 namespace Ibexa\AdminUi\Validator\Constraints;
 
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
  */
-class UniqueContentTypeIdentifier extends Constraint
+class UniqueContentTypeIdentifier extends Constraint implements TranslationContainerInterface
 {
     /**
      * %identifier% placeholder is passed.
@@ -19,6 +21,14 @@ class UniqueContentTypeIdentifier extends Constraint
      * @var string
      */
     public $message = 'ez.content_type.identifier.unique';
+
+    public static function getTranslationMessages()
+    {
+        return [
+            Message::create('ez.content_type.identifier.unique', 'validators')
+                ->setDesc('The Content Type identifier "%identifier%" is used by another Content Type. Enter a unique identifier.'),
+        ];
+    }
 
     public function validatedBy()
     {

--- a/src/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
+++ b/src/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
@@ -22,7 +22,10 @@ class UniqueContentTypeIdentifier extends Constraint implements TranslationConta
      */
     public $message = 'ez.content_type.identifier.unique';
 
-    public static function getTranslationMessages()
+    /**
+     * @return array<\JMS\TranslationBundle\Model\Message>
+     */
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ez.content_type.identifier.unique', 'validators')

--- a/src/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
+++ b/src/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
@@ -22,7 +22,10 @@ class UniqueFieldDefinitionIdentifier extends Constraint implements TranslationC
      */
     public $message = 'ez.field_definition.identifier.unique';
 
-    public static function getTranslationMessages()
+    /**
+     * @return array<\JMS\TranslationBundle\Model\Message>
+     */
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ez.field_definition.identifier.unique', 'validators')

--- a/src/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
+++ b/src/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
@@ -6,12 +6,14 @@
  */
 namespace Ibexa\AdminUi\Validator\Constraints;
 
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
  */
-class UniqueFieldDefinitionIdentifier extends Constraint
+class UniqueFieldDefinitionIdentifier extends Constraint implements TranslationContainerInterface
 {
     /**
      * %identifier% placeholder is passed.
@@ -19,6 +21,14 @@ class UniqueFieldDefinitionIdentifier extends Constraint
      * @var string
      */
     public $message = 'ez.field_definition.identifier.unique';
+
+    public static function getTranslationMessages()
+    {
+        return [
+            Message::create('ez.field_definition.identifier.unique', 'validators')
+                ->setDesc('The Field definition identifier "%identifier%" is used by another Field definition. Enter a unique identifier.'),
+        ];
+    }
 
     public function getTargets()
     {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4922
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
