### PR TITLE
IBX-6230: Fix incorrect CSS selectors in Behat code

### DIFF
--- a/src/lib/Behat/Component/Fields/Matrix.php
+++ b/src/lib/Behat/Component/Fields/Matrix.php
@@ -54,7 +54,6 @@ class Matrix extends FieldTypeComponent
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('matrixCellSelectorFormat', '[name="ezplatform_content_forms_content_edit[fieldsData][ezmatrix][value][entries][%d][%s]"]'),
             new VisibleCSSLocator('row', '.ibexa-table__row'),
             new VisibleCSSLocator('addRowButton', '.ibexa-btn--add-matrix-entry'),
             new VisibleCSSLocator('viewModeTableHeaders', 'thead th'),
@@ -94,11 +93,7 @@ class Matrix extends FieldTypeComponent
 
     private function internalSetValue(int $rowIndex, string $column, $value): void
     {
-        $matrixCellSelector = CSSLocatorBuilder::combine(
-            $this->getLocator('matrixCellSelectorFormat')->getSelector(),
-            new VisibleCSSLocator('rowIndex', (string) $rowIndex),
-            new VisibleCSSLocator('columnIndex', $column),
-        );
+        $matrixCellSelector = new VisibleCSSLocator('matrixCell', sprintf('[name="ezplatform_content_forms_content_edit[fieldsData][ezmatrix][value][entries][%d][%s]"]', $rowIndex, $column));
 
         $this->getHTMLPage()->find($matrixCellSelector)->setValue($value);
     }

--- a/src/lib/Behat/Component/Fields/Matrix.php
+++ b/src/lib/Behat/Component/Fields/Matrix.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
-use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;

--- a/src/lib/Behat/Component/Table/TableBuilder.php
+++ b/src/lib/Behat/Component/Table/TableBuilder.php
@@ -52,7 +52,7 @@ class TableBuilder
             new VisibleCSSLocator('empty', '.ibexa-table__empty-table-cell'),
             new VisibleCSSLocator('columnHeader', '.ibexa-table__header-cell,th'),
             new VisibleCSSLocator('row', 'tr'),
-            new VisibleCSSLocator('cell', '.ibexa-table__cell:nth-of-type(%d),td:nth-of-type(%d)'),
+            new VisibleCSSLocator('cell', 'div.ibexa-table__cell:nth-of-type(%d),td:nth-of-type(%d)'),
             new VisibleCSSLocator('parent', '.ibexa-table'),
         ]);
 

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -211,10 +211,10 @@ class UniversalDiscoveryWidget extends Component
             new VisibleCSSLocator('previewImage', '.c-content-meta-preview__preview'),
             // selectors for path traversal
             new CSSLocator('treeLevelFormat', '.c-finder-branch:nth-child(%d)'),
-            new CSSLocator('treeLevelElementsFormat', '.c-finder-branch:nth-of-type(%d) .c-finder-leaf'),
+            new CSSLocator('treeLevelElementsFormat', 'div.c-finder-branch:nth-of-type(%d) .c-finder-leaf'),
             new CSSLocator('elementName', '.c-finder-leaf__name'),
             new CSSLocator('input', '.c-udw-toggle-selection'),
-            new CSSLocator('treeLevelSelectedFormat', '.c-finder-branch:nth-of-type(%d) .c-finder-leaf--marked'),
+            new CSSLocator('treeLevelSelectedFormat', 'div.c-finder-branch:nth-of-type(%d) .c-finder-leaf--marked'),
             // itemActions
             new VisibleCSSLocator('contentPreview', '.c-content-meta-preview'),
             new CSSLocator('editButton', '.c-content-edit-button__btn'),

--- a/src/lib/Behat/Page/ContentTypePage.php
+++ b/src/lib/Behat/Page/ContentTypePage.php
@@ -101,7 +101,7 @@ class ContentTypePage extends Page
             new VisibleCSSLocator('createButton', '.btn-icon .ibexa-icon--create'),
             new VisibleCSSLocator('pageTitle', '.ibexa-page-title h1'),
             new VisibleCSSLocator('contentTypeDataTable', '.ibexa-details .ibexa-table'),
