### PR TITLE
[Behat] Increased timeout when searching for subitem headers

### DIFF
--- a/src/lib/Behat/Component/SubItemsList.php
+++ b/src/lib/Behat/Component/SubItemsList.php
@@ -46,14 +46,20 @@ class SubItemsList extends Component
             return;
         }
 
-        $header = $this->getHTMLPage()->findAll($this->getLocator('horizontalHeaders'))->getByCriterion(new ElementTextCriterion($columnName));
+        $header = $this->getHTMLPage()
+            ->setTimeout(3)
+            ->findAll($this->getLocator('horizontalHeaders'))
+            ->getByCriterion(new ElementTextCriterion($columnName));
         $header->mouseOver();
         usleep(100 * 2500); // 250 ms TODO: Remove after redesign
         $header->click();
         $isSortedDescending = $this->getHTMLPage()->findAll($this->getLocator('sortingOrderDescending'))->any();
 
         if (!$isSortedDescending && !$ascending) {
-            $header = $this->getHTMLPage()->findAll($this->getLocator('horizontalHeaders'))->getByCriterion(new ElementTextCriterion($columnName));
+            $header = $this->getHTMLPage()
+                ->setTimeout(3)
+                ->findAll($this->getLocator('horizontalHeaders'))
+                ->getByCriterion(new ElementTextCriterion($columnName));
             $header->mouseOver();
             usleep(100 * 2500); // 250 ms TODO: Remove after redesign
             $header->click();


### PR DESCRIPTION
Example failure:
https://github.com/ibexa/experience/actions/runs/4088165529/jobs/7049534493

```
       | root/FolderGrandParent/FolderParent/FolderChild1 | NewContent2 | NewContent2Edited | root/FolderGrandParent/FolderParent/FolderChild1 |
      | root/FolderGrandParent/FolderParent              | NewContent1 | NewContent1Edited | root/FolderGrandParent/FolderParent              |
        Failed step: Given I navigate to content "NewContent1" of type "DedicatedFolder" in "root/FolderGrandParent/FolderParent"
        Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'Modified'. Collection is empty. CSS locator 'horizontalHeaders': '.m-sub-items .ibexa-table__header-cell'. in vendor/ibexa/behat/src/lib/Browser/Element/ElementCollection.php:61
```

![obraz](https://user-images.githubusercontent.com/10993858/216934745-77b269c9-e5db-4fe8-aee2-5fc064ba82af.png)

Increasing the timeout should do the trick 🤞 