### PR TITLE
[Behat] Increased timeout for subitems loading

### DIFF
--- a/src/lib/Behat/Component/SubItemsList.php
+++ b/src/lib/Behat/Component/SubItemsList.php
@@ -77,7 +77,7 @@ class SubItemsList extends Component
     public function verifyIsLoaded(): void
     {
         Assert::assertTrue($this->getHTMLPage()->find($this->getLocator('table'))->isVisible());
-        $this->getHTMLPage()->setTimeout(5)->waitUntilCondition(
+        $this->getHTMLPage()->setTimeout(10)->waitUntilCondition(
             new ElementNotExistsCondition($this->getHTMLPage(), $this->getLocator('spinner'))
         );
 


### PR DESCRIPTION
Example failure:
https://github.com/ibexa/experience/actions/runs/6526653543/job/17720634676

```
   Scenario: Create a new Landing Page and use Publish Later     # vendor/ibexa/scheduler/features/PublishInTheFuture.feature:19
    Given I'm on Content view Page for root                     # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iMOnContentViewPageFor()
      Ibexa\Behat\Browser\Exception\TimeoutException: Element with CSS locator 'spinner': '.m-sub-items__spinner-wrapper' was found, but it should not exist. Timeout value: 5 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:59
```

I believe increasing the timeout will make this failure go away 🤞 