### PR TITLE
IBX-7055: Removed unused method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -502,16 +502,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method getContentInfo\\(\\) on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
-			count: 12
+			count: 11
 			path: src/bundle/Controller/LocationController.php
 
 		-
 			message: "#^Parameter \\#1 \\$contentInfo of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:createLocation\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Controller/LocationController.php
-
-		-
-			message: "#^Parameter \\#1 \\$location of method Ibexa\\\\Contracts\\\\AdminUi\\\\Controller\\\\Controller\\:\\:redirectToLocation\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null given\\.$#"
 			count: 1
 			path: src/bundle/Controller/LocationController.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -456,11 +456,6 @@ parameters:
 			path: src/bundle/Controller/LinkManagerController.php
 
 		-
-			message: "#^Call to method getLocation\\(\\) on an unknown class Ibexa\\\\AdminUi\\\\Form\\\\Data\\\\Location\\\\LocationTrashContainerData\\.$#"
-			count: 1
-			path: src/bundle/Controller/LocationController.php
-
-		-
 			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
 			count: 1
 			path: src/bundle/Controller/LocationController.php
@@ -497,7 +492,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$parentLocationId on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
-			count: 2
+			count: 1
 			path: src/bundle/Controller/LocationController.php
 
 		-
@@ -508,11 +503,6 @@ parameters:
 		-
 			message: "#^Cannot call method getContentInfo\\(\\) on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
 			count: 12
-			path: src/bundle/Controller/LocationController.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\AdminUi\\\\Controller\\\\LocationController\\:\\:handleTrashLocationForm\\(\\) is unused\\.$#"
-			count: 1
 			path: src/bundle/Controller/LocationController.php
 
 		-
@@ -541,13 +531,8 @@ parameters:
 			path: src/bundle/Controller/LocationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$location of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\SectionService\\:\\:assignSectionToSubtree\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Controller/LocationController.php
-
-		-
 			message: "#^Parameter \\#1 \\$location of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\TrashService\\:\\:trash\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null given\\.$#"
-			count: 2
+			count: 1
 			path: src/bundle/Controller/LocationController.php
 
 		-
@@ -577,11 +562,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$targetParentLocation of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:copySubtree\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Controller/LocationController.php
-
-		-
-			message: "#^Parameter \\$data of method Ibexa\\\\Bundle\\\\AdminUi\\\\Controller\\\\LocationController\\:\\:handleTrashLocationForm\\(\\) has invalid type Ibexa\\\\AdminUi\\\\Form\\\\Data\\\\Location\\\\LocationTrashContainerData\\.$#"
 			count: 1
 			path: src/bundle/Controller/LocationController.php
 

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -401,24 +401,11 @@ class LocationController extends Controller
             ) {
                 $this->trashRelatedAsset($location->getContentInfo());
             }
-            $trashItem = $this->trashService->trash($location);
+            $this->trashService->trash($location);
             $this->repository->commit();
         } catch (\Exception $exception) {
             $this->repository->rollback();
             throw $exception;
-        }
-
-        if ($trashItem === null) {
-            $this->notificationHandler->info(
-                $this->translator->trans(
-                    /** @Desc("Location '%name%' was not moved to Trash.") */
-                    'location.trash.failure',
-                    ['%name%' => $location->getContentInfo()->name],
-                    'ibexa_location'
-                )
-            );
-
-            return $this->redirectToLocation($location);
         }
 
         $this->notificationHandler->success(

--- a/src/bundle/Resources/translations/ibexa_location.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_location.en.xliff
@@ -41,11 +41,6 @@
         <target state="new">Location '%name%' swapped with Location '%location%'</target>
         <note>key: location.swap.success</note>
       </trans-unit>
-      <trans-unit id="8dae139e819d22e90584ad4e09d6fb541009ec61" resname="location.trash.failure">
-        <source>Location '%name%' was not moved to Trash.</source>
-        <target state="new">Location '%name%' was not moved to Trash.</target>
-        <note>key: location.trash.failure</note>
-      </trans-unit>
       <trans-unit id="48699e3e0320623a7ac78df3b808f6341dd7d4c3" resname="location.trash.success">
         <source>Location '%name%' moved to Trash.</source>
         <target state="new">Location '%name%' moved to Trash.</target>

--- a/src/bundle/Resources/translations/ibexa_location.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_location.en.xliff
@@ -41,6 +41,11 @@
         <target state="new">Location '%name%' swapped with Location '%location%'</target>
         <note>key: location.swap.success</note>
       </trans-unit>
+      <trans-unit id="8dae139e819d22e90584ad4e09d6fb541009ec61" resname="location.trash.failure">
+        <source>Location '%name%' was not moved to Trash.</source>
+        <target state="new">Location '%name%' was not moved to Trash.</target>
+        <note>key: location.trash.failure</note>
+      </trans-unit>
       <trans-unit id="48699e3e0320623a7ac78df3b808f6341dd7d4c3" resname="location.trash.success">
         <source>Location '%name%' moved to Trash.</source>
         <target state="new">Location '%name%' moved to Trash.</target>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | IBX-7055
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
| Needs         | https://github.com/ibexa/dashboard/pull/54/files
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

A different approach was merged but it is still worth to merge it. It removes an unused method and reduces the number of phpstan errors. 
 
~When the Exception is thrown and the content item is not sent to Trash then a proper flash message should be displayed~

![image](https://github.com/ibexa/admin-ui/assets/1654712/b1a4525e-b67b-4307-b157-2445f99801d4)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
