### PR TITLE
IBX-4681: Cannot swap sections with D&D in Content/Product Type

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -13,7 +13,7 @@
         class="ibexa-content-type-edit__field-definitions-group-list"
         data-template="{{ include("@ibexadesign/ui/component/collapse.html.twig", {
             'is_expanded': false,
-            'is_draggable': false,
+            'is_draggable': true,
             'class': 'ibexa-collapse--field-definition ibexa-collapse--field-definition-highlight ibexa-collapse--field-definition-loading',
             'body_id': 'loading-collapse',
             'header_label': 'content_type.view.edit.default_header'|trans|desc('New field type') ~ ' ({{ type }})',

--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -36,6 +36,7 @@
                 'ibexa-collapse--field-definitions-group ibexa-field-definitions-group-%s'|format(id),
                 field_defintions is empty and not loop.first or loop.first and not should_show_first and field_defintions is empty ? 'ibexa-collapse--hidden'
             ] %}
+            {% set is_field_definition_draggable = is_draggable ?? true %}
 
             {%- embed "@ibexadesign/ui/component/collapse.html.twig" with {
                 'class': field_definitions_group_class|join(' '),
@@ -63,7 +64,7 @@
                             {%- include "@ibexadesign/content_type/field_definitions_empty_group.html.twig" -%}
 
                             {% for field_definition in field_defintions %}
-                                {{ include('@ibexadesign/content_type/field_definition.html.twig', { is_draggable: is_draggable ?? true}) }}
+                                {{ include('@ibexadesign/content_type/field_definition.html.twig', { is_draggable: is_field_definition_draggable }) }}
                             {% endfor %}
                         {% endblock %}
                     </div>

--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -13,7 +13,7 @@
         class="ibexa-content-type-edit__field-definitions-group-list"
         data-template="{{ include("@ibexadesign/ui/component/collapse.html.twig", {
             'is_expanded': false,
-            'is_draggable': true,
+            'is_draggable': false,
             'class': 'ibexa-collapse--field-definition ibexa-collapse--field-definition-highlight ibexa-collapse--field-definition-loading',
             'body_id': 'loading-collapse',
             'header_label': 'content_type.view.edit.default_header'|trans|desc('New field type') ~ ' ({{ type }})',
@@ -42,6 +42,7 @@
                 'body_id': '%s_collapse'|format(id),
                 'header_label': id | ibexa_field_group_name,
                 'is_expanded': true,
+                'is_draggable': false,
                 'extra_actions': [
                     {
                         'icon_name': 'discard',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4681
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
As discussed with backend team, it's not possible to customize section order per CT, so we remove icon and possibility to drag sections (which does nothing in fact).


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
