### PR TITLE
IBX-5411: Fixed form exception due to incomplete field definition

### DIFF
--- a/src/lib/Form/Type/ContentType/FieldDefinitionsCollectionType.php
+++ b/src/lib/Form/Type/ContentType/FieldDefinitionsCollectionType.php
@@ -43,7 +43,6 @@ final class FieldDefinitionsCollectionType extends AbstractType
                     'block_prefix' => 'content_type_field_definition',
                 ],
                 'label' => /** @Desc("Content Field definitions") */ 'content_type.field_definitions_data',
-                'allow_add' => true,
                 'allow_delete' => true,
                 'prototype' => false,
             ]);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-5411](https://issues.ibexa.co/browse/IBX-5411)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR fixes an issue with Content Type update form in UI which occurs when:
1. A field is removed from a Content Type (AJAX request starts).
2. Form is submitted.
3. AJAX request resolves or for any other reason HTML form elements are not (yet) removed from DOM when form submission occured.

Despite the description in the issue suggesting this is related to field groups, it is in fact related to race condition between Javascript UI changes and normal browser submission.

While the main issue lies in the aforementioned race condition (frontend), we can remedy this situation by presenting the form again to the user.
To allow this, we must ensure that form data that is incorrect is discarded by the Symfony Form. This is due to the fact that in practice `allow_add` option in Field Definition Collection Type never took effect because POST data does not describe complete Field Definition (as the exception shows, field type identifier was missing).
Disabling this option allows the form to re-displayed to the user with a default Symfony error message in our toast.

### Current behavior
When the field is removed and form submission occurs too early, a following exception can be seen:
![image](https://github.com/ibexa/admin-ui/assets/3183926/322db6d3-9d61-4c4f-95ec-5efe8e297a9d)

Profiler shows that both requests are made in quick succession (less than 1 sec difference). On the UI the field is transitioning and almost being removed:
![2023-06-13_13-28](https://github.com/ibexa/admin-ui/assets/3183926/7e0361c7-d0b9-4c77-8d44-a80dc6b1c0f3)

POST data shows that the field being removed is sent as part of the payload:
![2023-06-13_13-29](https://github.com/ibexa/admin-ui/assets/3183926/a031a856-47d5-4c7e-8da7-924712b422a4)

Normally, if sufficient time passes between field removal and form submission, the field is absent in POST payload and request succeeds:
![2023-06-13_13-30](https://github.com/ibexa/admin-ui/assets/3183926/6feee01a-93b2-461f-b6a0-6e74da5ba7df)

This PR will cause the form to instead discard the POST data that is not correct and will re-display the form:
![2023-06-13_13-48](https://github.com/ibexa/admin-ui/assets/3183926/7e94e918-3a79-4aa4-af68-749376a5904a)

### QA
Other Content Type related forms need to be checked against errors. I assume that this change should have no impact anywhere, but I don't know if there are other places that relate to this form type.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
