### PR TITLE
[CI] Increased job count for Behat

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -16,6 +16,7 @@ jobs:
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'
             test-setup-phase-2: '--profile=setup --suite=content-translation --mode=standard'
+            job-count: 2
             timeout: 40
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Example failing job:
https://github.com/ibexa/admin-ui/actions/runs/6392168048/job/17348897150?pr=929
```
     Examples:
      | fieldInternalName    | fieldName                    | fieldSettings | label1    | value1       | label2     | value2      | label3 | value3 | contentItemName |
      | ezobjectrelation     | Content relation (single)    |               | value     | Media/Images |            |             |        |        | Images          |
        Failed step: Then success notification that "Content published." appears
        Facebook\WebDriver\Exception\StaleElementReferenceException: stale element reference: element is not attached to the page document
          (Session info: chrome=110.0.5481.177) in vendor/php-webdriver/webdriver/lib/Exception/WebDriverException.php:132
```

For some reason the notifications stop appearing (not sure yet why).

I've tried debugging it in https://github.com/ibexa/admin-ui/pull/927 and the results so far are:
1) It's not related to parallelism (I've seen a failure in single thread run)
2) It's not consistent

I think it happen less often when the job-count is increased - so this PR is a workaround. At the same time the CI time for Behat is 36 minutes, so I think it's ok to increase the job-count.