### PR TITLE
Allowed CompileAssets Command to respect COMPOSER_PROCESS_TIMEOUT env variable

### DIFF
--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -21,20 +21,32 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
 {
     public const COMMAND_NAME = 'ibexa:encore:compile';
 
+    public const COMMAND_DEFAULT_TIMEOUT = 300;
+
+    protected static $defaultName = self::COMMAND_NAME;
+
+    protected static $defaultDescription = 'Compiles all assets using WebPack Encore';
+
+    private int $timeout;
+
+    public function __construct(int $timeout = self::COMMAND_DEFAULT_TIMEOUT)
+    {
+        $this->timeout = $timeout;
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this
-            ->setName(self::COMMAND_NAME)
             ->setAliases([
                 'ezplatform:encore:compile',
             ])
-            ->setDescription('Compiles all assets using WebPack Encore')
             ->addOption(
                 'timeout',
                 't',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Timeout in seconds',
-                300
+                $this->timeout
             )
             ->addOption(
                 'config-name',

--- a/src/bundle/Resources/config/services/commands.yaml
+++ b/src/bundle/Resources/config/services/commands.yaml
@@ -1,3 +1,7 @@
+parameters:
+    ibexa.admin_ui.command.compile_assets_timeout.default: !php/const Ibexa\Bundle\AdminUi\Command\CompileAssetsCommand::COMMAND_DEFAULT_TIMEOUT
+    ibexa.admin_ui.command.compile_assets_timeout: '%env(default:ibexa.admin_ui.command.compile_assets_timeout.default:COMPOSER_PROCESS_TIMEOUT)%'
+
 services:
     _defaults:
         autowire: true
@@ -5,5 +9,7 @@ services:
         public: false
 
     Ibexa\Bundle\AdminUi\Command\CompileAssetsCommand:
+        arguments:
+            $timeout: '%ibexa.admin_ui.command.compile_assets_timeout%'
         tags:
             - { name: console.command }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR makes the `CompileAssets` command respect the `COMPOSER_PROCESS_TIMEOUT` environment variable if present.

![image](https://user-images.githubusercontent.com/3183926/229071050-455f3bfe-0485-451b-a2ba-d51ab1eb67d2.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
