### PR TITLE
[Behat] Fix for create and edit company form

### DIFF
--- a/src/lib/Behat/Component/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationSingle.php
@@ -29,7 +29,7 @@ class ContentRelationSingle extends FieldTypeComponent
     public function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('selectContent', '.ibexa-relations__cta-btn-label'),
+            new VisibleCSSLocator('selectContent', '.ibexa-relations__cta-btn'),
             new VisibleCSSLocator('buttonRemove', '.ibexa-relations__table-action--remove-item'),
             new VisibleCSSLocator('relationRow', '.ibexa-relations__list tr'),
             new VisibleCSSLocator('columnHeader', 'tr:not(.ibexa-relations__table-header) th'),


### PR DESCRIPTION
Fix for create and edit company form.

Issue:
`Facebook\WebDriver\Exception\ElementClickInterceptedException: element click intercepted: Element <span class="ibexa-relations__cta-btn-label">...</span> is not clickable at point (484, 820). Other element would receive the click: <p class="ibexa-relations__helper-text">...</p>`

Failure example:
https://github.com/ibexa/experience/actions/runs/5272432723/jobs/9534689193

PR and regression build Exp:
https://github.com/ibexa/experience/pull/191
https://github.com/ibexa/experience/actions/runs/5282065720/jobs/9556504632?pr=191

- [x] Code follows the code style of this project (use `$ composer fix-cs`).
- [ ] Change requires a change to the documentation.
- [x] Code is ready for a review.