### PR TITLE
IBX-5606: Removed duplicated GraphQL request in the Subitems module

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -102,10 +102,14 @@ export default class SubItemsModule extends Component {
         });
 
         containerResizeObserver.observe(this._refMainContainerWrapper.current);
+
+        if (!this.state.activePageItems) {
+            this.loadPage(0);
+        }
     }
 
     componentDidUpdate() {
-        const { activePageIndex, activePageItems, totalCount } = this.state;
+        const { activePageIndex, totalCount } = this.state;
         const { limit: itemsPerPage } = this.props;
         const pagesCount = Math.ceil(totalCount / itemsPerPage);
         const pageDoesNotExist = activePageIndex > pagesCount - 1 && activePageIndex !== 0;
@@ -116,12 +120,6 @@ export default class SubItemsModule extends Component {
             });
 
             return;
-        }
-
-        const shouldLoadPage = !activePageItems;
-
-        if (shouldLoadPage) {
-            this.loadPage(activePageIndex);
         }
 
         ibexa.helpers.tooltips.parse();

--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -123,6 +123,7 @@ export default class SubItemsModule extends Component {
         }
 
         const shouldLoadPage = !activePageItems;
+
         if (shouldLoadPage) {
             this.loadPage(activePageIndex);
         }

--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -102,10 +102,6 @@ export default class SubItemsModule extends Component {
         });
 
         containerResizeObserver.observe(this._refMainContainerWrapper.current);
-
-        if (!this.state.activePageItems) {
-            this.loadPage(0);
-        }
     }
 
     componentDidUpdate() {

--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -109,7 +109,7 @@ export default class SubItemsModule extends Component {
     }
 
     componentDidUpdate() {
-        const { activePageIndex, totalCount } = this.state;
+        const { activePageIndex, activePageItems, totalCount } = this.state;
         const { limit: itemsPerPage } = this.props;
         const pagesCount = Math.ceil(totalCount / itemsPerPage);
         const pageDoesNotExist = activePageIndex > pagesCount - 1 && activePageIndex !== 0;
@@ -122,6 +122,11 @@ export default class SubItemsModule extends Component {
             return;
         }
 
+        const shouldLoadPage = !activePageItems;
+        if (shouldLoadPage) {
+            this.loadPage(activePageIndex);
+        }
+
         ibexa.helpers.tooltips.parse();
     }
 
@@ -130,7 +135,12 @@ export default class SubItemsModule extends Component {
     }
 
     resizeSubItems() {
-        this.setState({ subItemsWidth: this.calculateSubItemsWidth() });
+        const calculatedWidth = this.calculateSubItemsWidth();
+        const { subItemsWidth } = this.state;
+
+        if (calculatedWidth !== subItemsWidth) {
+            this.setState({ subItemsWidth: calculatedWidth });
+        }
     }
 
     calculateSubItemsWidth() {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5606
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The  `containerResizeObserver` injected into `componentDidMount` method actually causes double GraphQL requests. Component is immediately updated because of `containerResizeObserver`, hence firing `componentDidUpdate` method, hence second GraphQL request.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
