### PR TITLE
Fixed extraction of translation

### DIFF
--- a/src/lib/Menu/Admin/ContentType/AbstractContentTypeRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/AbstractContentTypeRightSidebarBuilder.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Menu\Admin\ContentType;
 
 use Ibexa\Contracts\AdminUi\Menu\AbstractBuilder;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Knp\Menu\ItemInterface;
 
-abstract class AbstractContentTypeRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+abstract class AbstractContentTypeRightSidebarBuilder extends AbstractBuilder
 {
     public function createStructure(array $options): ItemInterface
     {

--- a/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
@@ -8,13 +8,14 @@ namespace Ibexa\AdminUi\Menu\Admin\ContentType;
 
 use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
  *
  * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
  */
-class ContentTypeCreateRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder
+class ContentTypeCreateRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder implements TranslationContainerInterface
 {
     /* Menu items */
     public const ITEM__SAVE = 'content_type_create__sidebar_right__save';

--- a/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
@@ -8,13 +8,14 @@ namespace Ibexa\AdminUi\Menu\Admin\ContentType;
 
 use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
  *
  * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
  */
-class ContentTypeEditRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder
+class ContentTypeEditRightSidebarBuilder extends AbstractContentTypeRightSidebarBuilder implements TranslationContainerInterface
 {
     /* Menu items */
     public const ITEM__SAVE = 'content_type_edit__sidebar_right__save';


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixes an error which occurred during the extraction of translations:

```
In TranslationContainerExtractor.php line 112:
                                                                                                                                                         
  call_user_func() expects parameter 1 to be a valid callback, cannot call abstract method Ibexa\AdminUi\Menu\Admin\ContentType\AbstractContentTypeRigh  
  tSidebarBuilder::getTranslationMessages()  
```


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
