### PR TITLE
IBX-6566: As a Editor I'd like to get content type suggestions while creating content in given location

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6341,7 +6341,7 @@ parameters:
 			path: src/lib/Form/Type/Content/CustomUrl/CustomUrlRemoveType.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Loader\\\\ChoiceLoaderInterface\\:\\:setRestrictedContentTypeIds\\(\\)\\.$#"
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Loader\\\\ChoiceLoaderInterface\\:\\:setTargetLocation\\(\\)\\.$#"
 			count: 1
 			path: src/lib/Form/Type/Content/Draft/ContentCreateType.php
 
@@ -6784,11 +6784,6 @@ parameters:
 			message: "#^Method Ibexa\\\\AdminUi\\\\Form\\\\Type\\\\Embedded\\\\SectionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Form/Type/Embedded/SectionType.php
-
-		-
-			message: "#^Method Ibexa\\\\AdminUi\\\\Form\\\\Type\\\\Event\\\\ContentCreateContentTypeChoiceLoaderEvent\\:\\:__construct\\(\\) has parameter \\$contentTypeGroups with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6341,11 +6341,6 @@ parameters:
 			path: src/lib/Form/Type/Content/CustomUrl/CustomUrlRemoveType.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Loader\\\\ChoiceLoaderInterface\\:\\:setTargetLocation\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Form/Type/Content/Draft/ContentCreateType.php
-
-		-
 			message: "#^Method Ibexa\\\\AdminUi\\\\Form\\\\Type\\\\Content\\\\Draft\\\\ContentCreateType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -6362,11 +6357,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\AdminUi\\\\Form\\\\Type\\\\Content\\\\Draft\\\\ContentCreateType\\:\\:getLimitationValuesForLocation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Form/Type/Content/Draft/ContentCreateType.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$contentTypeChoiceLoader$#"
 			count: 1
 			path: src/lib/Form/Type/Content/Draft/ContentCreateType.php
 

--- a/src/bundle/Resources/translations/ibexa_content_create.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_create.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="26902ae74a03f81c299e5a32051f2ab1eb69d63f" resname="content_type_suggestions">
+        <source>Suggestions</source>
+        <target state="new">Suggestions</target>
+        <note>key: content_type_suggestions</note>
+      </trans-unit>
       <trans-unit id="ad4e9a4e42b99d945f972bab5a2eff694d283793" resname="creating">
         <source>Creating</source>
         <target state="new">Creating</target>

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -47,21 +47,24 @@
 {%- endblock -%}
 
 {%- block content_type_choice_widget_options -%}
-    {%- for group_label, choice in options -%}
-        {%- if choice is iterable -%}
+    {%- for key, option in options -%}
+        {%- if option is iterable -%}
             <div class="ibexa-instant-filter__group">
-                <div class="ibexa-instant-filter__group-name">{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}</div>
-                {%- set options = choice -%}
+                <div class="ibexa-instant-filter__group-name">
+                    {{ choice_translation_domain is same as(false) ? key : key|trans({}, choice_translation_domain) }}
+                </div>
+
+                {%- set options = option -%}
                 {{- block('content_type_choice_widget_options') -}}
             </div>
         {%- else -%}
             <div class="ibexa-instant-filter__group-item">
-                <label class="ibexa-instant-filter__group-item-label-icon" for="{{ form[choice.value].vars.id }}">
+                <label class="ibexa-instant-filter__group-item-label-icon" for="{{ form[key].vars.id }}">
                     <svg class="ibexa-icon ibexa-icon--small">
-                        <use xlink:href="{{ ibexa_content_type_icon(choice.value) }}"></use>
+                        <use xlink:href="{{ ibexa_content_type_icon(option.value) }}"></use>
                     </svg>
                 </label>
-                {{ form_widget(form[choice.value]) }}
+                {{ form_widget(form[key]) }}
             </div>
         {%- endif -%}
     {%- endfor -%}

