### PR TITLE
IBX-4012: [Sections] Recalculate last section padding on section height change

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.anchor.navigation.js
@@ -9,6 +9,9 @@
     const headerContainer = header?.querySelector('.ibexa-edit-header__container');
     const SECTION_ADJUST_MARGIN_TOP = 20;
     const formContainerNode = doc.querySelector('.ibexa-edit-content');
+    const lastSectionObserver = new ResizeObserver(() => {
+        fitSections();
+    });
     const getSectionGroupActiveItems = () => {
         const sectionGroupNode = formContainerNode.querySelector('.ibexa-anchor-navigation__section-group') ?? formContainerNode;
         const sections = sectionGroupNode.querySelectorAll('.ibexa-anchor-navigation__section');
@@ -68,7 +71,7 @@
 
         currentlyVisibleSections = getSectionGroupActiveItems();
 
-        fitSections();
+        initFitSection();
     };
     const attachSectionsMenuEvents = () => {
         const items = doc.querySelectorAll('.ibexa-anchor-navigation-menu .ibexa-anchor-navigation-menu__sections-item-btn');
@@ -96,7 +99,7 @@
 
         return sections[sections.length - 1];
     };
-    const fitSections = () => {
+    const initFitSection = () => {
         const sectionGroup =
             formContainerNode.querySelector('.ibexa-anchor-navigation__section-group--active') ??
             formContainerNode.querySelector('.ibexa-anchor-navigation-sections');
@@ -105,14 +108,26 @@
             return;
         }
 
-        const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
-        const firstSection = getFirstSection(sectionGroup);
         const lastSection = getLastSection(sectionGroup);
 
-        if (!firstSection) {
+        if (!lastSection) {
             return;
         }
 
+        const contentContainer = lastSection.closest('.ibexa-edit-content__container');
+
+        fitSections();
+
+        lastSectionObserver.unobserve(contentContainer);
+        lastSectionObserver.observe(contentContainer);
+    };
+    const fitSections = () => {
+        const sectionGroup =
+            formContainerNode.querySelector('.ibexa-anchor-navigation__section-group--active') ??
+            formContainerNode.querySelector('.ibexa-anchor-navigation-sections');
+        const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
+        const firstSection = getFirstSection(sectionGroup);
+        const lastSection = getLastSection(sectionGroup);
         const contentContainer = lastSection.closest('.ibexa-edit-content__container');
 
         if (!firstSection.isSameNode(lastSection) && lastSection.offsetHeight) {
@@ -224,6 +239,6 @@
     attachSectionsMenuEvents();
     attachScrollContainerEvents();
     attachListenForIsInvalidClass();
-    fitSections();
+    initFitSection();
     ibexa.helpers.tooltips.parse(navigationMenu);
 })(window, window.document, window.ibexa);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4012
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
We need to recalculate last section padding in case of when there is dynamically loaded content, as it changes content height and breaks proper selecting of active section in left nav menu

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
