### PR TITLE
[Behat] Fix for company edition

### DIFF
--- a/src/lib/Behat/Component/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationSingle.php
@@ -46,6 +46,8 @@ class ContentRelationSingle extends FieldTypeComponent
     public function setValue(array $parameters): void
     {
         if (!$this->isRelationEmpty()) {
+            $this->getHTMLPage()->find($this->getLocator('buttonRemove'))->mouseOver();
+            usleep(100 * 5000); // 500ms
             $this->getHTMLPage()->find($this->getLocator('buttonRemove'))->click();
         }
 


### PR DESCRIPTION
Fix for company edition.

Issue:
`Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'combined--selectContent': 'div.ibexa-field-edit:nth-of-type(6) .ibexa-relations__cta-btn-label' not found in 1 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79`

Failure example:
https://github.com/ibexa/experience/actions/runs/5305890694/jobs/9603136896

Regression builds (experience and commerce):
https://github.com/ibexa/experience/pull/193
https://github.com/ibexa/commerce/pull/287

- [x] Code follows the code style of this project (use `$ composer fix-cs`).
- [ ] Change requires a change to the documentation.
- [x] Code is ready for a review.