### PR TITLE
[Behat] Added small wait before interacting with Single relation button

### DIFF
--- a/src/lib/Behat/Component/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationSingle.php
@@ -51,14 +51,13 @@ class ContentRelationSingle extends FieldTypeComponent
             $this->getHTMLPage()->find($this->getLocator('buttonRemove'))->click();
         }
 
-        $this->getHTMLPage()
-            ->setTimeout(5)
-            ->find(
-                CSSLocatorBuilder::base($this->parentLocator)
+        $buttonLocator = CSSLocatorBuilder::base($this->parentLocator)
                     ->withDescendant($this->getLocator('selectContent'))
-                    ->build()
-            )
-            ->click();
+                    ->build();
+
+        $this->getHTMLPage()->setTimeout(5)->find($buttonLocator)->mouseOver();
+        usleep(100);
+        $this->getHTMLPage()->find($buttonLocator)->click();
 
         $this->universalDiscoveryWidget->verifyIsLoaded();
         $this->universalDiscoveryWidget->selectContent($parameters['value']);


### PR DESCRIPTION
Failure: https://github.com/ibexa/experience/actions/runs/5448786834/jobs/9912374424

```
     And I set content fields                                                                            # Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext::iSetFields()
      | label          | value                                                   |
      | Is active      | true                                                    |
      | Name           | Ibexa Poland Sp. z o.o.                                 |
      | Tax ID         | 200027649902100895                                      |
      | Website        | www.ibexa.co                                            |
      | Customer group | Customer group for corporate account                    |
      | Sales rep      | Users/Sales reps/SalesRepFirstCreate SalesRepLastCreate |
      Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'udw': '.m-ud' not found in 1 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79
      Stack trace:
```

Tested in https://github.com/ibexa/experience/pull/199 