### PR TITLE
IBX-5121: Streamlined SiteaccessResolverInterface

### DIFF
--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -72,7 +72,9 @@ services:
 
     Ibexa\AdminUi\Form\Type\Content\ContentVisibilityUpdateType: ~
 
-    Ibexa\AdminUi\Form\Type\Content\CustomUrl\CustomUrlAddType: ~
+    Ibexa\AdminUi\Form\Type\Content\CustomUrl\CustomUrlAddType:
+        arguments:
+            $siteAccessNameGenerator: '@Ibexa\AdminUi\Siteaccess\SiteAccessNameGenerator'
 
     Ibexa\AdminUi\Form\Type\Content\CustomUrl\CustomUrlRemoveType: ~
 

--- a/src/bundle/Resources/config/services/menu.yaml
+++ b/src/bundle/Resources/config/services/menu.yaml
@@ -41,6 +41,8 @@ services:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.trash.sidebar_right }
 
     Ibexa\AdminUi\Menu\ContentEditRightSidebarBuilder:
+        arguments:
+            $siteaccessResolver: '@Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver'
         public: true
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.content_edit.sidebar_right }

--- a/src/lib/Component/Content/PreviewUnavailableTwigComponent.php
+++ b/src/lib/Component/Content/PreviewUnavailableTwigComponent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Component\Content;
 
-use Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\Contracts\AdminUi\Component\Renderable;
 use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
@@ -33,7 +33,7 @@ class PreviewUnavailableTwigComponent implements Renderable
      */
     public function __construct(
         Environment $twig,
-        NonAdminSiteaccessResolver $siteaccessResolver,
+        SiteaccessResolverInterface $siteaccessResolver,
         LocationService $locationService
     ) {
         $this->twig = $twig;
@@ -63,7 +63,7 @@ class PreviewUnavailableTwigComponent implements Renderable
             $versionNo = null;
         }
 
