### PR TITLE
IBX-6377: Wrong table color in RTE in content preview

### DIFF
--- a/src/bundle/Resources/public/scss/_custom.scss
+++ b/src/bundle/Resources/public/scss/_custom.scss
@@ -245,6 +245,7 @@ $ibexa-border-radius-small: calculateRem(5px);
 $table-cell-padding: calculateRem(12px) calculateRem(16px);
 $table-bg: $white;
 $table-border-width: 0;
+$table-border-color: $ibexa-color-light-600;
 $table-hover-bg: $ibexa-color-light-300;
 
 // Breadcrumbs


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6377
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
