### PR TITLE
IBX-5280: Added constraint LocationIsContainer to parentLocation in ContentCreateData

### DIFF
--- a/src/lib/Form/Data/Content/Draft/ContentCreateData.php
+++ b/src/lib/Form/Data/Content/Draft/ContentCreateData.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Form\Data\Content\Draft;
 
+use Ibexa\AdminUi\Validator\Constraints as AdminUiAssert;
 use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -20,7 +21,11 @@ class ContentCreateData
     /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|null */
     protected $contentType;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null */
+    /**
+     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null
+     *
+     * @AdminUiAssert\LocationIsContainer()
+     */
     protected $parentLocation;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language|null */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-5280](https://issues.ibexa.co/browse/IBX-5280)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
