### PR TITLE
IBX-6160: Fix tooltip text height calculation

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -105,6 +105,7 @@
             'font-style': computedNodeStyles.getPropertyValue('font-style'),
             'font-variant': computedNodeStyles.getPropertyValue('font-variant'),
             'line-height': computedNodeStyles.getPropertyValue('line-height'),
+            'word-break': 'break-all',
         };
 
         const textHeight = getTextHeight(title, styles);


### PR DESCRIPTION
Changes from PR https://github.com/ibexa/admin-ui/pull/851 because there is no way to check this fix for version 4.5
