### PR TITLE
Removed duplicated class key in drowdown_widget.html.twig

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields/dropdown_widget.html.twig
@@ -19,7 +19,6 @@
             class: attr.dropdown_class|default(''),
             translation_domain: choice_translation_domain|default(false),
             custom_form: false,
-            class: attr.dropdown_class|default(''),
             is_disabled: attr.disabled|default(false) or disabled|default(false) or dropdown_disabled|default(false),
             is_hidden: attr.dropdown_hidden|default(false),
             is_small: attr.is_small|default(false),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


`class` is already passed to `@ibexadesign/ui/component/dropdown/dropdown.html.twig` in line 19.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
