### PR TITLE
IBX-5886: Dispatched `ContentCreateContentTypeChoiceLoaderEvent`

### DIFF
--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -46,7 +46,10 @@ services:
         arguments:
             $configResolver: '@ibexa.config.resolver'
 
-    Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentCreateContentTypeChoiceLoader: ~
+    Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentCreateContentTypeChoiceLoader:
+        arguments:
+            $contentTypeChoiceLoader: '@Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader'
+            $eventDispatcher: '@event_dispatcher'
 
     Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentCreateLanguageChoiceLoader: ~
 
@@ -80,7 +83,7 @@ services:
 
     Ibexa\AdminUi\Form\Type\Content\Draft\ContentCreateType:
         arguments:
-            $contentTypeChoiceLoader: '@Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader'
+            $contentCreateContentTypeChoiceLoader: '@Ibexa\AdminUi\Form\Type\ChoiceList\Loader\ContentCreateContentTypeChoiceLoader'
             $languageChoiceLoader: '@Ibexa\AdminUi\Form\Type\ChoiceList\Loader\LanguageChoiceLoader'
 
     Ibexa\AdminUi\Form\Type\Content\Draft\ContentEditType: ~

--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -31,7 +31,7 @@ class ContentCreateType extends AbstractType
     protected $languageService;
 
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
-    private $contentTypeChoiceLoader;
+    private $contentCreateContentTypeChoiceLoader;
 
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
     private $languageChoiceLoader;
@@ -51,13 +51,13 @@ class ContentCreateType extends AbstractType
      */
     public function __construct(
         LanguageService $languageService,
-        ChoiceLoaderInterface $contentTypeChoiceLoader,
+        ContentCreateContentTypeChoiceLoader $contentCreateContentTypeChoiceLoader,
         ChoiceLoaderInterface $languageChoiceLoader,
         PermissionCheckerInterface $permissionChecker,
         LookupLimitationsTransformer $lookupLimitationsTransformer
     ) {
         $this->languageService = $languageService;
-        $this->contentTypeChoiceLoader = $contentTypeChoiceLoader;
+        $this->contentCreateContentTypeChoiceLoader = $contentCreateContentTypeChoiceLoader;
         $this->languageChoiceLoader = $languageChoiceLoader;
         $this->permissionChecker = $permissionChecker;
         $this->lookupLimitationsTransformer = $lookupLimitationsTransformer;
@@ -93,7 +93,8 @@ class ContentCreateType extends AbstractType
                     'label' => false,
                     'multiple' => false,
                     'expanded' => true,
-                    'choice_loader' => new ContentCreateContentTypeChoiceLoader($this->contentTypeChoiceLoader, $restrictedContentTypesIds),
+                    'choice_loader' => $this->contentCreateContentTypeChoiceLoader
+                        ->setRestrictedContentTypeIds($restrictedContentTypesIds),
                 ]
             )
             ->add(

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ibexa\AdminUi\Form\Type\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ContentCreateContentTypeChoiceLoaderEvent extends Event
+{
+    public const RESOLVE_CONTENT_TYPES = 'admin_ui.content_create.content_type_resolve';
+
+    /** @var array<string, array> */
+    private array $contentTypeGroups;
+
+    public function __construct(array $contentTypeGroups) {
+        $this->contentTypeGroups = $contentTypeGroups;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getContentTypeGroups(): array
+    {
+        return $this->contentTypeGroups;
+    }
+
+    /**
+     * @param array<string, array> $contentTypeGroups
+     */
+    public function setContentTypeGroups(array $contentTypeGroups): void
+    {
+        $this->contentTypeGroups = $contentTypeGroups;
+    }
+}

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -12,7 +12,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
 {
     public const RESOLVE_CONTENT_TYPES = 'admin_ui.content_create.content_type_resolve';
 
-    /** @var array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> */
+    /** @var array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> */
     private array $contentTypeGroups;
 
     public function __construct(array $contentTypeGroups)
@@ -21,7 +21,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     }
 
     /**
-     * @return array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>>
+     * @return array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>>
      */
     public function getContentTypeGroups(): array
     {
@@ -29,7 +29,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     }
 
     /**
-     * @param array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
+     * @param array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
      */
     public function setContentTypeGroups(array $contentTypeGroups): void
     {

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -12,7 +12,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
 {
     public const RESOLVE_CONTENT_TYPES = 'admin_ui.content_create.content_type_resolve';
 
-    /** @var array<string, array> */
+    /** @var array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> */
     private array $contentTypeGroups;
 
     public function __construct(array $contentTypeGroups)
@@ -21,7 +21,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>>
      */
     public function getContentTypeGroups(): array
     {
@@ -29,7 +29,7 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     }
 
     /**
-     * @param array<string, array> $contentTypeGroups
+     * @param array<string, array<Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
      */
     public function setContentTypeGroups(array $contentTypeGroups): void
     {

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace Ibexa\AdminUi\Form\Type\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
@@ -11,7 +15,8 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     /** @var array<string, array> */
     private array $contentTypeGroups;
 
-    public function __construct(array $contentTypeGroups) {
+    public function __construct(array $contentTypeGroups)
+    {
         $this->contentTypeGroups = $contentTypeGroups;
     }
 

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -29,10 +29,10 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     }
 
     /**
-     * @param array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
+     * @param array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType> $contentTypes
      */
-    public function setContentTypeGroups(array $contentTypeGroups): void
+    public function addContentTypeGroup(string $name, array $contentTypes): void
     {
-        $this->contentTypeGroups = $contentTypeGroups;
+        $this->contentTypeGroups[$name] = $contentTypes;
     }
 }

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\AdminUi\Form\Type\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-5886](https://issues.ibexa.co/browse/IBX-5886)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR refactors `ContentCreateType` to utilize `ContentCreateContentTypeChoiceLoader` as a service. Aside from that event is dispatched when loading content types.

Related PR: https://github.com/ibexa/taxonomy/pull/215

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
