### PR TITLE
[Behat] Removed duplicated folders

### DIFF
--- a/features/standard/ContentManagement.feature
+++ b/features/standard/ContentManagement.feature
@@ -1,4 +1,4 @@
-@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce @javascript
 Feature: Content items creation
   As an administrator
   In order to manage content to my site
@@ -7,11 +7,12 @@ Feature: Content items creation
 Background:
       Given I am logged as admin
 
-@javascript @APIUser:admin
 Scenario: Content moving can be cancelled
-  Given I create "folder" Content items
+  Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+  And I create "folder" Content items
     | name               | short_name          | parentPath        | language |
-    | ContentManagement  | ContentManagement   | root              | eng-GB   |
     | FolderToCancelMove | FolderToCancelMove  | ContentManagement | eng-GB   |
   And I'm on Content view Page for "ContentManagement/FolderToCancelMove"
   When I click on the edit action bar button "Move"
@@ -19,11 +20,12 @@ Scenario: Content moving can be cancelled
     And I close the UDW window
   Then I should be on Content view Page for "ContentManagement/FolderToCancelMove"
 
-@javascript @APIUser:admin
 Scenario: Content can be moved
-  Given I create "folder" Content items
+  Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+  And I create "folder" Content items
     | name               | short_name        | parentPath        | language |
-    | ContentManagement  | ContentManagement | root              | eng-GB   |
     | FolderToMove       | FolderToMove      | ContentManagement | eng-GB   |
   And I'm on Content view Page for "ContentManagement/FolderToMove"
   When I click on the edit action bar button "Move"
@@ -34,11 +36,12 @@ Scenario: Content can be moved
     And I'm on Content view Page for "ContentManagement"
     And there's no "FolderToMove" "Folder" on Subitems list
 
-@javascript @APIUser:admin
 Scenario: Content copying can be cancelled
-  Given I create "folder" Content items
+  Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+  And I create "folder" Content items
     | name               | short_name         | parentPath        | language |
-    | ContentManagement  | ContentManagement  | root              | eng-GB   |
     | FolderToCopyCancel | FolderToCopyCancel | ContentManagement | eng-GB   |
   And I'm on Content view Page for "ContentManagement/FolderToCopyCancel"
   When I click on the edit action bar button "Copy"
@@ -46,11 +49,12 @@ Scenario: Content copying can be cancelled
     And I close the UDW window
   Then I should be on Content view Page for "ContentManagement/FolderToCopyCancel"
 
-@javascript @APIUser:admin
 Scenario: Content can be copied
-  Given I create "folder" Content items
+  Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+  And I create "folder" Content items
     | name               | short_name         | parentPath        | language |
-    | ContentManagement  | ContentManagement  | root              | eng-GB   |
     | FolderToCopy       | FolderToCopy       | ContentManagement | eng-GB   |
   And I'm on Content view Page for "ContentManagement/FolderToCopy"
   When I click on the edit action bar button "Copy"
@@ -61,11 +65,12 @@ Scenario: Content can be copied
     And I'm on Content view Page for "ContentManagement"
     And there's a "FolderToCopy" "Folder" on Subitems list
 
-  @javascript @APIUser:admin
   Scenario: Subtree copying can be cancelled
-    Given I create "folder" Content items
+  Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+  And I create "folder" Content items
       | name                      | short_name                | parentPath        | language |
-      | ContentManagement         | ContentManagement         | root              | eng-GB   |
       | FolderToSubtreeCopyCancel | FolderToSubtreeCopyCancel | ContentManagement | eng-GB   |
     And I'm on Content view Page for "ContentManagement/FolderToSubtreeCopyCancel"
     When I click on the edit action bar button "Copy Subtree"
@@ -73,11 +78,12 @@ Scenario: Content can be copied
     And I close the UDW window
     Then I should be on Content view Page for "ContentManagement/FolderToSubtreeCopyCancel"
 
-  @javascript @APIUser:admin
   Scenario: Subtree can be copied
-    Given I create "folder" Content items
+    Given a "folder" Content item named "ContentManagement" exists in root
+      | name              | short_name        |
+      | ContentManagement | ContentManagement |
+    And I create "folder" Content items
       | name                      | short_name                | parentPath        | language |
-      | ContentManagement         | ContentManagement         | root              | eng-GB   |
       | FolderToSubtreeCopy | FolderToSubtreeCopy | ContentManagement | eng-GB   |
     And I'm on Content view Page for "ContentManagement/FolderToSubtreeCopy"
     When I click on the edit action bar button "Copy Subtree"

