### PR TITLE
[Behat] Country field: switch to using Ibexa dropdown

### DIFF
--- a/src/lib/Behat/Component/Fields/Country.php
+++ b/src/lib/Behat/Component/Fields/Country.php
@@ -8,18 +8,25 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
+use Behat\Mink\Session;
+use Ibexa\AdminUi\Behat\Component\IbexaDropdown;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
-use PHPUnit\Framework\Assert;
 
 class Country extends FieldTypeComponent
 {
+    private IbexaDropdown $dropdown;
+
+    public function __construct(Session $session, IbexaDropdown $dropdown)
+    {
+        parent::__construct($session);
+        $this->dropdown = $dropdown;
+    }
+
     public function setValue(array $parameters): void
     {
         $this->getHTMLPage()->find($this->getLocator('dropdownSelector'))->click();
-        Assert::assertTrue($this->getHTMLPage()->find($this->getLocator('dropdownExpanded'))->isVisible());
-        $this->getHTMLPage()->findAll($this->getLocator('dropdownItem'))->getByCriterion(new ElementTextCriterion($parameters['value']))->click();
-        $this->getHTMLPage()->find($this->getLocator('dropdownSelector'))->click();
+        $this->dropdown->verifyIsLoaded();
+        $this->dropdown->selectOption($parameters['value']);
     }
 
     public function getFieldTypeIdentifier(): string
@@ -32,8 +39,6 @@ class Country extends FieldTypeComponent
         return [
             new VisibleCSSLocator('fieldInput', 'select'),
             new VisibleCSSLocator('dropdownSelector', '.ibexa-dropdown__selection-info'),
-            new VisibleCSSLocator('dropdownExpanded', '.ibexa-dropdown-popover .ibexa-dropdown__items'),
-            new VisibleCSSLocator('dropdownItem', '.ibexa-dropdown__item'),
         ];
     }
 }


### PR DESCRIPTION
Example failure:
```
    Examples:
      | label1 | value1  | label2 | value2 | label3 | value3 | oldContentItemName | newContentItemName |
      | value  | Albania |        |        |        |        | Angola             | Albania            |
        Failed step: And I set content fields
        Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'dropdownExpanded': '.ibexa-dropdown-popover .ibexa-dropdown__items' not found in 1 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79
```
https://github.com/ibexa/commerce/actions/runs/6790838955/job/18461314383

I'm not sure if this helps, but this page should use the dedicated Dropdown component anyway - so this is a step in the right direction.