### PR TITLE
[Behat] IBX-6849: fixed rte buttons positions

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -141,14 +141,14 @@ class RichText extends FieldTypeComponent
 
     public function clickEmbedInlineButton(): void
     {
-        $buttonPosition = 11 + $this->getCustomStylesOffset();
+        $buttonPosition = 6 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }
 
     public function clickEmbedButton(): void
     {
-        $buttonPosition = 8 + $this->getCustomStylesOffset();
+        $buttonPosition = 3 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6849
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

This PR fixes CI errors from https://github.com/ibexa/page-builder/pull/281. Due to block config panel being bigger RTE editor button positions have changed.

Green multiple pr build - https://github.com/ibexa/commerce/pull/449
