### PR TITLE
IBX-3240: Expanded `FieldDefinitionMappingEvent` to include `isNew` flag

### DIFF
--- a/src/contracts/Event/FieldDefinitionMappingEvent.php
+++ b/src/contracts/Event/FieldDefinitionMappingEvent.php
@@ -29,14 +29,18 @@ class FieldDefinitionMappingEvent extends Event
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language|null */
     private $targetLanguage;
 
+    private bool $isNew;
+
     public function __construct(
         FieldDefinitionData $fieldDefinitionData,
         ?Language $baseLanguage,
-        ?Language $targetLanguage
+        ?Language $targetLanguage,
+        bool $isNew
     ) {
         $this->baseLanguage = $baseLanguage;
         $this->targetLanguage = $targetLanguage;
         $this->fieldDefinitionData = $fieldDefinitionData;
+        $this->isNew = $isNew;
     }
 
     public function getFieldDefinition(): FieldDefinition
@@ -62,6 +66,11 @@ class FieldDefinitionMappingEvent extends Event
     public function getTargetLanguage(): ?Language
     {
         return $this->targetLanguage;
+    }
+
+    public function isNew(): bool
+    {
+        return $this->isNew;
     }
 }
 

--- a/src/lib/Form/Data/FormMapper/ContentTypeDraftMapper.php
+++ b/src/lib/Form/Data/FormMapper/ContentTypeDraftMapper.php
@@ -69,7 +69,8 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
         $baseLanguage = $params['baseLanguage'] ?? null;
 
         $contentTypeData = new ContentTypeData(['contentTypeDraft' => $contentTypeDraft]);
-        if (!$contentTypeData->isNew()) {
+        $isNew = $contentTypeData->isNew();
+        if (!$isNew) {
             $contentTypeData->identifier = $contentTypeDraft->identifier;
         }
 
@@ -115,7 +116,8 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
             $event = new FieldDefinitionMappingEvent(
                 $fieldDefinitionData,
                 $baseLanguage,
-                $language
+                $language,
+                $isNew
             );
 
             $this->eventDispatcher->dispatch($event, FieldDefinitionMappingEvent::NAME);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-3240](https://issues.ibexa.co/browse/IBX-3240)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Needed to determine whether new or edited data is passed. This in turn allows us to distinguish create and edit views of Content Type / Product Type and pass some default values of VAT rate identifiers in the dedicated form.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
