### PR TITLE
IBX-6260: Fixed preview voter taking language priority into consideration

### DIFF
--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -32,38 +32,25 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
      */
     public function vote(SiteaccessPreviewVoterContext $context): bool
     {
-        $siteaccess = $context->getSiteaccess();
+        $siteAccess = $context->getSiteaccess();
         $location = $context->getLocation();
         $languageCode = $context->getLanguageCode();
-        $contentLanguages = $context->getVersionInfo()->languageCodes;
 
-        if (empty(array_intersect($this->getRootLocationIds($siteaccess), $location->path))) {
+        if (empty(array_intersect($this->getRootLocationIds($siteAccess), $location->path))) {
             return false;
         }
 
-        if (!$this->validateRepositoryMatch($siteaccess)) {
+        if (!$this->validateRepositoryMatch($siteAccess)) {
             return false;
         }
 
-        $siteaccessLanguages = $this->configResolver->getParameter(
+        $siteAccessLanguages = $this->configResolver->getParameter(
             'languages',
             null,
-            $siteaccess
+            $siteAccess
         );
 
-        if (!in_array($languageCode, $siteaccessLanguages, true)) {
-            return false;
-        }
-
-        $primarySiteaccessLanguage = reset($siteaccessLanguages);
-        if (
-            $languageCode !== $primarySiteaccessLanguage
-            && in_array($primarySiteaccessLanguage, $contentLanguages)
-        ) {
-            return false;
-        }
-
-        return true;
+        return in_array($languageCode, $siteAccessLanguages, true);
     }
 
     protected function validateRepositoryMatch(string $siteaccess): bool


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6260
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Possible siteAccesses to display given content should not take language order into consideration. It should be matter of selector, to pick _the most proper_ one out of those.

This same issue came up, when having identical siteAccess configuration (as in ticket), you tried to just translate any other content into other language and you get `Preview unavailable` information, when there clearly was one to do it.

Same issue goes up in 3.3 version, but as there, page-builder logic is separated from this one, it would require different approach (and it is possible to translate landing page there, it is only issue of the preview, so it is not as severe there).

For usage & tests:
https://github.com/ibexa/page-builder/pull/237
#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
