### PR TITLE
IBX-6589: Added optional parameter siteAccessList to SiteaccessResolver

### DIFF
--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -46,23 +46,33 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
     }
 
     /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess[] $siteAccessList
+     *
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
     public function getSiteAccessesListForLocation(
         Location $location,
         ?int $versionNo = null,
-        ?string $languageCode = null
+        ?string $languageCode = null,
+        array $siteAccessList = []
     ): array {
         return array_filter(
-            $this->siteaccessResolver->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
+            $this->siteaccessResolver->getSiteAccessesListForLocation(
+                $location,
+                $versionNo,
+                $languageCode,
+                $siteAccessList
+            ),
             fn (SiteAccess $siteAccess): bool => !$this->isAdminSiteAccess($siteAccess)
         );
     }
 
-    public function getSiteAccessesListForContent(Content $content): array
-    {
+    public function getSiteAccessesListForContent(
+        Content $content,
+        array $siteAccessList = []
+    ): array {
         return array_filter(
-            $this->siteaccessResolver->getSiteAccessesListForContent($content),
+            $this->siteaccessResolver->getSiteAccessesListForContent($content, $siteAccessList),
             fn (SiteAccess $siteAccess): bool => !$this->isAdminSiteAccess($siteAccess)
         );
     }

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -32,18 +32,26 @@ interface SiteaccessResolverInterface
     ): array;
 
     /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess[] $siteAccessList
+     *
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
     public function getSiteAccessesListForLocation(
         Location $location,
         ?int $versionNo = null,
-        ?string $languageCode = null
+        ?string $languageCode = null,
+        array $siteAccessList = []
     ): array;
 
     /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess[] $siteAccessList
+     *
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]
      */
-    public function getSiteAccessesListForContent(Content $content): array;
+    public function getSiteAccessesListForContent(
+        Content $content,
+        array $siteAccessList = []
+    ): array;
 
     /**
      * @return \Ibexa\Core\MVC\Symfony\SiteAccess[]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6589](https://issues.ibexa.co/browse/IBX-6589)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds optional parameter `siteAccessList` to `SiteaccessResolver::getSiteAccessesListForContent` and `SiteaccessResolver::getSiteAccessesListForLocation` methods, to only iterate over the passed SiteAccesses list. 
This will improve performance when iterating over all SiteAccesses are not needed.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
