### PR TITLE
IBX-6343: ezdate and ezdatetime validation is styled properly

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -3,7 +3,7 @@
     const SELECTOR_INPUT = '.ibexa-data-source__input:not(.flatpickr-input)';
     const SELECTOR_FLATPICKR_INPUT = '.flatpickr-input';
     const EVENT_VALUE_CHANGED = 'change';
-    const SELECTOR_ERROR_NODE = '.ibexa-data-source';
+    const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzDateValidator extends ibexa.BaseFieldValidator {
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -3,7 +3,7 @@
     const SELECTOR_INPUT = '.ibexa-data-source__input[data-seconds]';
     const SELECTOR_FLATPICKR_INPUT = '.flatpickr-input';
     const EVENT_VALUE_CHANGED = 'change';
-    const SELECTOR_ERROR_NODE = '.ibexa-data-source';
+    const SELECTOR_ERROR_NODE = '.ibexa-form-error';
     const { convertDateToTimezone } = ibexa.helpers.timezone;
 
     class EzDateTimeValidator extends ibexa.BaseFieldValidator {

--- a/src/bundle/Resources/public/scss/_mixins.scss
+++ b/src/bundle/Resources/public/scss/_mixins.scss
@@ -13,6 +13,23 @@
 @import 'mixins/drag-and-drop';
 
 @mixin datetime-field() {
+    &.is-invalid {
+        .ibexa-label {
+            color: $ibexa-color-danger;
+        }
+
+        .ibexa-input-text-wrapper__action-btn {
+            .ibexa-icon {
+                fill: $ibexa-color-danger;
+            }
+        }
+
+        .ibexa-data-source__input {
+            border: calculateRem(1px) solid $ibexa-color-danger;
+            background: $ibexa-color-danger-100;
+        }
+    }
+
     .ibexa-data-source__input-wrapper {
         max-width: 30ch;
         position: relative;
@@ -98,7 +115,7 @@
 
         .ibexa-data-source__input {
             border: calculateRem(1px) solid $ibexa-color-danger;
-            background: $ibexa-color-warning-pale;
+            background: $ibexa-color-danger-100;
         }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6343
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![Screenshot 2023-09-19 at 16 37 49](https://github.com/ibexa/admin-ui/assets/24355391/91aa27c4-aec5-42d2-b540-97e8b3f130a8)



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
