### PR TITLE
IBX-4929: TrashController::listAction: remove @internal

### DIFF
--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -101,9 +101,6 @@ class TrashController extends Controller
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @internal param int $page Current page
-     * @internal param int $limit Number of items per page
-     *
      * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \LogicException


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | n/a
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

`TrashController::listAction` method was ignored by phpDocumentor because of two `@internal` tags. As those tags seems meaningless, I propose their removal.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
