### PR TITLE
IBX-5361: Use NotCompromisedPassword constraint

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -817,8 +817,8 @@
         <note>key: field_definition.ezuser.require_at_least_one_non_alphanumeric_character</note>
       </trans-unit>
       <trans-unit id="283d87c7f3e760a02fde52274ed0a4a8523d2a0d" resname="field_definition.ezuser.require_not_compromised_password">
-        <source>Password must not be contained in a public breach</source>
-        <target state="new">Password must not be contained in a public breach</target>
+        <source>Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.</source>
+        <target state="new">Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.</target>
         <note>key: field_definition.ezuser.require_not_compromised_password</note>
       </trans-unit>
       <trans-unit id="26cb6ab7ae7e190a9d8d8b0411512b531c8c42ff" resname="field_definition.ezuser.require_at_least_one_numeric_character">

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -817,9 +817,14 @@
         <note>key: field_definition.ezuser.require_at_least_one_non_alphanumeric_character</note>
       </trans-unit>
       <trans-unit id="283d87c7f3e760a02fde52274ed0a4a8523d2a0d" resname="field_definition.ezuser.require_not_compromised_password">
-        <source>Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</source>
-        <target state="new">Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</target>
+        <source>Password must not be contained in a public breach.</source>
+        <target state="new">Password must not be contained in a public breach.</target>
         <note>key: field_definition.ezuser.require_not_compromised_password</note>
+      </trans-unit>
+      <trans-unit id="99aa2f672dfd9206b58ddf5d78e6a695ceb9ebf1" resname="field_definition.ezuser.require_not_compromised_password_help">
+        <source>%begin%This uses the API at %link% to securely check breach data. The password is not transmitted to the API.%end%</source>
+        <target state="new">%begin%This uses the API at %link% to securely check breach data. The password is not transmitted to the API.%end%</target>
+        <note>key: field_definition.ezuser.require_not_compromised_password_help</note>
       </trans-unit>
       <trans-unit id="26cb6ab7ae7e190a9d8d8b0411512b531c8c42ff" resname="field_definition.ezuser.require_at_least_one_numeric_character">
         <source>Password must contain at least one number</source>

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -816,6 +816,11 @@
         <target state="new">Password must contain at least one non-alphanumeric character</target>
         <note>key: field_definition.ezuser.require_at_least_one_non_alphanumeric_character</note>
       </trans-unit>
+      <trans-unit id="283d87c7f3e760a02fde52274ed0a4a8523d2a0d" resname="field_definition.ezuser.require_not_compromised_password">
+        <source>Password must not be contained in a public breach</source>
+        <target state="new">Password must not be contained in a public breach</target>
+        <note>key: field_definition.ezuser.require_not_compromised_password</note>
+      </trans-unit>
       <trans-unit id="26cb6ab7ae7e190a9d8d8b0411512b531c8c42ff" resname="field_definition.ezuser.require_at_least_one_numeric_character">
         <source>Password must contain at least one number</source>
         <target state="new">Password must contain at least one number</target>

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -822,8 +822,8 @@
         <note>key: field_definition.ezuser.require_not_compromised_password</note>
       </trans-unit>
       <trans-unit id="99aa2f672dfd9206b58ddf5d78e6a695ceb9ebf1" resname="field_definition.ezuser.require_not_compromised_password_help">
-        <source>%begin%This uses the API at %link% to securely check breach data. The password is not transmitted to the API.%end%</source>
-        <target state="new">%begin%This uses the API at %link% to securely check breach data. The password is not transmitted to the API.%end%</target>
+        <source>This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</source>
+        <target state="new">This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</target>
         <note>key: field_definition.ezuser.require_not_compromised_password_help</note>
       </trans-unit>
       <trans-unit id="26cb6ab7ae7e190a9d8d8b0411512b531c8c42ff" resname="field_definition.ezuser.require_at_least_one_numeric_character">

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -817,8 +817,8 @@
         <note>key: field_definition.ezuser.require_at_least_one_non_alphanumeric_character</note>
       </trans-unit>
       <trans-unit id="283d87c7f3e760a02fde52274ed0a4a8523d2a0d" resname="field_definition.ezuser.require_not_compromised_password">
