### PR TITLE
IBX-5854: Added base backoffice path to adminUI config

### DIFF
--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -68,7 +68,7 @@ parameters:
     ibexa.site_access.config.admin_group.user_edit.templates.create: '@@ibexadesign/user/create.html.twig'
 
     # Content Tree Module
-    ibexa.site_access.config.admin_group.content_tree_module.load_more_limit: 5
+    ibexa.site_access.config.admin_group.content_tree_module.load_more_limit: 30
     ibexa.site_access.config.admin_group.content_tree_module.children_load_max_limit: 200
     ibexa.site_access.config.admin_group.content_tree_module.tree_max_depth: 10
     ibexa.site_access.config.admin_group.content_tree_module.allowed_content_types: []

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -68,7 +68,7 @@ parameters:
     ibexa.site_access.config.admin_group.user_edit.templates.create: '@@ibexadesign/user/create.html.twig'
 
     # Content Tree Module
-    ibexa.site_access.config.admin_group.content_tree_module.load_more_limit: 30
+    ibexa.site_access.config.admin_group.content_tree_module.load_more_limit: 5
     ibexa.site_access.config.admin_group.content_tree_module.children_load_max_limit: 200
     ibexa.site_access.config.admin_group.content_tree_module.tree_max_depth: 10
     ibexa.site_access.config.admin_group.content_tree_module.allowed_content_types: []

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -121,3 +121,7 @@ services:
     Ibexa\AdminUi\UI\Config\Provider\BackOfficeLanguage:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'backOfficeLanguage' }
+
+    Ibexa\AdminUi\UI\Config\Provider\CurrentBackOfficePath:
+        tags:
+            - { name: ibexa.admin_ui.config.provider, key: 'backOfficePath' }