--- a/src/lib/EventListener/ContentTypeSuggestionsListener.php
+++ b/src/lib/EventListener/ContentTypeSuggestionsListener.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\EventListener;
+
+use Ibexa\AdminUi\Form\Type\Event\ContentCreateContentTypeChoiceLoaderEvent;
+use Ibexa\Contracts\Core\Repository\SearchService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\ParentLocationId;
+use JMS\TranslationBundle\Annotation\Desc;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ContentTypeSuggestionsListener implements EventSubscriberInterface
+{
+    private const SUGGESTIONS_AGGREGATION_KEY = 'suggestions';
+
+    private SearchService $searchService;
+
+    private TranslatorInterface $translator;
+
+    private int $limit;
+
+    public function __construct(SearchService $searchService, TranslatorInterface $translator, int $limit = 4)
+    {
+        $this->searchService = $searchService;
+        $this->translator = $translator;
+        $this->limit = $limit;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES => 'onResolveContentTypes',
+        ];
+    }
+
+    public function onResolveContentTypes(ContentCreateContentTypeChoiceLoaderEvent $event): void
+    {
+        if ($this->limit < 1 || $event->getTargetLocation() === null) {
+            return;
+        }
+
+        if (!$this->searchService->supports(SearchService::CAPABILITY_AGGREGATIONS)) {
+            return;
+        }
+
+        $suggestions = $this->getSuggestions($event->getTargetLocation());
+        if (!empty($suggestions)) {
+            $event->setContentTypeGroups([
+                $this->getSuggestionsGroupLabel() => $suggestions,
+            ] + $event->getContentTypeGroups());
+        }
+    }
+
+    private function getSuggestionsGroupLabel(): string
+    {
+        return $this->translator->trans(
+            /** @Desc("Suggestions") */
+            'content_type_suggestions',
+            [],
+            'ibexa_content_create'
+        );
+    }
+
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType[]
+     */
+    private function getSuggestions(Location $location): array
+    {
+        $aggregation = new ContentTypeTermAggregation(self::SUGGESTIONS_AGGREGATION_KEY);
+        $aggregation->setLimit($this->limit);
+
+        $query = new LocationQuery();
+        $query->limit = 0;
+        $query->filter = new ParentLocationId($location->id);
+        $query->aggregations[] = $aggregation;
+        $query->performCount = false;
+
+        $results = $this->searchService->findLocations($query);
+
+        if ($results->aggregations->has(self::SUGGESTIONS_AGGREGATION_KEY)) {
+            /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult $aggregationResult */
+            $aggregationResult = $results->aggregations->get(self::SUGGESTIONS_AGGREGATION_KEY);
+
+            $suggestions = [];
+            foreach ($aggregationResult->getEntries() as $entry) {
+                $suggestions[] = $entry->getKey();
+            }
+
+            return $suggestions;
+        }
+
+        return [];
+    }
+}

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Form\Type\ChoiceList\Loader;
 
 use Ibexa\AdminUi\Form\Type\Event\ContentCreateContentTypeChoiceLoaderEvent;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
@@ -18,10 +19,12 @@ class ContentCreateContentTypeChoiceLoader implements ChoiceLoaderInterface
 {
     private ContentTypeChoiceLoader $contentTypeChoiceLoader;
 
+    private EventDispatcherInterface $eventDispatcher;
+
     /** @var array<int> */
     private array $restrictedContentTypesIds;
 
-    private EventDispatcherInterface $eventDispatcher;
+    private ?Location $targetLocation = null;
 
     public function __construct(
         ContentTypeChoiceLoader $contentTypeChoiceLoader,
@@ -38,6 +41,18 @@ class ContentCreateContentTypeChoiceLoader implements ChoiceLoaderInterface
         return $this;
     }
 
+    public function getTargetLocation(): ?Location
+    {
+        return $this->targetLocation;
+    }
+
+    public function setTargetLocation(?Location $targetLocation): self
+    {
+        $this->targetLocation = $targetLocation;
+
+        return $this;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -46,7 +61,7 @@ class ContentCreateContentTypeChoiceLoader implements ChoiceLoaderInterface
         $contentTypesGroups = $this->contentTypeChoiceLoader->getChoiceList();
 
         $event = $this->eventDispatcher->dispatch(
-            new ContentCreateContentTypeChoiceLoaderEvent($contentTypesGroups),
+            new ContentCreateContentTypeChoiceLoaderEvent($contentTypesGroups, $this->targetLocation),
             ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES
         );
 

--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -30,8 +30,7 @@ class ContentCreateType extends AbstractType
     /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
     protected $languageService;
 
-    /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
-    private $contentCreateContentTypeChoiceLoader;
+    private ContentCreateContentTypeChoiceLoader $contentCreateContentTypeChoiceLoader;
 
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
     private $languageChoiceLoader;
@@ -44,7 +43,6 @@ class ContentCreateType extends AbstractType
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\LanguageService $languageService
-     * @param \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface $contentTypeChoiceLoader
      * @param \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface $languageChoiceLoader
      * @param \Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface $permissionChecker
      * @param \Ibexa\AdminUi\Permission\LookupLimitationsTransformer $lookupLimitationsTransformer

--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -94,6 +94,7 @@ class ContentCreateType extends AbstractType
                     'multiple' => false,
                     'expanded' => true,
                     'choice_loader' => $this->contentCreateContentTypeChoiceLoader
+                        ->setTargetLocation($location)
                         ->setRestrictedContentTypeIds($restrictedContentTypesIds),
                 ]
             )

