### PR TITLE
IBX-4937: Content Tree has CSS issues when loading plenty of children under a node

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/content-tree/_list.item.scss
@@ -181,7 +181,7 @@
     .c-list {
         opacity: 0;
         list-style: none;
-        max-height: 0;
+        display: none;
         max-width: 0;
         overflow: hidden;
     }
@@ -220,7 +220,7 @@
 
         > .c-list {
             opacity: 1;
-            max-height: calculateRem(20000px);
+            display: block;
             max-width: initial;
             overflow: initial;
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4937
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
This is fix for OSS version. For Content and above fix is in Tree Builder bundle: 

To whomever testing this - after clicking enter for executing script, you can go make a tea, script to generate 2000 contents takes around 10 minutes. ;)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
