### PR TITLE
IBX-4386: Removed argument binding to prevent breaking external libraries

### DIFF
--- a/src/bundle/Resources/config/services/events.yaml
+++ b/src/bundle/Resources/config/services/events.yaml
@@ -3,8 +3,6 @@ services:
         autowire: true
         autoconfigure: true
         public: false
-        bind:
-            string $logLevel: 'error'
 
     Ibexa\AdminUi\EventListener\:
         resource: "../../../lib/EventListener/*"
@@ -38,6 +36,7 @@ services:
             $kernelEnvironment: '%kernel.environment%'
             $encoreTagRenderer: '@webpack_encore.tag_renderer'
             $entrypointLookupCollection: '@webpack_encore.entrypoint_lookup_collection'
+            $logLevel: 'error'
         tags:
             - { name: kernel.event_listener, event: kernel.exception }
             - { name: monolog.logger, channel: ibexa.admin }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4386](https://issues.ibexa.co/browse/IBX-4386)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR fixes an issue that occurs in other libraries making use of `admin-ui`:
```
Error in bootstrap script: Symfony\Component\DependencyInjection\Exception\InvalidArgumentException:
A binding is configured for an argument of type "string" named "$logLevel" under "_defaults" in file "/.../admin-ui/src/bundle/DependencyInjection/../Resources/config/services/events.yaml", but no corresponding argument has been found. It may be unused and should be removed, or it may have a typo.
```

I have no idea why this happens, as service using this argument is defined in the same file, but without removing it it is not possible for external tests to pass.

Note that admin-ui does not use newer integration tests, which might be why it went undetected.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
