### PR TITLE
IBX-6214: Added form submission with Enter key

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.edit.js
@@ -14,6 +14,7 @@
     const popupMenuElement = sectionsNode.querySelector('.ibexa-popup-menu');
     const addGroupTriggerBtn = sectionsNode.querySelector('.ibexa-content-type-edit__add-field-definitions-group-btn');
     const fieldDefinitionsGroups = doc.querySelectorAll('.ibexa-collapse--field-definitions-group');
+    const ENTER_KEY = 'Enter';
     const noFieldsAddedError = Translator.trans(
         /*@Desc("You have to add at least one field definition")*/ 'content_type.edit.error.no_added_fields_definition',
         {},
@@ -612,6 +613,22 @@
                     event.preventDefault();
                     scrollToInvalidInput();
                 }
+            }
+        },
+        false,
+    );
+
+    editForm.addEventListener(
+        'keydown',
+        (event) => {
+            const activeElementType = typeof doc.activeElement.type !== 'undefined' ? doc.activeElement.type.toLowerCase() : '';
+
+            if (event.key === ENTER_KEY && activeElementType !== 'textarea') {
+                event.preventDefault();
+
+                const button = doc.querySelector('.ibexa-edit-header__context-actions .ibexa-btn--primary');
+
+                button.click();
             }
         },
         false,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6214
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


After talking to the design team, we agreed that enter should send the form as if we had pressed the primary button

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
