### PR TITLE
IBX-5369: Fixed admin notifications request being queued too often

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -169,10 +169,11 @@
 
     modal.querySelectorAll(SELECTOR_MODAL_RESULTS).forEach((link) => link.addEventListener('click', handleModalResultsClick, false));
 
-    const loop = function loop() {
-        global.setTimeout(() => {
-            getNotificationsStatus().then(() => loop());
-        }, INTERVAL)
-    }
-    getNotificationsStatus().then(() => loop());
+    const getNotificationsStatusLoop = () => {
+        getNotificationsStatus().finally(() => {
+            global.setTimeout(getNotificationsStatusLoop, INTERVAL);
+        });
+    };
+
+    getNotificationsStatusLoop();
 })(window, window.document, window.ibexa, window.Translator);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5369
| Bug fix?      | yes (kinda)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR replaces `setInterval` function call with `setTimeout`.

This is done to prevent notification requests being queued regardless of the state of the previous request. For development environments, especially with multiple tabs open, this can cause local server to become overwhelmed by long-running requests, especially when clearing cache or performing other operations which require application container to be recompiled, like changing configuration.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
