### PR TITLE
IBX-6627: Removed non-existing service definition

### DIFF
--- a/src/bundle/Resources/config/services/validators.yaml
+++ b/src/bundle/Resources/config/services/validators.yaml
@@ -7,10 +7,6 @@ services:
     Ibexa\AdminUi\Validator\Constraints\:
         resource: "../../../lib/Validator/Constraints"
 
-    Ibexa\AdminUi\Validator\Constraints\UserPasswordValidator:
-        tags:
-            - { name: validator.constraint_validator }
-
     Ibexa\AdminUi\Validator\Constraints\LocationIsWithinCopySubtreeLimitValidator:
         arguments:
             $configResolver: '@ibexa.config.resolver'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6627](https://issues.ibexa.co/browse/IBX-6627)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Deprecated Since eZ Platform 3.0.2 class moved to EzPlatformUser Bundle, and removed since Ibexa DXP 4.0 https://github.com/ezsystems/ezplatform-admin-ui/blob/118c25f18088cf556c65291e1035c9a0e3916c58/src/lib/Validator/Constraints/UserPasswordValidator.php#L19C66-L19C66.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
