### PR TITLE
IBX-5672: Performance Improvement of IconPathResolver::resolve()

### DIFF
--- a/src/lib/Resolver/IconPathResolver.php
+++ b/src/lib/Resolver/IconPathResolver.php
@@ -10,18 +10,22 @@ namespace Ibexa\AdminUi\Resolver;
 
 use Ibexa\Contracts\AdminUi\Resolver\IconPathResolverInterface;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Symfony\Component\Asset\Packages;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @internal
  */
-final class IconPathResolver implements IconPathResolverInterface
+final class IconPathResolver implements IconPathResolverInterface, EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Symfony\Component\Asset\Packages */
-    private $packages;
+    private Packages $packages;
+
+    /** @var string[] */
+    private array $iconCache;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
@@ -29,14 +33,34 @@ final class IconPathResolver implements IconPathResolverInterface
     ) {
         $this->configResolver = $configResolver;
         $this->packages = $packages;
+        $this->iconCache = [];
     }
 
     public function resolve(string $icon, ?string $set = null): string
     {
+        if (isset($this->iconCache[$set][$icon])) {
+            return $this->iconCache[$set][$icon];
+        }
+
         $iconSetName = $set ?? $this->configResolver->getParameter('assets.default_icon_set');
         $iconSets = $this->configResolver->getParameter('assets.icon_sets');
 
-        return sprintf('%s#%s', $this->packages->getUrl($iconSets[$iconSetName]), $icon);
+        $this->iconCache[$set][$icon] = sprintf('%s#%s', $this->packages->getUrl($iconSets[$iconSetName]), $icon);
+
+        return $this->iconCache[$set][$icon];
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MVCEvents::CONFIG_SCOPE_CHANGE => ['onConfigScopeChange', 100],
+            MVCEvents::CONFIG_SCOPE_RESTORE => ['onConfigScopeChange', 100],
+        ];
+    }
+
+    public function onConfigScopeChange(ScopeChangeEvent $event): void
+    {
+        $this->iconCache = [];
     }
 }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5672](https://jira.ez.no/browse/IBX-5672)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.3
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

## Upstream merge from https://github.com/ezsystems/ezplatform-core/pull/59

Add simple in-memory cache for IconPathResolver::resolve() to speed up icon handling. Often, the same icon ( like `checkmark` ) are used many times on the same page

FYI : You my find info from blackfire in the Jira ticket

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