--- a/src/lib/Form/Type/ContentType/ContentTypeChoiceType.php
+++ b/src/lib/Form/Type/ContentType/ContentTypeChoiceType.php
@@ -48,7 +48,6 @@ class ContentTypeChoiceType extends AbstractType
             ->setDefaults([
                 'choice_loader' => $this->contentTypeChoiceLoader,
                 'choice_label' => 'name',
-                'choice_name' => 'identifier',
                 'choice_value' => 'identifier',
             ]);
     }

--- a/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
+++ b/src/lib/Form/Type/Event/ContentCreateContentTypeChoiceLoaderEvent.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Form\Type\Event;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Symfony\Contracts\EventDispatcher\Event;
 
 final class ContentCreateContentTypeChoiceLoaderEvent extends Event
@@ -17,9 +18,15 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     /** @var array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> */
     private array $contentTypeGroups;
 
-    public function __construct(array $contentTypeGroups)
+    private ?Location $targetLocation;
+
+    /**
+     * @param array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
+     */
+    public function __construct(array $contentTypeGroups, ?Location $targetLocation)
     {
         $this->contentTypeGroups = $contentTypeGroups;
+        $this->targetLocation = $targetLocation;
     }
 
     /**
@@ -28,6 +35,14 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     public function getContentTypeGroups(): array
     {
         return $this->contentTypeGroups;
+    }
+
+    /**
+     * @param array<string, array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType>> $contentTypeGroups
+     */
+    public function setContentTypeGroups(array $contentTypeGroups): void
+    {
+        $this->contentTypeGroups = $contentTypeGroups;
     }
 
     /**
@@ -41,5 +56,10 @@ final class ContentCreateContentTypeChoiceLoaderEvent extends Event
     public function removeContentTypeGroup(string $name): void
     {
         unset($this->contentTypeGroups[$name]);
+    }
+
+    public function getTargetLocation(): ?Location
+    {
+        return $this->targetLocation;
     }
 }

--- a/tests/lib/EventListener/ContentTypeSuggestionsListenerTest.php
+++ b/tests/lib/EventListener/ContentTypeSuggestionsListenerTest.php
@@ -46,7 +46,7 @@ final class ContentTypeSuggestionsListenerTest extends TestCase
         ], $actualSubservients);
     }
 
-    public function testSkipSuggestionComputationIfAggregationApiIsNotSupported(): void
+    public function testSkipSuggestionComputationIfAggregationAPIIsNotSupported(): void
     {
         $this->disableSupportForAggregationAPI();
         $this->expectSuggestionsAreNotComputed();

--- a/tests/lib/EventListener/ContentTypeSuggestionsListenerTest.php
+++ b/tests/lib/EventListener/ContentTypeSuggestionsListenerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\EventListener;
+
+use Ibexa\AdminUi\EventListener\ContentTypeSuggestionsListener;
+use Ibexa\AdminUi\Form\Type\Event\ContentCreateContentTypeChoiceLoaderEvent;
+use Ibexa\Contracts\Core\Repository\SearchService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult;
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResultCollection;
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ContentTypeSuggestionsListenerTest extends TestCase
+{
+    /** @var \Ibexa\Contracts\Core\Repository\SearchService&\PHPUnit\Framework\MockObject\MockObject */
+    private SearchService $searchService;
+
+    /** @var \Symfony\Contracts\Translation\TranslatorInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private TranslatorInterface $translator;
+
+    protected function setUp(): void
+    {
+        $this->searchService = $this->createMock(SearchService::class);
+
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator->method('trans')->willReturnArgument(0);
+    }
+
+    public function testSubscribedEvents(): void
+    {
+        $actualSubservients = array_keys(ContentTypeSuggestionsListener::getSubscribedEvents());
+
+        self::assertEquals([
+            ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES,
+        ], $actualSubservients);
+    }
+
+    public function testSkipSuggestionComputationIfAggregationApiIsNotSupported(): void
+    {
+        $this->disableSupportForAggregationAPI();
+        $this->expectSuggestionsAreNotComputed();
+
+        $event = new ContentCreateContentTypeChoiceLoaderEvent([], $this->createExampleLocation());
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber($this->createDefaultListener());
+        $eventDispatcher->dispatch($event, ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES);
+
+        self::assertEmpty($event->getContentTypeGroups());
+    }
+
+    public function testSkipSuggestionComputationIfDisabled(): void
+    {
+        $this->enableSupportForAggregationAPI();
+        $this->expectSuggestionsAreNotComputed();
+
+        $listener = new ContentTypeSuggestionsListener(
+            $this->searchService,
+            $this->translator,
+            /* Disable suggestion computation */
+            0
+        );
+
+        $event = new ContentCreateContentTypeChoiceLoaderEvent([], $this->createExampleLocation());
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber($listener);
+        $eventDispatcher->dispatch($event, ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES);
+
+        self::assertEmpty($event->getContentTypeGroups());
+    }
+
+    public function testSkipSuggestionComputationIfTargetLocationIsMissing(): void
+    {
+        $this->enableSupportForAggregationAPI();
+        $this->expectSuggestionsAreNotComputed();
+
+        $event = new ContentCreateContentTypeChoiceLoaderEvent([], /* Target location is missing */ null);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber($this->createDefaultListener());
+        $eventDispatcher->dispatch($event, ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES);
+
+        self::assertEmpty($event->getContentTypeGroups());
+    }
+
+    public function testSuggestions(): void
+    {
+        $this->enableSupportForAggregationAPI();
+
+        $article = $this->createExampleContentType('article');
+        $folder = $this->createExampleContentType('folder');
+        $image = $this->createExampleContentType('image');
+
+        $results = new SearchResult();
+        $results->aggregations = new AggregationResultCollection([
+            'suggestions' => new TermAggregationResult(
+                'suggestions',
+                [
+                    new TermAggregationResultEntry($article, 20),
+                    new TermAggregationResultEntry($folder, 3),
+                ]
+            ),
+        ]);
+
+        $this->searchService->method('findLocations')->willReturn($results);
+
+        $event = new ContentCreateContentTypeChoiceLoaderEvent(
+            [
+                'content_type_group_content' => [$article, $folder],
+                'content_type_group_media' => [$image],
+            ],
+            $this->createExampleLocation()
+        );
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber($this->createDefaultListener());
+        $eventDispatcher->dispatch($event, ContentCreateContentTypeChoiceLoaderEvent::RESOLVE_CONTENT_TYPES);
+
+        $this->assertEquals([
+            'content_type_suggestions' => [$article, $folder],
+            'content_type_group_content' => [$article, $folder],
+            'content_type_group_media' => [$image],
+        ], $event->getContentTypeGroups());
+    }
+
+    private function disableSupportForAggregationAPI(): void
+    {
+        $this->searchService
+            ->method('supports')
+            ->with(SearchService::CAPABILITY_AGGREGATIONS)
+            ->willReturn(false);
+    }
+
+    private function enableSupportForAggregationAPI(): void
+    {
+        $this->searchService
+            ->method('supports')
+            ->with(SearchService::CAPABILITY_AGGREGATIONS)
+            ->willReturn(true);
+    }
+
+    private function createExampleLocation(int $id = 1): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location->method('__get')->with('id')->willReturn($id);
+
+        return $location;
+    }
+
+    private function createExampleContentType(string $identifier): ContentType
+    {
+        $contentType = $this->createMock(ContentType::class);
+        $contentType->method('__get')->with('identifier')->willReturn($identifier);
+
+        return $contentType;
+    }
+
+    private function createDefaultListener(): ContentTypeSuggestionsListener
+    {
+        return new ContentTypeSuggestionsListener(
+            $this->searchService,
+            $this->translator,
+        );
+    }
+
+    private function expectSuggestionsAreNotComputed(): void
+    {
+        $this->searchService->expects($this->never())->method('findLocations');
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://issues.ibexa.co/browse/IBX-6566](https://issues.ibexa.co/browse/IBX-6566)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

It's very common to have items of the same or very limited number of types inside single container. For example:

| Location        | Content Type |
|-----------------|--------------|
| `/Media/Images` | Images       |
| `/Media/Files`  | File         |
| `/Forms`        | Form         |
| `/Users`        | User Group   |
| `/Users/**/`    | User         |

This PR adds content type suggestions to content creation form 

![image](https://github.com/ibexa/admin-ui/assets/211967/531db0fa-5460-4c33-9275-d467bfddb44f)

and reduce time needed to finding appropriate content type on the list. 


### Implementation

Suggestions are computed using ~AI~ Aggregation API as `n` most frequently used content types in given location.

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