-        $siteaccesses = $this->siteaccessResolver->getSiteaccessesForLocation(
+        $siteaccesses = $this->siteaccessResolver->getSiteAccessesListForLocation(
             $location,
             $versionNo,
             $language->languageCode

--- a/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
@@ -8,7 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Form\Type\ChoiceList\Loader;
 
-use Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver;
+use Ibexa\AdminUi\Siteaccess\SiteAccessNameGeneratorInterface;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
@@ -16,37 +17,35 @@ use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 class SiteAccessChoiceLoader implements ChoiceLoaderInterface
 {
     /** @var \Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver */
-    private $nonAdminSiteaccessResolver;
+    private SiteaccessResolverInterface $nonAdminSiteaccessResolver;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null */
     private $location;
 
+    private SiteAccessNameGeneratorInterface $siteAccessNameGenerator;
+
     public function __construct(
-        NonAdminSiteaccessResolver $nonAdminSiteaccessResolver,
+        SiteaccessResolverInterface $nonAdminSiteaccessResolver,
+        SiteAccessNameGeneratorInterface $siteAccessNameGenerator,
         ?Location $location = null
     ) {
         $this->nonAdminSiteaccessResolver = $nonAdminSiteaccessResolver;
         $this->location = $location;
+        $this->siteAccessNameGenerator = $siteAccessNameGenerator;
     }
 
     /**
-     * Provides data in format:
-     * [
-     *     site_access => location_id,
-     *     ...
-     * ].
-     *
-     * @return int[]
+     * @return array<string, string>
      */
     public function getChoiceList(): array
     {
         $siteAccesses = $this->location === null
-            ? $this->nonAdminSiteaccessResolver->getSiteaccesses()
-            : $this->nonAdminSiteaccessResolver->getSiteaccessesForLocation($this->location);
+            ? $this->nonAdminSiteaccessResolver->getSiteAccessesList()
+            : $this->nonAdminSiteaccessResolver->getSiteAccessesListForLocation(($this->location));
 
         $data = [];
         foreach ($siteAccesses as $siteAccess) {
-            $data[$siteAccess] = $siteAccess;
+            $data[$this->siteAccessNameGenerator->generate($siteAccess)] = $siteAccess->name;
         }
 
         return $data;

--- a/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
@@ -45,7 +45,8 @@ class SiteAccessChoiceLoader implements ChoiceLoaderInterface
 
         $data = [];
         foreach ($siteAccesses as $siteAccess) {
-            $data[$this->siteAccessNameGenerator->generate($siteAccess)] = $siteAccess->name;
+            $siteAccessKey = $this->siteAccessNameGenerator->generate($siteAccess);
+            $data[$siteAccessKey] = $siteAccess->name;
         }
 
         return $data;

--- a/src/lib/Form/Type/Content/CustomUrl/CustomUrlAddType.php
+++ b/src/lib/Form/Type/Content/CustomUrl/CustomUrlAddType.php
@@ -13,7 +13,8 @@ use Ibexa\AdminUi\Form\EventListener\BuildPathFromRootListener;
 use Ibexa\AdminUi\Form\EventListener\DisableSiteRootCheckboxIfRootLocationListener;
 use Ibexa\AdminUi\Form\Type\ChoiceList\Loader\SiteAccessChoiceLoader;
 use Ibexa\AdminUi\Form\Type\Content\LocationType;
-use Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver;
+use Ibexa\AdminUi\Siteaccess\SiteAccessNameGeneratorInterface;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\Contracts\Core\Repository\LanguageService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
@@ -41,18 +42,22 @@ class CustomUrlAddType extends AbstractType
     /** @var \Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver */
     private $nonAdminSiteaccessResolver;
 
+    private SiteAccessNameGeneratorInterface $siteAccessNameGenerator;
+
     public function __construct(
         LanguageService $languageService,
         AddLanguageFieldBasedOnContentListener $addLanguageFieldBasedOnContentListener,
         BuildPathFromRootListener $buildPathFromRootListener,
         DisableSiteRootCheckboxIfRootLocationListener $checkboxIfRootLocationListener,
-        NonAdminSiteaccessResolver $nonAdminSiteaccessResolver
+        SiteaccessResolverInterface $nonAdminSiteaccessResolver,
+        SiteAccessNameGeneratorInterface $siteAccessNameGenerator
     ) {
         $this->languageService = $languageService;
         $this->addLanguageFieldBasedOnContentListener = $addLanguageFieldBasedOnContentListener;
         $this->buildPathFromRootListener = $buildPathFromRootListener;
         $this->checkboxIfRootLocationListener = $checkboxIfRootLocationListener;
         $this->nonAdminSiteaccessResolver = $nonAdminSiteaccessResolver;
+        $this->siteAccessNameGenerator = $siteAccessNameGenerator;
     }
 
     /**
@@ -107,6 +112,7 @@ class CustomUrlAddType extends AbstractType
                     'required' => false,
                     'choice_loader' => new SiteAccessChoiceLoader(
                         $this->nonAdminSiteaccessResolver,
+                        $this->siteAccessNameGenerator,
                         $location
                     ),
                 ]

--- a/src/lib/Menu/ContentEditRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentEditRightSidebarBuilder.php
@@ -7,7 +7,7 @@
 namespace Ibexa\AdminUi\Menu;
 
 use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
-use Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
 use Ibexa\Contracts\Core\Limitation\Target;
 use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
@@ -53,7 +53,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
     public function __construct(
         MenuItemFactory $factory,
         EventDispatcherInterface $eventDispatcher,
-        NonAdminSiteaccessResolver $siteaccessResolver,
+        SiteaccessResolverInterface $siteaccessResolver,
         PermissionResolver $permissionResolver,
         LocationService $locationService,
         TranslatorInterface $translator
@@ -202,7 +202,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
             $versionNo = null;
         }
 
-        $siteaccesses = $this->siteaccessResolver->getSiteaccessesForLocation(
+        $siteAccesses = $this->siteaccessResolver->getSiteAccessesListForLocation(
             $location,
             $versionNo,
             $language->languageCode
@@ -223,7 +223,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
         return $this->createMenuItem(
             self::ITEM__PREVIEW,
             [
-                'attributes' => $canPreview && !empty($siteaccesses)
+                'attributes' => $canPreview && !empty($siteAccesses)
                     ? $previewAttributes
                     : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
                 'extras' => [

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Siteaccess;
 
 use Ibexa\AdminUi\Specification\SiteAccess\IsAdmin;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 
@@ -38,8 +39,9 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
         int $versionNo = null,
         string $languageCode = null
     ): array {
-        return $this->filter(
-            $this->siteaccessResolver->getSiteaccessesForLocation($location, $versionNo, $languageCode)
+        return array_column(
+            $this->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
+            'name'
         );
     }
 
@@ -53,20 +55,24 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
     ): array {
         return array_filter(
             $this->siteaccessResolver->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
-            function ($siteAccess) {
-                return !$this->isAdminSiteAccess($siteAccess);
-            }
+            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
         );
     }
 
-    public function getSiteaccesses(): array
+    public function getSiteAccessesListForContent(Content $content): array
     {
-        return $this->filter($this->siteaccessResolver->getSiteaccesses());
+        return array_filter(
+            $this->siteaccessResolver->getSiteAccessesListForContent($content),
+            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
+        );
     }
 
-    private function filter(array $siteaccesses): array
+    public function getSiteAccessesList(): array
     {
-        return array_diff($siteaccesses, $this->siteAccessGroups['admin_group']);
+        return array_filter(
+            $this->siteaccessResolver->getSiteAccessesList(),
+            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
+        );
     }
 
     private function isAdminSiteAccess(SiteAccess $siteAccess): bool

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -55,7 +55,7 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
     ): array {
         return array_filter(
             $this->siteaccessResolver->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
-            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
+            fn (SiteAccess $siteAccess): bool => !$this->isAdminSiteAccess($siteAccess)
         );
     }
 
@@ -63,7 +63,7 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
     {
         return array_filter(
             $this->siteaccessResolver->getSiteAccessesListForContent($content),
-            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
+            fn (SiteAccess $siteAccess): bool => !$this->isAdminSiteAccess($siteAccess)
         );
     }
 
@@ -71,7 +71,7 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
     {
         return array_filter(
             $this->siteaccessResolver->getSiteAccessesList(),
-            fn (SiteAccess $siteAccess) => !$this->isAdminSiteAccess($siteAccess)
+            fn (SiteAccess $siteAccess): bool => !$this->isAdminSiteAccess($siteAccess)
         );
     }
 

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -75,6 +75,14 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
         );
     }
 
+    public function getSiteaccesses(): array
+    {
+        return array_column(
+            $this->getSiteAccessesList(),
+            'name'
+        );
+    }
+
     private function isAdminSiteAccess(SiteAccess $siteAccess): bool
     {
         return (new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($siteAccess);

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -59,6 +59,15 @@ class SiteaccessResolver implements SiteaccessResolverInterface
         int $versionNo = null,
         string $languageCode = null
     ): array {
+        @trigger_error(
+            sprintf(
+                'The "%s" method is deprecated since Ibexa DXP 4.5.0. Use "%s" instead.',
+                '\Ibexa\AdminUi\Siteaccess\SiteaccessResolver::getSiteaccessesForLocation',
+                '\Ibexa\AdminUi\Siteaccess\SiteaccessResolver::getSiteAccessesList'
+            ),
+            E_USER_DEPRECATED
+        );
+
         return array_column($this->getSiteAccessesListForLocation($location, $versionNo, $languageCode), 'name');
     }
 

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -116,6 +116,14 @@ class SiteaccessResolver implements SiteaccessResolverInterface
         return array_unique($siteAccesses);
     }
 
+    public function getSiteaccesses(): array
+    {
+        return array_column(
+            $this->getSiteAccessesList(),
+            'name'
+        );
+    }
+
     public function getSiteAccessesList(): array
     {
         return iterator_to_array($this->siteAccessService->getAll());

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Siteaccess;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 
 interface SiteaccessResolverInterface
@@ -20,6 +21,8 @@ interface SiteaccessResolverInterface
      * @param string|null $languageCode
      *
      * @return array
+     *
+     * @deprecated use \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesListForLocation instead
      */
     public function getSiteaccessesForLocation(
         Location $location,
@@ -28,8 +31,6 @@ interface SiteaccessResolverInterface
     ): array;
 
     /**
-     * Returns a complete list of Site Access objects.
-     *
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
     public function getSiteAccessesListForLocation(
@@ -39,11 +40,14 @@ interface SiteaccessResolverInterface
     ): array;
 
     /**
-     * Returns a complete list of Site Access names.
-     *
-     * @return array
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
-    public function getSiteaccesses(): array;
+    public function getSiteAccessesListForContent(Content $content): array;
+
+    /**
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
+     */
+    public function getSiteAccessesList(): array;
 }
 
 class_alias(SiteaccessResolverInterface::class, 'EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface');

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -48,6 +48,14 @@ interface SiteaccessResolverInterface
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
     public function getSiteAccessesList(): array;
+
+    /**
+     * @deprecated use \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesList instead.
+     * Returns a complete list of Site Access names.
+     *
+     * @return array
+     */
+    public function getSiteaccesses(): array;
 }
 
 class_alias(SiteaccessResolverInterface::class, 'EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface');

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -22,7 +22,8 @@ interface SiteaccessResolverInterface
      *
      * @return array
      *
-     * @deprecated use \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesListForLocation instead
+     * @deprecated Deprecated since Ibexa DXP 4.5.0.
+     * Use { @see \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesList } instead.
      */
     public function getSiteaccessesForLocation(
         Location $location,

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -20,7 +20,7 @@ interface SiteaccessResolverInterface
      * @param int|null $versionNo
      * @param string|null $languageCode
      *
-     * @return array
+     * @return string[]
      *
      * @deprecated Deprecated since Ibexa DXP 4.5.0.
      * Use { @see \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesList } instead.
@@ -54,7 +54,7 @@ interface SiteaccessResolverInterface
      * @deprecated use \Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteAccessesList instead.
      * Returns a complete list of Site Access names.
      *
-     * @return array
+     * @return string[]
      */
     public function getSiteaccesses(): array;
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5121
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no(?)
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a part of changes, I moved `\Ibexa\PageBuilder\Siteaccess\SiteaccessService::resolveSiteAccessForContent` into  `\Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface` as it seems that is a proper place for it. As additional cleanup, I had deprecated `\Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface::getSiteaccessesForLocation` as `getSiteAccessesListForLocation` does basically the same thing, and the naming is quite confusing - same thing was done for `getSiteaccesses` method.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
