### PR TITLE
IBX-4993 changed content_fields.html.twig to display table header for single/multiple relation in preview

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -349,6 +349,7 @@
                 { content: 'ezobjectrelationlist.content_type'|trans|desc('Content Type') },
                 { content: 'ezobjectrelationlist.created'|trans|desc('Created') },
             ],
+            show_head_cols_if_empty: true,
         } %}
             {% block tbody %}
                 {% for contentId in field.value.destinationContentIds %}
@@ -494,6 +495,7 @@
                 { content: 'ezobjectrelation.content_type'|trans|desc('Content Type') },
                 { content: 'ezobjectrelation.version_created'|trans|desc('Version created') },
             ],
+            show_head_cols_if_empty: true,
         } %}
             {% block tbody %}
                 {% embed '@ibexadesign/ui/component/table/table_body_row.html.twig' with { field: field } %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4993](https://issues.ibexa.co/browse/IBX-4993)
| Bug fix?      |no
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Changed template to display table headers for single/multiple relations fields in the content preview


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