-        <source>Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.</source>
-        <target state="new">Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.</target>
+        <source>Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</source>
+        <target state="new">Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.</target>
         <note>key: field_definition.ezuser.require_not_compromised_password</note>
       </trans-unit>
       <trans-unit id="26cb6ab7ae7e190a9d8d8b0411512b531c8c42ff" resname="field_definition.ezuser.require_at_least_one_numeric_character">

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -252,6 +252,10 @@
             {{- form_row(form.requireAtLeastOneNonAlphanumericCharacter, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         </div>
 
+        <div class="ibexa-user__settings {% if group_class is not empty %} {{ group_class }}{% endif %}">
+            {{- form_row(form.requireNotCompromisedPassword, {'label_attr': {'class': 'checkbox-inline'}}) -}}
+        </div>
+
         <div class="ibexa-user__settings text-rows{% if group_class is not empty %} {{ group_class }}{% endif %}">
             {{- form_row(form.minLength) -}}
         </div>

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -387,19 +387,21 @@
             <svg class="ibexa-icon ibexa-icon--small ibexa-form-help__icon">
                 <use xlink:href="{{ ibexa_icon_path('system-information') }}"></use>
             </svg>
-            {%- if translation_domain is same as(false) -%}
-                {%- if help_html is same as(false) -%}
-                    {{- help -}}
+            <div class="ibexa-form-help__content">
+                {%- if translation_domain is same as(false) -%}
+                    {%- if help_html is same as(false) -%}
+                        {{- help -}}
+                    {%- else -%}
+                        {{- help|raw -}}
+                    {%- endif -%}
                 {%- else -%}
-                    {{- help|raw -}}
+                    {%- if help_html is same as(false) -%}
+                        {{- help|trans(help_translation_parameters, translation_domain) -}}
+                    {%- else -%}
+                        {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
+                    {%- endif -%}
                 {%- endif -%}
-            {%- else -%}
-                {%- if help_html is same as(false) -%}
-                    {{- help|trans(help_translation_parameters, translation_domain) -}}
-                {%- else -%}
-                    {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
-                {%- endif -%}
-            {%- endif -%}
+            </div>
         </small>
     {%- endif -%}
 {%- endblock form_help %}

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -50,14 +50,17 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
 
         $fieldDefinitionForm->add('requireNotCompromisedPassword', PasswordConstraintCheckboxType::class, [
             'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
-            'label' => /** @Desc("Password must not be contained in a public breach.
-                * This uses the API at %link% to securely check breach data.
-                * The password is not transmitted to the API.") */
+            'label' => /** @Desc("Password must not be contained in a public breach.") */
                 'field_definition.ezuser.require_not_compromised_password',
-            'label_translation_parameters' => [
+            'help' => /** @Desc("%begin%This uses the API at %link% to securely check breach data.
+                * The password is not transmitted to the API.%end%") */
+                'field_definition.ezuser.require_not_compromised_password_help',
+            'help_translation_parameters' => [
+                '%begin%' => '<div>',
                 '%link%' => '<a href="https://haveibeenpwned.com/" target="_blank">https://haveibeenpwned.com/</a>',
+                '%end%' => '</div>',
             ],
-            'label_html' => true,
+            'help_html' => true,
         ]);
 
         $fieldDefinitionForm->add('requireNewPassword', PasswordConstraintCheckboxType::class, [

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -48,6 +48,11 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
             'label' => /** @Desc("Password must contain at least one non-alphanumeric character") */ 'field_definition.ezuser.require_at_least_one_non_alphanumeric_character',
         ]);
 
+        $fieldDefinitionForm->add('requireNotCompromisedPassword', PasswordConstraintCheckboxType::class, [
+            'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
+            'label' => /** @Desc("Password must not be contained in a public breach") */ 'field_definition.ezuser.require_not_compromised_password',
+        ]);
+
         $fieldDefinitionForm->add('requireNewPassword', PasswordConstraintCheckboxType::class, [
             'property_path' => $validatorPropertyPathPrefix . '[requireNewPassword]',
             'label' => /** @Desc("Prevent reusing old password") */ 'field_definition.ezuser.require_new_password',

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -50,7 +50,7 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
 
         $fieldDefinitionForm->add('requireNotCompromisedPassword', PasswordConstraintCheckboxType::class, [
             'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
-            'label' => /** @Desc("Password must not be contained in a public breach") */ 'field_definition.ezuser.require_not_compromised_password',
+            'label' => /** @Desc("Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.") */ 'field_definition.ezuser.require_not_compromised_password',
         ]);
 
         $fieldDefinitionForm->add('requireNewPassword', PasswordConstraintCheckboxType::class, [

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -50,7 +50,11 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
 
         $fieldDefinitionForm->add('requireNotCompromisedPassword', PasswordConstraintCheckboxType::class, [
             'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
-            'label' => /** @Desc("Password must not be contained in a public breach. This uses the API at https://haveibeenpwned.com/ to securely check breach data. The password is not transmitted to the API.") */ 'field_definition.ezuser.require_not_compromised_password',
+            'label' => /** @Desc("Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.") */ 'field_definition.ezuser.require_not_compromised_password',
+            'label_translation_parameters' => [
+                '%link%' => '<a href="https://haveibeenpwned.com/" target="_blank">https://haveibeenpwned.com/</a>',
+            ],
+            'label_html' => true,
         ]);
 
         $fieldDefinitionForm->add('requireNewPassword', PasswordConstraintCheckboxType::class, [

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -52,13 +52,11 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
             'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
             'label' => /** @Desc("Password must not be contained in a public breach.") */
                 'field_definition.ezuser.require_not_compromised_password',
-            'help' => /** @Desc("%begin%This uses the API at %link% to securely check breach data.
-                * The password is not transmitted to the API.%end%") */
+            'help' => /** @Desc("This uses the API at %link% to securely check breach data.
+                * The password is not transmitted to the API.") */
                 'field_definition.ezuser.require_not_compromised_password_help',
             'help_translation_parameters' => [
-                '%begin%' => '<div>',
                 '%link%' => '<a href="https://haveibeenpwned.com/" target="_blank">https://haveibeenpwned.com/</a>',
-                '%end%' => '</div>',
             ],
             'help_html' => true,
         ]);

--- a/src/lib/FieldType/Mapper/UserAccountFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFormMapper.php
@@ -50,7 +50,10 @@ final class UserAccountFormMapper implements FieldDefinitionFormMapperInterface
 
         $fieldDefinitionForm->add('requireNotCompromisedPassword', PasswordConstraintCheckboxType::class, [
             'property_path' => $validatorPropertyPathPrefix . '[requireNotCompromisedPassword]',
-            'label' => /** @Desc("Password must not be contained in a public breach. This uses the API at %link% to securely check breach data. The password is not transmitted to the API.") */ 'field_definition.ezuser.require_not_compromised_password',
+            'label' => /** @Desc("Password must not be contained in a public breach.
+                * This uses the API at %link% to securely check breach data.
+                * The password is not transmitted to the API.") */
+                'field_definition.ezuser.require_not_compromised_password',
             'label_translation_parameters' => [
                 '%link%' => '<a href="https://haveibeenpwned.com/" target="_blank">https://haveibeenpwned.com/</a>',
             ],


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-5361](https://issues.ibexa.co/browse/IBX-5361)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

See description in the companion PR https://github.com/ibexa/core/pull/221. That PR adds the feature that this one adds admin UI for. The feature is disabled by default, for BC.

**Documentation**
The [password rules page](https://doc.ibexa.co/en/latest/users/user_management/#password-rules) would need documentation for this feature.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Attribution
- [x] Ready for Code Review

**Screenshot**
![screenshot](https://issues.ibexa.co/secure/attachment/40605/help-ok.png)