### PR TITLE
[Behat] Disabled tests checking status of button hidden in the Context menu

### DIFF
--- a/features/personas/SubtreeEditor.feature
+++ b/features/personas/SubtreeEditor.feature
@@ -60,7 +60,7 @@ Feature: Verify that an Editor with Subtree limitations can perform all his task
     Then the buttons are disabled
       | buttonName     |
       | Create content |
-      | Edit           |
+      # | Edit           |
     And the "Send to trash" button is not visible
 
   Scenario: I cannot edit, create or send to trash Content outside my permissions
@@ -68,5 +68,5 @@ Feature: Verify that an Editor with Subtree limitations can perform all his task
     Then the buttons are disabled
       | buttonName     |
       | Create content |
-      | Edit           |
+      # | Edit           |
     And the "Send to trash" button is not visible


### PR DESCRIPTION
This commit was part of https://github.com/ibexa/admin-ui/pull/995 (https://github.com/ibexa/admin-ui/commit/450e330262b0795b5c1712a5ccf7ed4016143a19) , but then it got lost during the rebase process

There is a bug in context menu in AdminUI - reported as https://issues.ibexa.co/browse/IBX-7153

We will need to enable this tests (or adjust them) once it's fixed.