--- a/src/bundle/Resources/public/js/scripts/adaptive.filters.js
+++ b/src/bundle/Resources/public/js/scripts/adaptive.filters.js
@@ -11,7 +11,7 @@
             const cookieValue = isExpanded ? 'true' : 'false';
 
             if (expandedInfoCookieName) {
-                ibexa.helpers.cookies.setCookie(expandedInfoCookieName, cookieValue);
+                ibexa.helpers.cookies.setBackOfficeCookie(expandedInfoCookieName, cookieValue);
             }
         };
         const collapse = bootstrap.Collapse.getOrCreateInstance(adaptiveItemsCollapsibleContainer, {

--- a/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
@@ -1,6 +1,7 @@
 (function (global, doc, ibexa) {
     const setCookie = (name, value, maxAgeDays = 356, path = '/') => {
         const maxAge = maxAgeDays * 24 * 60 * 60;
+        path = '/admin';
 
         doc.cookie = `${name}=${value};max-age=${maxAge};path=${path}`;
     };

--- a/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
@@ -3,7 +3,6 @@
     const setBackOfficeCookie = (name, value, maxAgeDays = 356, path = backOfficePath) => {
         setCookie(name, value, maxAgeDays, path);
     };
-
     const setCookie = (name, value, maxAgeDays = 356, path = '/') => {
         const maxAge = maxAgeDays * 24 * 60 * 60;
 

--- a/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
@@ -1,7 +1,12 @@
 (function (global, doc, ibexa) {
+    const { backOfficePath } = ibexa.adminUiConfig;
+
+    const setBackOfficeCookie = (name, value, maxAgeDays = 356, path = backOfficePath) => {
+        setCookie(name, value, maxAgeDays, path);
+    };
+
     const setCookie = (name, value, maxAgeDays = 356, path = '/') => {
         const maxAge = maxAgeDays * 24 * 60 * 60;
-        path = '/admin';
 
         doc.cookie = `${name}=${value};max-age=${maxAge};path=${path}`;
     };
@@ -22,5 +27,6 @@
     ibexa.addConfig('helpers.cookies', {
         getCookie,
         setCookie,
+        setBackOfficeCookie,
     });
 })(window, window.document, window.ibexa);

--- a/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/cookies.helper.js
@@ -1,6 +1,5 @@
 (function (global, doc, ibexa) {
     const { backOfficePath } = ibexa.adminUiConfig;
-
     const setBackOfficeCookie = (name, value, maxAgeDays = 356, path = backOfficePath) => {
         setCookie(name, value, maxAgeDays, path);
     };

--- a/src/bundle/Resources/public/js/scripts/sidebar/main.menu.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/main.menu.js
@@ -81,7 +81,7 @@
         const isSecondLevelMenuCollapsed = secondLevelMenuNode.classList.contains('ibexa-main-menu__navbar--collapsed');
         const newMenuWidth = isSecondLevelMenuCollapsed ? SECOND_LEVEL_EXPANDED_WIDTH : SECOND_LEVEL_COLLAPSED_WIDTH;
 
-        ibexa.helpers.cookies.setCookie('second_menu_width', newMenuWidth);
+        ibexa.helpers.cookies.setBackOfficeCookie('second_menu_width', newMenuWidth);
         setWidthOfSecondLevelMenu();
     };
     const parsePopup = (button) => {
@@ -131,7 +131,7 @@
         const resizeValue = secondMenuLevelCurrentWidth + (clientX - resizeStartPositionX);
         const newMenuWidth = resizeValue > SECOND_LEVEL_MANUAL_RESIZE_MIN_WIDTH ? resizeValue : SECOND_LEVEL_COLLAPSED_WIDTH;
 
-        ibexa.helpers.cookies.setCookie('second_menu_width', newMenuWidth);
+        ibexa.helpers.cookies.setBackOfficeCookie('second_menu_width', newMenuWidth);
         setWidthOfSecondLevelMenu();
     };
 

--- a/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
+++ b/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
@@ -27,7 +27,7 @@ final class CurrentBackOfficePath implements ProviderInterface
          * We need base path here, to properly set backoffice cookies only,
          * so they do not interfere with front end SiteAccesses.
          * Generating route for `/` allows us to make sure that we do not have any additional parameters
-         *  and we get raw path to back office.
+         * and we get raw path to back office.
          * We are not using reverse matchers here as they work in context of current request.
          */
         $routeInfo = $this->router->match('/');

--- a/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
+++ b/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Config\Provider;
+
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+final class CurrentBackOfficePath implements ProviderInterface
+{
+    private RouterInterface $router;
+
+    public function __construct(
+        RouterInterface $router
+    ) {
+        $this->router = $router;
+    }
+
+    public function getConfig(): string
+    {
+        /*
+         * We need base path here, to properly set backoffice cookies only,
+         *  so they do not interfere with front end site accesses.
+         * Generating route for `/` allows us to make sure that we do not have any additional parameters
+         *  and we get raw path to back office.
+         * We are not using reverse matchers here as they work in context of current request.
+         */
+        $routeInfo = $this->router->match('/');
+        $path = $this->router->generate($routeInfo['_route'], $routeInfo);
+        $pathInfo = pathinfo($path);
+
+        return $pathInfo['dirname'];
+    }
+}

--- a/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
+++ b/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
@@ -25,7 +25,7 @@ final class CurrentBackOfficePath implements ProviderInterface
     {
         /*
          * We need base path here, to properly set backoffice cookies only,
-         *  so they do not interfere with front end site accesses.
+         * so they do not interfere with front end SiteAccesses.
          * Generating route for `/` allows us to make sure that we do not have any additional parameters
          *  and we get raw path to back office.
          * We are not using reverse matchers here as they work in context of current request.

--- a/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
+++ b/src/lib/UI/Config/Provider/CurrentBackOfficePath.php
@@ -9,16 +9,21 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\UI\Config\Provider;
 
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Symfony\Component\Routing\RouterInterface;
 
 final class CurrentBackOfficePath implements ProviderInterface
 {
     private RouterInterface $router;
 
+    private Repository $repository;
+
     public function __construct(
-        RouterInterface $router
+        RouterInterface $router,
+        Repository $repository
     ) {
         $this->router = $router;
+        $this->repository = $repository;
     }
 
     public function getConfig(): string
@@ -29,11 +34,17 @@ final class CurrentBackOfficePath implements ProviderInterface
          * Generating route for `/` allows us to make sure that we do not have any additional parameters
          * and we get raw path to back office.
          * We are not using reverse matchers here as they work in context of current request.
+         *
+         * Sudo is used to avoid insufficient permissions on reading root Location.
          */
-        $routeInfo = $this->router->match('/');
-        $path = $this->router->generate($routeInfo['_route'], $routeInfo);
-        $pathInfo = pathinfo($path);
+        return $this->repository->sudo(
+            function (Repository $repository): string {
+                $routeInfo = $this->router->match('/');
+                $path = $this->router->generate($routeInfo['_route'], $routeInfo);
+                $pathInfo = pathinfo($path);
 
-        return $pathInfo['dirname'];
+                return $pathInfo['dirname'];
+            }
+        );
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5854
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

For @ibexa/javascript-dev,
we would also need to unify used cookies names, as atm we have:
```
second_menu_width
ibexa-tb-ibexa-category-filter-tree-%d-container-width
ibexa-tb-ibexa-taxonomy-tree-%d-+-container-width
ibexa-tb-ibexa-content-tree-%d-container-width
ibexa_adaptive_filters-is_expanded-ibexa_om_orders_list
```

### Q&A:
This is just part of the solution for the issue. What needs to be checked here if backoffice path is always properly added to adminUI conig with different siteAccess configurations.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
