### PR TITLE
IBX-6327: Added missing content_type_name parameter

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -32,6 +32,7 @@
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
         icon_name: 'content-type',
+        content_type_name: content_type.name,
         show_autosave_status: true,
         description: content_type.description,
         subtitle: 'editing_details'|trans({ '%location_name%': parent_location.contentInfo.name, '%language%': language.name })|desc('under %location_name% in %language%'),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6327
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
