### PR TITLE
IBX-6937: Used NumberType field to set max image size in ImageFormMapper

### DIFF
--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -12,7 +12,7 @@ use Ibexa\ContentForms\ConfigResolver\MaxUploadSize;
 use Ibexa\Contracts\Core\Repository\FieldTypeService;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Range;
@@ -31,7 +31,7 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
     {
         $isTranslation = $data->contentTypeData->languageCode !== $data->contentTypeData->mainLanguageCode;
         $fieldDefinitionForm
-            ->add('maxSize', IntegerType::class, [
+            ->add('maxSize', NumberType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[FileSizeValidator][maxFileSize]',
                 'label' => /** @Desc("Maximum file size (MB)") */ 'field_definition.ezimage.max_file_size',
@@ -46,6 +46,7 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
                     'max' => $this->maxUploadSize->get(MaxUploadSize::MEGABYTES),
                 ],
                 'disabled' => $isTranslation,
+                'scale' => 1,
             ])
             ->add('isAlternativeTextRequired', CheckboxType::class, [
                 'required' => false,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6937
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| Related to   | https://github.com/ibexa/core/pull/291
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR changes form type field `maxSize` from Integer to Number that allows to use float values for max file size setting.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
