### PR TITLE
Changed translation key to avoiding duplication of keys

### DIFF
--- a/src/bundle/Resources/translations/dropdown.en.xliff
+++ b/src/bundle/Resources/translations/dropdown.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">All</target>
         <note>key: dropdown.placeholder</note>
       </trans-unit>
+      <trans-unit id="bcf45496a8dbad6959111ca6eae0ab456d4ad1c7" resname="dropdown.placeholder.all">
+        <source>All</source>
+        <target state="new">All</target>
+        <note>key: dropdown.placeholder.all</note>
+      </trans-unit>
       <trans-unit id="49f6d75aca8da375a2a79c0778934bc45a8ffe8c" resname="dropdown.placeholder.empty">
         <source>No options available</source>
         <target state="new">No options available</target>

--- a/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/dropdown/dropdown.html.twig
@@ -72,7 +72,7 @@
                 {% if value is empty %}
                     {% if not multiple %}
                         {% if placeholder is defined and placeholder is not none %}
-                            {% set default_label = 'dropdown.placeholder'|trans()|desc('All') %}
+                            {% set default_label = 'dropdown.placeholder.all'|trans()|desc('All') %}
 
                             {% include '@ibexadesign/ui/component/dropdown/dropdown_selected_item.html.twig' with {
                                 value: '',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixes 
```
  The message 'dropdown.placeholder' exists with two different descs: 'All' in /vendor/ibexa/admin-ui/src/bundle/DependencyInjection/../../../src/bundle/Resources/views/themes/a  
  dmin/ui/component/dropdown/dropdown.html.twig on line 75, and 'Choose an option' in /vendor/ibexa/admin-ui/src/bundle/DependencyInjection/../../../src/bundle/Resources/views/t  
  hemes/admin/ui/component/dropdown/dropdown.html.twig on line 115 
``` 
error


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
