### PR TITLE
[Behat] Emulate a focused page when interacting with Richtext

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -45,6 +45,7 @@ class RichText extends FieldTypeComponent
 
     private function focusFieldInput(): void
     {
+        $this->getDevToolsDriver()->execute('Emulation.setFocusEmulationEnabled', ['enabled' => true]);
         $this->getFieldInput()->click();
     }
 


### PR DESCRIPTION
Requires https://github.com/ibexa/behat/pull/90 to be merged first - the CI build will be green then

This should help with https://issues.ibexa.co/browse/IBX-6281 and https://issues.ibexa.co/browse/IBX-3097

"Emulate a focused page" is a cool trick that can be used when automating Richtext:
```
Now, the hidden elements will not disappear on the page and you would be able to inspect the elements on the web application.
```
This makes working with Richtext much easier.
Tested in:
https://github.com/ibexa/experience/pull/251
https://github.com/ibexa/commerce/pull/421
