### PR TITLE
IBX-5583: Fix multiselect dropdown not firing change event

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/dropdown.js
@@ -183,7 +183,7 @@
 
             this.fitItems();
 
-            if (this.currentSelectedValue !== value) {
+            if (this.currentSelectedValue !== value || !this.canSelectOnlyOne) {
                 this.fireValueChangedEvent();
 
                 this.currentSelectedValue = value;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5583
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
 
Fix multi-select dropdown not firing change event for the first option when selected/unselected at least twice in a row
