### PR TITLE
IBX-3698: Conditional icon for form_help

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -383,10 +383,14 @@
 {% block form_help -%}
     {%- if help is not empty -%}
         {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' ibexa-form-help')|trim}) -%}
+        {%- set with_icon = help_attr.with_icon is defined ? help_attr.with_icon : true -%}
+
         <small id="{{ id }}_help"{% with { attr: help_attr } %}{{ block('attributes') }}{% endwith %}>
-            <svg class="ibexa-icon ibexa-icon--small ibexa-form-help__icon">
-                <use xlink:href="{{ ibexa_icon_path('system-information') }}"></use>
-            </svg>
+            {% if with_icon %}
+                <svg class="ibexa-icon ibexa-icon--small ibexa-form-help__icon">
+                    <use xlink:href="{{ ibexa_icon_path('system-information') }}"></use>
+                </svg>
+            {% endif %}
             <div class="ibexa-form-help__content">
                 {%- if translation_domain is same as(false) -%}
                     {%- if help_html is same as(false) -%}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3698
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Added properties `help_attr.with_icon|default(true)` to display icons in the `form_help` block 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