-            new VisibleCSSLocator('contentFieldsTable', 'section.ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('contentFieldsTable', 'section.ibexa-fieldgroup:nth-of-type(1)'),
             new VisibleCSSLocator('globalPropertiesItem', '.ibexa-details__item'),
             new VisibleCSSLocator('globalPropertiesLabel', '.ibexa-details__item-label'),
             new VisibleCSSLocator('globalPropertiesValue', '.ibexa-details__item-content'),

--- a/src/lib/Behat/Page/ContentTypePage.php
+++ b/src/lib/Behat/Page/ContentTypePage.php
@@ -101,7 +101,7 @@ class ContentTypePage extends Page
             new VisibleCSSLocator('createButton', '.btn-icon .ibexa-icon--create'),
             new VisibleCSSLocator('pageTitle', '.ibexa-page-title h1'),
             new VisibleCSSLocator('contentTypeDataTable', '.ibexa-details .ibexa-table'),
-            new VisibleCSSLocator('contentFieldsTable', 'div.ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('contentFieldsTable', 'section.ibexa-fieldgroup:nth-of-type(2)'),
             new VisibleCSSLocator('globalPropertiesItem', '.ibexa-details__item'),
             new VisibleCSSLocator('globalPropertiesLabel', '.ibexa-details__item-label'),
             new VisibleCSSLocator('globalPropertiesValue', '.ibexa-details__item-content'),

--- a/src/lib/Behat/Page/ContentTypePage.php
+++ b/src/lib/Behat/Page/ContentTypePage.php
@@ -101,7 +101,7 @@ class ContentTypePage extends Page
             new VisibleCSSLocator('createButton', '.btn-icon .ibexa-icon--create'),
             new VisibleCSSLocator('pageTitle', '.ibexa-page-title h1'),
             new VisibleCSSLocator('contentTypeDataTable', '.ibexa-details .ibexa-table'),
-            new VisibleCSSLocator('contentFieldsTable', '.ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('contentFieldsTable', 'div.ibexa-fieldgroup:nth-of-type(2)'),
             new VisibleCSSLocator('globalPropertiesItem', '.ibexa-details__item'),
             new VisibleCSSLocator('globalPropertiesLabel', '.ibexa-details__item-label'),
             new VisibleCSSLocator('globalPropertiesValue', '.ibexa-details__item-content'),

--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -78,7 +78,7 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
         $fieldSelector = new VisibleCSSLocator(
             'field',
             sprintf(
-                '.ibexa-available-field-types__list > li:not(.ibexa-available-field-type--hidden) .ibexa-available-field-type__content:nth-of-type(%d)',
+                '.ibexa-available-field-types__list > li:not(.ibexa-available-field-type--hidden) div.ibexa-available-field-type__content:nth-of-type(%d)',
                 $fieldPosition
             )
         );

--- a/src/lib/Behat/Page/SystemInfoPage.php
+++ b/src/lib/Behat/Page/SystemInfoPage.php
@@ -82,7 +82,7 @@ class SystemInfoPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('packagesTable', '.tab-pane.active div.ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('packagesTable', '.tab-pane.active section.ibexa-fieldgroup:nth-of-type(2)'),
         ];
     }
 

--- a/src/lib/Behat/Page/SystemInfoPage.php
+++ b/src/lib/Behat/Page/SystemInfoPage.php
@@ -82,7 +82,7 @@ class SystemInfoPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('packagesTable', '.tab-pane.active .ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('packagesTable', '.tab-pane.active div.ibexa-fieldgroup:nth-of-type(2)'),
         ];
     }
 

--- a/src/lib/Behat/Page/SystemInfoPage.php
+++ b/src/lib/Behat/Page/SystemInfoPage.php
@@ -82,7 +82,7 @@ class SystemInfoPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('packagesTable', '.tab-pane.active section.ibexa-fieldgroup:nth-of-type(2)'),
+            new VisibleCSSLocator('packagesTable', '.tab-pane.active section.ibexa-fieldgroup:nth-of-type(1)'),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6230](https://issues.ibexa.co/browse/IBX-6230)
| Bug fix?      | no (behat)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This is the second part of the task (first part is done in https://github.com/ibexa/behat/pull/69 which covers validation for new selectors).

This fixes existing wrong selectors in this repo.

Tests for all PRs combined: https://github.com/ibexa/commerce/pull/348.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
