### PR TITLE
IBX-3075: Switched to loading all choices at once for ContentCreate form

### DIFF
--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -93,8 +93,10 @@ class ContentCreateType extends AbstractType
                     'label' => false,
                     'multiple' => false,
                     'expanded' => true,
-                    'choice_loader' => $this->contentCreateContentTypeChoiceLoader
-                        ->setRestrictedContentTypeIds($restrictedContentTypesIds),
+                    'choices' => $this->contentCreateContentTypeChoiceLoader
+                                    ->setRestrictedContentTypeIds($restrictedContentTypesIds)
+                                    ->loadChoiceList()
+                                    ->getChoices(),
                 ]
             )
             ->add(


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3075

![obraz](https://github.com/ibexa/admin-ui/assets/10993858/57cb1d38-3c1f-444e-838f-b07a9faa0e89)

Please look at the JIRA ticket to learn more about this issue - there's a reproducer that I've used to test that with my changes it doesn't occur anymore.

This is the most common issue triggering Behat failures (because we run the tests in parallel) and that's why I've started investigating it.

Without this change the `ContentCreateContentTypeChoiceLoader::loadChoiceList` method is called 6 times (looks like the Form is created 2 times and there are 3 calls per Form).

After this change the call is made 2 times (once per Form).

This is my first interaction with the Form component - so while I was able to see what's going on (my diagnosis: for a single Form the `ContentCreateContentTypeChoiceLoader::loadChoices` method is called multiple times - and because the Content Types are changed in the background there is a mismatch between values returned from the calls made for single Form) I'm not sure if this is the right solution. From what I've read in the doc it doesn't look like we're filtering the values in a way that's benefiting from lazy loading them (but I might be wrong 😄 ) and using the ChoiceLoader might not be necessary here.

I've attached the Blackfire profiles (before and after) in the Jira ticket - so you can verify the number of calls I've mentioned.

TODO:
- [ ] check if the Content Types are still filtered based on permissions
