### PR TITLE
Added removing content type draft when clicking cancel button

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
@@ -6,8 +6,7 @@
 
 {% block header %}
     {% set content_type_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_create.sidebar_right', [], {
-        'save_id': form.publishContentType.vars.id,
-        'group': content_type_group
+        'form_view': form,
     }) %}
 
     {% include '@ibexadesign/ui/edit_header.html.twig' with {
@@ -86,6 +85,7 @@
         </div>
         {{ form_widget(form.saveContentType, { attr: { hidden: 'hidden' }}) }}
         {{ form_widget(form.publishContentType, { attr: { class: 'ibexa-content-type-edit__publish-content-type', hidden: 'hidden' }}) }}
+        {{ form_widget(form.removeDraft, { attr: { hidden: 'hidden', formnovalidate: true }}) }}
 
         {{ form_widget(form._token) }}
     {{ form_end(form, {'render_rest': false }) }}

--- a/src/lib/Menu/Admin/ContentType/AbstractContentTypeRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/AbstractContentTypeRightSidebarBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Menu\Admin\ContentType;
+
+use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Knp\Menu\ItemInterface;
+
+abstract class AbstractContentTypeRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+{
+    public function createStructure(array $options): ItemInterface
+    {
+        /** @var \Symfony\Component\Form\FormView $contentTypeFormView */
+        $contentTypeFormView = $options['form_view'];
+
+        /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */
+        $menu = $this->factory->createItem('root');
+
+        $itemSaveIdentifier = $this->getItemSaveIdentifier();
+        $itemCancelIdentifier = $this->getItemCancelIdentifier();
+
+        $menu->setChildren([
+            $itemSaveIdentifier => $this->createMenuItem(
+                $itemSaveIdentifier,
+                [
+                    'attributes' => [
+                        'class' => 'ibexa-btn--trigger ibexa-btn--save-content-type',
+                        'data-click' => sprintf('#%s', $contentTypeFormView['publishContentType']->vars['id']),
+                    ],
+                ]
+            ),
+            $itemCancelIdentifier => $this->createMenuItem(
+                $itemCancelIdentifier,
+                [
+                    'attributes' => [
+                        'class' => 'ibexa-btn--trigger',
+                        'data-click' => sprintf('#%s', $contentTypeFormView['removeDraft']->vars['id']),
+                    ],
+                ]
+            ),
+        ]);
+
+        return $menu;
+    }
+
+    abstract public function getItemSaveIdentifier(): string;
+
+    abstract public function getItemCancelIdentifier(): string;
+}

--- a/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
@@ -7,88 +7,22 @@
 namespace Ibexa\AdminUi\Menu\Admin\ContentType;
 
 use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
-use Ibexa\AdminUi\Menu\MenuItemFactory;
-use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
-use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
-use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
  *
  * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
  */
-class ContentTypeCreateRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+class ContentTypeCreateRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder
 {
     /* Menu items */
     public const ITEM__SAVE = 'content_type_create__sidebar_right__save';
     public const ITEM__CANCEL = 'content_type_create__sidebar_right__cancel';
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
-
-    public function __construct(
-        MenuItemFactory $factory,
-        EventDispatcherInterface $eventDispatcher,
-        TranslatorInterface $translator
-    ) {
-        parent::__construct($factory, $eventDispatcher);
-
-        $this->translator = $translator;
-    }
-
-    /**
-     * @return string
-     */
     protected function getConfigureEventName(): string
     {
         return ConfigureMenuEvent::CONTENT_TYPE_CREATE_SIDEBAR_RIGHT;
-    }
-
-    /**
-     * @param array $options
-     *
-     * @return \Knp\Menu\ItemInterface
-     *
-     * @throws \InvalidArgumentException
-     * @throws ApiExceptions\BadStateException
-     * @throws \InvalidArgumentException
-     */
-    public function createStructure(array $options): ItemInterface
-    {
-        /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup $section */
-        $group = $options['group'];
-
-        $saveId = $options['save_id'];
-
-        /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */
-        $menu = $this->factory->createItem('root');
-
-        $menu->setChildren([
-            self::ITEM__SAVE => $this->createMenuItem(
-                self::ITEM__SAVE,
-                [
-                    'attributes' => [
-                        'class' => 'ibexa-btn--trigger ibexa-btn--save-content-type',
-                        'data-click' => sprintf('#%s', $saveId),
-                    ],
-                ]
-            ),
-            self::ITEM__CANCEL => $this->createMenuItem(
-                self::ITEM__CANCEL,
-                [
-                    'route' => 'ibexa.content_type_group.view',
-                    'routeParameters' => [
-                        'contentTypeGroupId' => $group->id,
-                    ],
-                ]
-            ),
-        ]);
-
-        return $menu;
     }
 
     /**
@@ -100,6 +34,16 @@ class ContentTypeCreateRightSidebarBuilder extends AbstractBuilder implements Tr
             (new Message(self::ITEM__SAVE, 'menu'))->setDesc('Create'),
             (new Message(self::ITEM__CANCEL, 'menu'))->setDesc('Cancel'),
         ];
+    }
+
+    public function getItemSaveIdentifier(): string
+    {
+        return self::ITEM__SAVE;
+    }
+
+    public function getItemCancelIdentifier(): string
+    {
+        return self::ITEM__CANCEL;
     }
 }
 

--- a/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
@@ -7,86 +7,22 @@
 namespace Ibexa\AdminUi\Menu\Admin\ContentType;
 
 use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
-use Ibexa\AdminUi\Menu\MenuItemFactory;
-use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
-use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
-use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
  *
  * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
  */
-class ContentTypeEditRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+class ContentTypeEditRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder
 {
     /* Menu items */
     public const ITEM__SAVE = 'content_type_edit__sidebar_right__save';
     public const ITEM__CANCEL = 'content_type_edit__sidebar_right__cancel';
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
-
-    public function __construct(
-        MenuItemFactory $factory,
-        EventDispatcherInterface $eventDispatcher,
-        TranslatorInterface $translator
-    ) {
-        parent::__construct($factory, $eventDispatcher);
-
-        $this->translator = $translator;
-    }
-
-    /**
-     * @return string
-     */
     protected function getConfigureEventName(): string
     {
         return ConfigureMenuEvent::CONTENT_TYPE_EDIT_SIDEBAR_RIGHT;
-    }
-
-    /**
-     * @param array $options
-     *
-     * @return \Knp\Menu\ItemInterface
-     *
-     * @throws \InvalidArgumentException
-     * @throws ApiExceptions\BadStateException
-     * @throws \InvalidArgumentException
-     */
-    public function createStructure(array $options): ItemInterface
-    {
-        /** @var \Symfony\Component\Form\FormView $contentTypeEditFormView */
-        $contentTypeEditFormView = $options['form_view'];
-
-        /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */
-        $menu = $this->factory->createItem('root');
-
-        $menu->setChildren([
-            self::ITEM__SAVE => $this->createMenuItem(
-                self::ITEM__SAVE,
-                [
-                    'attributes' => [
-                        'class' => 'ibexa-btn--trigger ibexa-btn--save-content-type',
-                        'data-click' => sprintf('#%s', $contentTypeEditFormView['publishContentType']->vars['id']),
-                    ],
-                ]
-            ),
-            self::ITEM__CANCEL => $this->createMenuItem(
-                self::ITEM__CANCEL,
-                [
-                    'attributes' => [
-                        'class' => 'ibexa-btn--trigger',
-                        'data-click' => sprintf('#%s', $contentTypeEditFormView['removeDraft']->vars['id']),
-                    ],
-                ]
-            ),
-        ]);
-
-        return $menu;
     }
 
     /**
@@ -98,6 +34,16 @@ class ContentTypeEditRightSidebarBuilder extends AbstractBuilder implements Tran
             (new Message(self::ITEM__SAVE, 'menu'))->setDesc('Save'),
             (new Message(self::ITEM__CANCEL, 'menu'))->setDesc('Cancel'),
         ];
+    }
+
+    public function getItemSaveIdentifier(): string
+    {
+        return self::ITEM__SAVE;
+    }
+
+    public function getItemCancelIdentifier(): string
+    {
+        return self::ITEM__CANCEL;
     }
 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR adds removing content type draft when clicking cancel button in create content type process. There is inconsistency between create and update actions. In edit process clicking cancel button removes draft but not in create process. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
