### PR TITLE
IBX-7147: Fixed issue where multiple Encore entries are applied to ESI fragments

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/all.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/all.html.twig
@@ -1,8 +1,10 @@
 {% trans_default_domain 'ibexa_dashboard' %}
 
+{% set parameters = parameters|default({})|merge({ hide_toggler: true }) %}
+
 <div class="card border-light ibexa-card ibexa-card--no-padding mb-4">
     <div class="ibexa-card__title">{{ 'everyone'|trans|desc('Common content') }}</div>
     <div class="ibexa-card__body">
-        {{ ibexa_render_component_group('dashboard-all-tab-groups', { hide_toggler: true }) }}
+        {{ ibexa_render_component_group('dashboard-all-tab-groups', parameters) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/me.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/me.html.twig
@@ -1,8 +1,10 @@
 {% trans_default_domain 'ibexa_dashboard' %}
 
+{% set parameters = parameters|default({})|merge({ hide_toggler: true }) %}
+
 <div class="card border-light ibexa-card ibexa-card--no-padding my-4">
     <div class="ibexa-card__title">{{ 'me'|trans|desc('My content') }}</div>
     <div class="ibexa-card__body">
-        {{ ibexa_render_component_group('dashboard-my-tab-groups', { hide_toggler: true }) }}
+        {{ ibexa_render_component_group('dashboard-my-tab-groups', parameters) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/tab/default.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/tab/default.html.twig
@@ -9,5 +9,8 @@
 } %}
 
 {% block javascripts %}
-    {{ encore_entry_script_tags('ibexa-admin-ui-tabs-js', null, 'ibexa') }}
+    {% set render_encore_entry = render_encore_entry is defined ? render_encore_entry : true %}
+    {% if render_encore_entry %}
+        {{ encore_entry_script_tags('ibexa-admin-ui-tabs-js', null, 'ibexa') }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
This is a workaround to the issue that causes `runtime.js` to be applied on all ESI fragments.

Requires: https://github.com/ibexa/dashboard/pull/45