### PR TITLE
IBX-5702: Fixed ezselection rendering

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezselection.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezselection.html.twig
@@ -1,6 +1,7 @@
 {% use '@ibexadesign/ui/form_fields/dropdown_widget.html.twig' %}
 
 {%- block ezplatform_fieldtype_ezselection_widget -%}
-    {% set attr = attr|merge({'class': 'ibexa-data-source__input ibexa-data-source__input--selection', disabled: attr.readonly|default(false) }) %}
+    {% set attr = attr|merge({'class': 'ibexa-data-source__input ibexa-data-source__input--selection' }) %}
+    {% set dropdown_disabled = attr.readonly|default(false) %}
     {{ block('choice_widget') }}
 {%- endblock -%}

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
@@ -20,7 +20,7 @@
             translation_domain: choice_translation_domain|default(false),
             custom_form: false,
             class: attr.dropdown_class|default(''),
-            is_disabled: attr.disabled|default(false) or disabled|default(false),
+            is_disabled: attr.disabled|default(false) or disabled|default(false) or dropdown_disabled|default(false),
             is_hidden: attr.dropdown_hidden|default(false),
             is_small: attr.is_small|default(false),
             is_ghost: attr.is_ghost|default(false),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5702
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR fixes `ezselection` field rendering when field should be displayed as readonly. In case when field is set as required and not-translatable, value for `ezselection` field is not sent because source field contains disabled attribute. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
