### PR TITLE
[Behat] Keep only inline custom styles to calculate offset

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -188,7 +188,9 @@ class RichText extends FieldTypeComponent
 
     private function getCustomStylesOffset(): int
     {
-        return count($this->customStyleProvider->getConfiguration());
+        return count(array_filter($this->customStyleProvider->getConfiguration(), static function (array $config): bool {
+            return $config['inline'] === true;
+        }));
     }
 
     private function clickElementsToolbarButton(int $buttonPosition): void


### PR DESCRIPTION
Needed for https://github.com/ibexa/recipes-dev/pull/55 and https://github.com/ibexa/admin-ui-assets/pull/17

This PR changes how the offset is calculated when Custom Styles are used - only the inline ones are counted.