### PR TITLE
IBX-5018: Unified 'Create' buttons in Content Types and Content Type Groups lists

### DIFF
--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -273,6 +273,7 @@ class ContentTypeGroupController extends Controller
             'content_type_group' => $group,
             'page' => $page,
             'route_name' => $request->get('_route'),
+            'can_create' => $this->isGranted(new Attribute('class', 'create')),
         ]);
     }
 

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -331,6 +331,11 @@
         <target state="new">Some of the Fields are disabled when translating a Content Type. To modify them, edit the Content Type in the main language.</target>
         <note>key: content_type.view.edit.notranslatable_fields_disabled</note>
       </trans-unit>
+      <trans-unit id="803a61fc8cf4e7bdfcf27432bb35e379a4971134" resname="content_type.view.list.action.add">
+        <source>Create</source>
+        <target state="new">Create</target>
+        <note>key: content_type.view.list.action.add</note>
+      </trans-unit>
       <trans-unit id="da5f710198c48c803b3d0e2272e488903f92e569" resname="content_type.view.list.cannot_delete_notice">
         <source>You cannot delete the disabled Content Types, because Content items of those types exist.</source>
         <target state="new">You cannot delete the disabled Content Types, because Content items of those types exist.</target>

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/index.html.twig
@@ -18,6 +18,30 @@
     } %}
 {% endblock %}
 
+{% block context_menu %}
+    {% set menu_items %}
+        {% if can_create %}
+            <li class="ibexa-context-menu__item ibexa-adaptive-items__item">
+                <a
+                    href="{{ path('ibexa.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
+                    class="btn ibexa-btn ibexa-btn--primary"
+                >
+                    <svg class="ibexa-icon ibexa-icon--small ibexa-icon--create">
+                        <use xlink:href="{{ ibexa_icon_path('create') }}"></use>
+                    </svg>
+                    <span class="ibexa-btn__label">
+                        {{ 'content_type.view.list.action.add'|trans|desc('Create') }}
+                    </span>
+                </a>
+            </li>
+        {% endif %}
+    {% endset %}
+
+    {{ include('@ibexadesign/ui/component/context_menu/context_menu.html.twig', {
+        menu_items: menu_items,
+    }) }}
+{% endblock %}
+
 {% block content %}
     {{ render(controller('Ibexa\\Bundle\\AdminUi\\Controller\\ContentTypeController::listAction', {
         contentTypeGroupId: content_type_group.id,

--- a/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
@@ -94,19 +94,6 @@
         {% block header %}
             {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}
                 {% block actions %}
-                    {% if can_create %}
-                        <a
-                            href="{{ path('ibexa.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
-                            class="btn ibexa-btn ibexa-btn--tertiary ibexa-btn--small"
-                        >
-                            <svg class="ibexa-icon ibexa-icon--small ibexa-icon--create">
-                                <use xlink:href="{{ ibexa_icon_path('create') }}"></use>
-                            </svg>
-                            <span class="ibexa-btn__label">
-                                {{ 'content_type.view.list.action.add'|trans|desc('Add new') }}
-                            </span>
-                        </a>
-                    {% endif %}
                     {% if can_delete %}
                         {% set modal_data_target = 'delete-content-types-modal' %}
                         <button


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5018
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Updated Content Type list template to match Content Type Group list template when it comes to the 'Create' buttons.

After:
![image](https://user-images.githubusercontent.com/22300504/222206195-a925b505-93d0-4de6-ab27-321990cff968.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
