### PR TITLE
IBX-6883: [PB] Add tooltips for all buttons in header

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,6 +1,6 @@
 (function (global, doc, ibexa, bootstrap) {
     let lastInsertTooltipTarget = null;
-    const TOOLTIPS_SELECTOR = '[title]';
+    const TOOLTIPS_SELECTOR = '[title], [data-tooltip-title]';
     const observerConfig = {
         childList: true,
         subtree: true,
@@ -93,7 +93,7 @@
         return texHeight;
     };
     const isTitleEllipsized = (node) => {
-        const title = node.title || node.dataset.originalTitle;
+        const title = node.dataset.originalTitle;
         const { width: nodeWidth, height: nodeHeight } = node.getBoundingClientRect();
         const computedNodeStyles = getComputedStyle(node);
         const styles = {
@@ -112,6 +112,37 @@
 
         return textHeight > nodeHeight;
     };
+    const initializeTooltip = (tooltipNode) => {
+        const delay = {
+            show: parseInt(tooltipNode.dataset.delayShow, 10) ?? 150,
+            hide: parseInt(tooltipNode.dataset.delayHide, 10) ?? 75,
+        };
+        const extraClass = tooltipNode.dataset.tooltipExtraClass ?? '';
+        const placement = tooltipNode.dataset.tooltipPlacement ?? 'bottom';
+        const trigger = tooltipNode.dataset.tooltipTrigger ?? 'hover focus';
+        const useHtml = tooltipNode.dataset.tooltipUseHtml !== undefined;
+        const container = tooltipNode.dataset.tooltipContainerSelector
+            ? tooltipNode.closest(tooltipNode.dataset.tooltipContainerSelector)
+            : 'body';
+        const iframe = document.querySelector(tooltipNode.dataset.tooltipIframeSelector);
+
+        new bootstrap.Tooltip(tooltipNode, {
+            delay,
+            placement,
+            trigger,
+            container,
+            popperConfig: modifyPopperConfig.bind(null, iframe),
+            html: useHtml,
+            template: `<div class="tooltip ibexa-tooltip ${extraClass}">
+                            <div class="tooltip-arrow ibexa-tooltip__arrow"></div>
+                            <div class="tooltip-inner ibexa-tooltip__inner"></div>
+                       </div>`,
+        });
+
+        tooltipNode.addEventListener('inserted.bs.tooltip', (event) => {
+            lastInsertTooltipTarget = event.currentTarget;
+        });
+    };
     const parse = (baseElement = doc) => {
         if (!baseElement) {
             return;
@@ -124,77 +155,46 @@
         }
 
         for (const tooltipNode of tooltipNodes) {
-            if (tooltipNode.hasAttribute('title')) {
-                const hasEllipsisStyle = getComputedStyle(tooltipNode).textOverflow === 'ellipsis';
+            const hasEllipsisStyle = getComputedStyle(tooltipNode).textOverflow === 'ellipsis';
+            const hasNewTitle = tooltipNode.hasAttribute('title');
+            const tooltipInitialized = !!tooltipNode.dataset.originalTitle;
+            let shouldHaveTooltip = !hasEllipsisStyle;
 
-                if (hasEllipsisStyle) {
-                    resizeEllipsisObserver.observe(tooltipNode);
+            if (!tooltipInitialized && hasNewTitle) {
+                resizeEllipsisObserver.observe(tooltipNode);
+                tooltipNode.dataset.originalTitle = tooltipNode.title;
 
-                    const isEllipsized = isTitleEllipsized(tooltipNode);
-                    const tooltipInstance = bootstrap.Tooltip.getInstance(tooltipNode);
-
-                    if (tooltipInstance) {
-                        if (!isEllipsized) {
-                            tooltipInstance.dispose();
-                        }
-
-                        continue;
-                    }
-
-                    if (isEllipsized) {
-                        if (tooltipNode.dataset.title) {
-                            tooltipNode.title = tooltipNode.dataset.title;
-                        }
-                    } else {
-                        if (tooltipNode.title) {
-                            tooltipNode.dataset.title = tooltipNode.title;
-                            tooltipNode.title = '';
-                        }
-
-                        continue;
-                    }
+                if (!shouldHaveTooltip) {
+                    shouldHaveTooltip = isTitleEllipsized(tooltipNode);
                 }
 
-                const delay = {
-                    show: parseInt(tooltipNode.dataset.delayShow, 10) ?? 150,
-                    hide: parseInt(tooltipNode.dataset.delayHide, 10) ?? 75,
-                };
-                const extraClass = tooltipNode.dataset.tooltipExtraClass ?? '';
-                const placement = tooltipNode.dataset.tooltipPlacement ?? 'bottom';
-                const trigger = tooltipNode.dataset.tooltipTrigger ?? 'hover focus';
-                const useHtml = tooltipNode.dataset.tooltipUseHtml !== undefined;
-                const container = tooltipNode.dataset.tooltipContainerSelector
-                    ? tooltipNode.closest(tooltipNode.dataset.tooltipContainerSelector)
-                    : 'body';
-                const iframe = document.querySelector(tooltipNode.dataset.tooltipIframeSelector);
+                if (shouldHaveTooltip) {
+                    initializeTooltip(tooltipNode);
+                } else {
+                    tooltipNode.removeAttribute('title');
+                }
+            } else if (tooltipInitialized && (hasNewTitle || hasEllipsisStyle)) {
+                if (hasNewTitle) {
+                    tooltipNode.dataset.originalTitle = tooltipNode.title;
+                }
                 const tooltipInstance = bootstrap.Tooltip.getInstance(tooltipNode);
+                const hasTooltip = !!tooltipInstance;
 
-                if (tooltipInstance) {
-                    tooltipNode.title = tooltipInstance._getTitle();
+                if (!shouldHaveTooltip) {
+                    shouldHaveTooltip = isTitleEllipsized(tooltipNode);
+                }
 
+                if (hasTooltip && ((hasNewTitle && shouldHaveTooltip) || !shouldHaveTooltip)) {
                     tooltipInstance.dispose();
                 }
 
-                tooltipNode.dataset.originalTitle = tooltipNode.title;
+                if (shouldHaveTooltip && (hasNewTitle || !hasTooltip)) {
+                    tooltipNode.title = tooltipNode.dataset.originalTitle;
 
-                new bootstrap.Tooltip(tooltipNode, {
-                    delay,
-                    placement,
-                    trigger,
-                    container,
-                    popperConfig: modifyPopperConfig.bind(null, iframe),
-                    html: useHtml,
-                    template: `<div class="tooltip ibexa-tooltip ${extraClass}">
-                                    <div class="tooltip-arrow ibexa-tooltip__arrow"></div>
-                                    <div class="tooltip-inner ibexa-tooltip__inner"></div>
-                               </div>`,
-                });
-
-                tooltipNode.title = '';
-
-                tooltipNode.addEventListener('inserted.bs.tooltip', (event) => {
-                    lastInsertTooltipTarget = event.currentTarget;
-                });
+                    initializeTooltip(tooltipNode);
+                } else {
+                    tooltipNode.removeAttribute('title');
+                }
             }
         }
     };


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6883
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`[data-original-title]` is used to store original `title` parameter, as after initializing tooltips BS takes control over `title` parameter and I want to have reliable way of retrieving og value ("If you want something done right, do it yourself")

`initializeTooltip` method is almost the same code as before (minus disposing tooltip instance)  just moved to new function

`hasEllipsisStyle` checks for ellipsis style - if there's no such style, tooltip should be always visible. Otherwise, it should be visible only when `...` is on screen
`hasNewTitle` tracks if title was changed by dev - as BS removes completely this value, if it's there at next parsing, it means dev wants to change it.
`tooltipInitialized` checks if given node was already parsed and is ready to show tooltip

When node has no ellipsis styles we ALWAYS want to show tooltip, so in general after first `parse()` we don't have to touch it again, except when title has changed (disposing and initializng is necessary to update tooltip content)
When node has ellipsis styles we have cases:
1. name has changed - therefore width could change, we calculate if it should be visible now and init/reinit/dispose it
2. name has not changed; width has changed - we calculate if it should be visible now and init/dispose it

We ALWAYS remove `title`, as when element has ellipsis styles, has title, but shouldn't have tooltip (no `...` visible) there should be no native title/tooltip as well.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
