### PR TITLE
Allowed overwriting component id using tag property for RendererInterface::renderSingle

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -44,6 +44,8 @@ class ComponentPass implements CompilerPassInterface
                 if (!isset($tag['group'])) {
                     throw new InvalidArgumentException($id, 'Tag ' . self::TAG_NAME . ' must contain a "group" argument.');
                 }
+
+                $id = $tag['id'] ?? $id;
                 $registryDefinition->addMethodCall('addComponent', [$tag['group'], $id, $serviceReference]);
             }
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes?
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

This PR allows `Ibexa\AdminUi\Component\Renderer\DefaultRenderer::renderSingle` to be used without the knowledge of service ID, by allowing `ibexa.admin_ui.component` tag additional `id` property. This could be used to control the key that is put in the component group, making the following call possible:
```php
$this->renderer->renderSingle(
    '<component_id>',
    '<group_id>',
    $parameters,
);
```

So the new service definition could be:
```diff
    ibexa.adminui.content_type.tab_groups:
        parent: Ibexa\AdminUi\Component\TabsComponent
        arguments:
            $template: '@@ibexadesign/ui/tab/content_type.html.twig'
            $groupIdentifier: 'content-type'
        tags:
            - { name: ibexa.admin_ui.component, group: 'content-type-tab-groups' }
+           - { name: ibexa.admin_ui.component, group: 'content-type-tab-groups', id: 'tab-group' }
```

> [!WARNING]
> This registers the component in the group **twice**. Calling render group will cause it to render twice because of it.

```php
$this->renderer->renderSingle(
    'tab-group',
    'content-type-tab-groups',
    $parameters,
);
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