--- a/features/standard/Trash.feature
+++ b/features/standard/Trash.feature
@@ -1,4 +1,4 @@
-@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce @javascript
 Feature: Trash management
   As an administrator
   In order to manage content on my site
@@ -7,11 +7,12 @@ Feature: Trash management
   Background:
     Given I am logged as admin
 
-  @javascript @APIUser:admin
   Scenario: Trash can be emptied
-    Given I create "folder" Content items
+    Given a "folder" Content item named "TrashTest" exists in root
+      | name      | short_name |
+      | TrashTest | TrashTest  |
+    And I create "folder" Content items
       | name          | short_name    | parentPath     | language |
-      | TrashTest     | TrashTest     | root           | eng-GB   |
       | FolderToTrash | FolderToTrash | TrashTest | eng-GB   |
     And I send "TrashTest/FolderToTrash" to the Trash
     And I open "Trash" page in admin SiteAccess
@@ -19,11 +20,12 @@ Feature: Trash management
     When I empty the trash
     Then trash is empty
 
-  @javascript @APIUser:admin
   Scenario: Content can be moved to trash
-    Given I create "folder" Content items
-      | name          | short_name    | parentPath | language |
-      | TrashTest     | TrashTest     | root       | eng-GB   |
+    Given a "folder" Content item named "TrashTest" exists in root
+      | name      | short_name |
+      | TrashTest | TrashTest  |
+    And I create "folder" Content items
+      | name                  | short_name            | parentPath | language |
       | FolderToTrashManually | FolderToTrashManually | TrashTest  | eng-GB   |
     And I'm on Content view Page for "TrashTest/FolderToTrashManually"
     When I send content to trash
@@ -31,11 +33,12 @@ Feature: Trash management
     And I open "Trash" page in admin SiteAccess
     And there is a "Folder" "FolderToTrashManually" on Trash list
 
-  @javascript @APIUser:admin
   Scenario: Element in trash can be deleted
-    Given I create "folder" Content items
+    Given a "folder" Content item named "TrashTest" exists in root
+      | name      | short_name |
+      | TrashTest | TrashTest  |
+    And I create "folder" Content items
       | name          | short_name    | parentPath | language |
-      | TrashTest     | TrashTest     | root       | eng-GB   |
       | DeleteFromTrash | DeleteFromTrash | TrashTest  | eng-GB   |
     And I send "TrashTest/DeleteFromTrash" to the Trash
     And I open "Trash" page in admin SiteAccess
@@ -46,9 +49,8 @@ Feature: Trash management
     Then success notification that "Deleted selected item(s) from Trash." appears
     And there is no "Folder" "DeleteFromTrash" on Trash list
 
-  @javascript @APIUser:admin
   Scenario: Element in trash can be restored
-    Given I create "folder" Content items in root in "eng-GB"
+    Given a "folder" Content item named "TrashTest" exists in root
       | name      | short_name |
       | TrashTest | TrashTest  |
     And I create "folder" Content items in "TrashTest" in "eng-GB"
@@ -64,11 +66,12 @@ Feature: Trash management
     And there is no "Folder" "RestoreFromTrash" on Trash list
     And there exists Content view Page for "TrashTest/RestoreFromTrash"
 
-  @javascript @APIUser:admin
   Scenario: Element in trash can be restored under new location
-    Given I create "folder" Content items
+    Given a "folder" Content item named "TrashTest" exists in root
+      | name      | short_name |
+      | TrashTest | TrashTest  |
+    And I create "folder" Content items
       | name          | short_name    | parentPath | language |
-      | TrashTest     | TrashTest     | root       | eng-GB   |
       | RestoreFromTrashNewLocation | RestoreFromTrashNewLocation | TrashTest  | eng-GB   |
     And I send "TrashTest/RestoreFromTrashNewLocation" to the Trash
     And I open "Trash" page in admin SiteAccess


### PR DESCRIPTION
As you can see on the screenshot in https://github.com/ibexa/admin-ui/actions/runs/6534801187/job/17742837238 :
![obraz](https://github.com/ibexa/admin-ui/assets/10993858/c0811217-2c8d-4e76-971a-5bb2fd731404)

We're creating too many `ContentManagement` and `TrashTest` folders.

Using the `Given a "folder" Content item named "X" exists in root` step allows us to create it only once.