### PR TITLE
[Behat] Disabled COTF tests on Experience and Commerce editions

### DIFF
--- a/features/standard/Bookmark.feature
+++ b/features/standard/Bookmark.feature
@@ -1,10 +1,10 @@
-@IbexaOSS @IbexaHeadless @IbexaExperience @IbexaCommerce @javascript
+@IbexaOSS @IbexaHeadless @javascript
 Feature: Bookmarks management
 
   Background:
     Given I am logged as admin
 
-  @APIUser:admin
+  @IbexaExperience @IbexaCommerce
   Scenario: Content Item can be added to bookmarks
     Given I create "folder" Content items
       | name            | short_name       | parentPath        | language |
@@ -13,7 +13,32 @@ Feature: Bookmarks management
     When I bookmark the Content Item "root/BookmarkFolder"
     Then it is marked as bookmarked
 
-  @APIUser:admin
+  @IbexaExperience @IbexaCommerce
+  Scenario: Bookmarks can be displayed
+    Given I open "Bookmarks" page in admin SiteAccess
+    Then there's a "BookmarkFolder" Content Item on Bookmarks list
+
+  @IbexaExperience @IbexaCommerce
+  Scenario: Content Item can be previewed from Bookmarks page
+    Given I open "Bookmarks" page in admin SiteAccess
+    And there's a "BookmarkFolder" Content Item on Bookmarks list
+    When I go to "BookmarkFolder" Content Item from Bookmarks
+    Then I should be on Content view Page for "root/BookmarkFolder"
+
+  @IbexaExperience @IbexaCommerce
+  Scenario: Content Item can be edited
+    Given I open "Bookmarks" page in admin SiteAccess
+    And there's a "BookmarkFolder" Content Item on Bookmarks list
+    When I start editing "BookmarkFolder" Content Item from Bookmarks
+    Then I should be on Content update page for "BookmarkFolder"
+
+  @IbexaExperience @IbexaCommerce
+  Scenario: Bookmark can be deleted
+    Given I open "Bookmarks" page in admin SiteAccess
+    And there's a "BookmarkFolder" Content Item on Bookmarks list
+    When I delete the bookmark for "BookmarkFolder" Content Item
+    Then there's no "BookmarkFolder" Content Item on Bookmarks list
+
   Scenario: Content Item can be bookmarked from UDW
     Given I create "folder" Content items
       | name         | short_name    | parentPath        | language |
@@ -23,29 +48,6 @@ Feature: Bookmarks management
     When I select content "root/BookmarkUDW" through UDW
     And I bookmark the Content Item "root/BookmarkUDW" in Universal Discovery Widget
     Then it is marked as bookmarked in Universal Discovery Widget
-
-  Scenario: Bookmarks can be displayed
-    Given I open "Bookmarks" page in admin SiteAccess
-    Then there's a "BookmarkFolder" Content Item on Bookmarks list
-    And there's a "BookmarkUDW" Content Item on Bookmarks list
-
-  Scenario: Content Item can be previewed from Bookmarks page
-    Given I open "Bookmarks" page in admin SiteAccess
-    And there's a "BookmarkFolder" Content Item on Bookmarks list
-    When I go to "BookmarkFolder" Content Item from Bookmarks
-    Then I should be on Content view Page for "root/BookmarkFolder"
-
-  Scenario: Content Item can be edited
-    Given I open "Bookmarks" page in admin SiteAccess
-    And there's a "BookmarkFolder" Content Item on Bookmarks list
-    When I start editing "BookmarkFolder" Content Item from Bookmarks
-    Then I should be on Content update page for "BookmarkFolder"
-
-  Scenario: Bookmark can be deleted
-    Given I open "Bookmarks" page in admin SiteAccess
-    And there's a "BookmarkFolder" Content Item on Bookmarks list
-    When I delete the bookmark for "BookmarkFolder" Content Item
-    Then there's no "BookmarkFolder" Content Item on Bookmarks list
 
   Scenario: Bookmarked Content Item can be edited from UDW
     Given I open "Dashboard" page in admin SiteAccess

--- a/features/standard/SearchContent.feature
+++ b/features/standard/SearchContent.feature
@@ -1,9 +1,9 @@
-@IbexaOSS @IbexaHeadless @IbexaExperience @IbexaCommerce
+@IbexaOSS @IbexaHeadless  @javascript
 Feature: Searching for a Content item
   As an administrator
   I want to search for Content items.
 
-  @javascript @APIUser:admin
+  @IbexaExperience @IbexaCommerce
   Scenario: Content can be searched for
     Given I create "folder" Content items in root in "eng-GB"
       | name              | short_name          |
@@ -13,7 +13,6 @@ Feature: Searching for a Content item
     When I search for a Content named "Searched folder"
     Then I should see in search results an item named "Searched folder"
 
-  @javascript @APIUser:admin
   Scenario: Content can be searched for in UDW
     Given I create "folder" Content items in root in "eng-GB"
       | name      | short_name  |


### PR DESCRIPTION
The tests using Cotf cannot be run on Ibexa Experience and Commerce editions - removing the tags should be enough

We will bring them back once "Create content" action is added by default in the Dashboard