### PR TITLE
IBX-6413 Added min_query_lenght and result_limit configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ibexa/user": "~4.6.0@dev",
         "ibexa/fieldtype-richtext": "~4.6.0@dev",
         "ibexa/rest": "~4.6.0@dev",
-        "ibexa/search": "~4.6.0@dev",
+        "ibexa/search": "dev-IBX-6413-part2-core-functionality",
         "babdev/pagerfanta-bundle": "^2.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "mck89/peast": "^1.9",

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -127,3 +127,10 @@ services:
     Ibexa\AdminUi\UI\Config\Provider\CurrentBackOfficePath:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'backOfficePath' }
+
+    Ibexa\AdminUi\UI\Config\Provider\Suggestions:
+        arguments:
+            $minQueryLength: '%ibexa.site_access.config.default.search.suggestion.min_query_length%'
+            $resultLimit: '%ibexa.site_access.config.default.search.suggestion.result_limit%'
+        tags:
+            - { name: ibexa.admin_ui.config.provider, key: 'suggestions' }

--- a/src/lib/UI/Config/Provider/SuggestionSetting.php
+++ b/src/lib/UI/Config/Provider/SuggestionSetting.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Config\Provider;
+
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+
+final class SuggestionSetting implements ProviderInterface
+{
+    private int $minQueryLength;
+
+    private int $resultLimit;
+
+    public function __construct(int $minQueryLength, int $resultLimit)
+    {
+        $this->minQueryLength = $minQueryLength;
+        $this->resultLimit = $resultLimit;
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    public function getConfig(): array
+    {
+        return [
+            'minQueryLength' => $this->minQueryLength,
+            'resultLimit' => $this->resultLimit,
+        ];
+    }
+}


### PR DESCRIPTION
> [!WARNING]  
> Temporary commit inside: 5f0796bb29cf118250072eec2ac25d0d286c5682



| Question      | Answer
| ------------- | ---
| Tickets       | IBX-6413
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


> [!NOTE]  
> Related PR https://github.com/ibexa/search/pull/33

This PR adds ```min_query_lenght``` and ```result_limit``` avability to frontend.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
