### PR TITLE
Removed duplicated classes in form_fields.html.twig

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -48,17 +48,17 @@
 
 {% block form_row_subfield -%}
     {% set wrapper_class = 'ibexa-data-source__field ibexa-data-source__field--' ~ name %}
-    {% if required %}{% set wrapper_class = (wrapper_class ~ ' ibexa-data-source__field--required ibexa-data-source__field--required')|trim %}{% endif %}
+    {% if required %}{% set wrapper_class = (wrapper_class ~ ' ibexa-data-source__field--required')|trim %}{% endif %}
     {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' is-invalid')|trim %}{% endif %}
 
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ibexa-label ibexa-data-source__label ibexa-data-source__label')|trim}) %}
-    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ ' ibexa-data-source__label-wrapper ibexa-data-source__label-wrapper')|trim}) %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ibexa-label ibexa-data-source__label')|trim}) %}
+    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ ' ibexa-data-source__label-wrapper')|trim}) %}
     {% set attr = attr|merge({
-        class: (attr.class|default('') ~ ' ibexa-data-source__input ibexa-data-source__input ibexa-input--small')|trim,
+        class: (attr.class|default('') ~ ' ibexa-data-source__input ibexa-input--small')|trim,
         is_small: true,
     }) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({class: (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
-    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({class: (widget_wrapper_attr.class|default('') ~ ' ibexa-data-source__input-wrapper ibexa-data-source__input-wrapper')|trim}) %}
+    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({class: (widget_wrapper_attr.class|default('') ~ ' ibexa-data-source__input-wrapper')|trim}) %}
 
     {% if required %}{% set label_attr = label_attr|merge({'class': label_attr.class ~ ' required' }) %}{% endif %}
 
@@ -81,11 +81,11 @@
     {% set translation_mode = fieldtype.vars.mainLanguageCode != fieldtype.vars.languageCode %}
     {% set fieldtype_is_not_translatable = translation_mode and not fieldtype.vars.value.fieldDefinition.isTranslatable %}
 
-    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ibexa-field-edit__data ibexa-field-edit__data')|trim}) %}
-    {% set wrapper_class = 'ibexa-field-edit ibexa-field-edit--' ~ fieldtype_identifier ~ ' ibexa-field-edit ibexa-field-edit--' ~ fieldtype_identifier %}
+    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ibexa-field-edit__data')|trim}) %}
+    {% set wrapper_class = 'ibexa-field-edit ibexa-field-edit--' ~ fieldtype_identifier %}
 
     {% if fieldtype.vars.disabled %}
-        {% set wrapper_class = wrapper_class ~ ' ibexa-field-edit--disabled ibexa-field-edit--disabled' %}
+        {% set wrapper_class = wrapper_class ~ ' ibexa-field-edit--disabled' %}
         {% set attr = attr|merge({'readonly': 'readonly'}) %}
     {% endif %}
 
@@ -96,15 +96,15 @@
         {% endif %}
     {% endfor %}
 
-    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ibexa-field-edit--required ibexa-field-edit--required')|trim %}{% endif %}
+    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ibexa-field-edit--required')|trim %}{% endif %}
     {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' is-invalid')|trim %}{% endif %}
     {% if fieldtype_is_not_translatable %}
-        {% set wrapper_class = (wrapper_class|default('') ~ ' ibexa-field-edit--nontranslatable ibexa-field-edit--nontranslatable')|trim %}
+        {% set wrapper_class = (wrapper_class|default('') ~ ' ibexa-field-edit--nontranslatable')|trim %}
         {% set attr = attr|merge({'readonly': 'readonly'}) %}
     {% endif %}
-    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ 'ibexa-field-edit__label-wrapper ibexa-field-edit__label-wrapper')|trim}) %}
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ibexa-label ibexa-field-edit__label ibexa-field-edit__label')|trim}) %}
-    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-data-source__input ibexa-data-source__input')|trim}) %}
+    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ 'ibexa-field-edit__label-wrapper')|trim}) %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ibexa-label ibexa-field-edit__label')|trim}) %}
+    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-data-source__input')|trim}) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
 
     {% set field_type_descriptions = fieldtype.vars.value.fieldDefinition.descriptions %}
@@ -128,7 +128,7 @@
         {% endif %}
 
         {% if fieldtype_is_not_translatable %}
-            <p class="ibexa-field-edit__nontranslatable ibexa-field-edit__nontranslatable text-secondary">{{ 'fieldtype.translation_is_disabled'|trans({'%fieldName%': label})|desc('Translating the %fieldName% Field is disabled. See Content Type definition for details.') }}</p>
+            <p class="ibexa-field-edit__nontranslatable text-secondary">{{ 'fieldtype.translation_is_disabled'|trans({'%fieldName%': label})|desc('Translating the %fieldName% Field is disabled. See Content Type definition for details.') }}</p>
         {% endif %}
 
         {% set description = field_type_descriptions[fieldtype.vars.languageCode]|default(field_type_descriptions|first) %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | (or N/A)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
In form_fields.html.twig there are some classes duplicated. Is it necessary to have duplicity in these classes?

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
