### PR TITLE
IBX-6413: Fixes minQueryLength test to stick to parameter's meaning

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.search.autocomplete.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.autocomplete.js
@@ -74,7 +74,7 @@
 
         searchAbortController?.abort();
 
-        if (searchText.length <= minQueryLength) {
+        if (searchText.length < minQueryLength) {
             hideAutocomplete();
 
             return;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6413](https://issues.ibexa.co/browse/IBX-6413)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes/no
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

`ibexa.site_access.config.<scope>.search.suggestion.min_query_length: 3` should mean that suggestion start to be made for a 3 character long text.
- With `<=` it was starting at 4 characters.
- With `<` it starts at 3.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
