### PR TITLE
IBX-6848: Added `OpenedBlockSettings` and `IsPageBuilderVisited` config providers

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -127,3 +127,11 @@ services:
     Ibexa\AdminUi\UI\Config\Provider\CurrentBackOfficePath:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'backOfficePath' }
+
+    Ibexa\AdminUi\UI\Config\Provider\OpenedBlockSettings:
+        tags:
+            - { name: ibexa.admin_ui.config.provider, key: 'openedBlockSettings' }
+
+    Ibexa\AdminUi\UI\Config\Provider\IsPageBuilderVisited:
+        tags:
+            - { name: ibexa.admin_ui.config.provider, key: 'isPageBuilderVisited' }

--- a/src/lib/UI/Config/Provider/IsPageBuilderVisited.php
+++ b/src/lib/UI/Config/Provider/IsPageBuilderVisited.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Config\Provider;
+
+use Exception;
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Ibexa\Contracts\Core\Repository\UserPreferenceService;
+
+final class IsPageBuilderVisited implements ProviderInterface
+{
+    private UserPreferenceService $userPreferenceService;
+
+    public function __construct(UserPreferenceService $userPreferenceService)
+    {
+        $this->userPreferenceService = $userPreferenceService;
+    }
+
+    public function getConfig(): string
+    {
+        try {
+            return $this->userPreferenceService
+                ->getUserPreference('page_builder_visited')
+                ->value;
+        } catch (Exception $e) {
+            return 'false';
+        }
+    }
+}

--- a/src/lib/UI/Config/Provider/OpenedBlockSettings.php
+++ b/src/lib/UI/Config/Provider/OpenedBlockSettings.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Config\Provider;
+
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Ibexa\User\UserSetting\UserSettingService;
+
+final class OpenedBlockSettings implements ProviderInterface
+{
+    private UserSettingService $userSettingService;
+
+    public function __construct(UserSettingService $userSettingService)
+    {
+        $this->userSettingService = $userSettingService;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    public function getConfig(): string
+    {
+        return $this->userSettingService
+            ->getUserSetting('block_settings')
+            ->value;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6848](https://issues.ibexa.co/browse/IBX-6848)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Exposed settings added within https://github.com/ibexa/page-builder/pull/274.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
