### PR TITLE
IBX-7126: Allowed passing extra parameters to pager of "My Drafts" tab

### DIFF
--- a/src/lib/Tab/Dashboard/MyDraftsTab.php
+++ b/src/lib/Tab/Dashboard/MyDraftsTab.php
@@ -130,7 +130,8 @@ class MyDraftsTab extends AbstractTab implements OrderedTabInterface, Conditiona
         return $this->twig->render('@ibexadesign/ui/dashboard/tab/my_draft_list.html.twig', [
             'data' => $pagination->getCurrentPageResults(),
             'pager' => $pagination,
-            'pager_options' => [
+            // merge pager options, prioritizing the ones passed via $parameters
+            'pager_options' => ($parameters['pager_options'] ?? []) + [
                 'pageParameter' => '[' . self::PAGINATION_PARAM_NAME . ']',
             ],
         ]);

--- a/tests/lib/Tab/Dashboard/MyDraftsTabTest.php
+++ b/tests/lib/Tab/Dashboard/MyDraftsTabTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Tab\Dashboard;
+
+use Ibexa\AdminUi\Tab\Dashboard\MyDraftsTab;
+use Ibexa\AdminUi\UI\Dataset\DatasetFactory;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * @covers \Ibexa\AdminUi\Tab\Dashboard\MyDraftsTab
+ */
+final class MyDraftsTabTest extends TestCase
+{
+    public function testRenderView(): void
+    {
+        $templateMock = '{{ pager_options.routeName }} | {{ pager_options.pageParameter }}';
+        $twigStub = new Environment(
+            new ArrayLoader(
+                [
+                    '@ibexadesign/ui/dashboard/tab/my_draft_list.html.twig' => $templateMock,
+                ]
+            )
+        );
+
+        $requestStackMock = $this->createMock(RequestStack::class);
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $tab = new MyDraftsTab(
+            $twigStub,
+            $this->createMock(TranslatorInterface::class),
+            $this->createMock(ContentService::class),
+            $this->createMock(ContentTypeService::class),
+            $this->createMock(PermissionResolver::class),
+            $this->createMock(DatasetFactory::class),
+            $requestStackMock,
+            $configResolverMock
+        );
+
+        $configResolverMock->method('getParameter')->with('pagination.content_draft_limit')->willReturn(10);
+        $requestStackMock->method('getCurrentRequest')->willReturn(new Request());
+
+        self::assertSame(
+            // see $templateMock
+            'app.page | [mydrafts-page]',
+            $tab->renderView(
+                [
+                    'pager_options' => [
+                        'routeName' => 'app.page',
+                    ],
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-7126](https://issues.ibexa.co/browse/IBX-7126) |
| **Required by** | ibexa/dashboard#53
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.6`             |
| **BC breaks**            | no                                              |

When "My Drafts" Dashboard tab is rendered as a Customizable Dashboard Builder block, neither original request route name nor pagination parameter is available in a current context.

Parameters, in the end, after a few iterations, were seamlessly copied from main request to the block-rendering request via https://github.com/ibexa/dashboard/pull/53.

This PR allows merging extra Pagerfanta options coming from a template (see https://github.com/ibexa/dashboard/pull/53 for usage - passed extra `routeName`) with current rendering options.

Because of high coupling between MyDraftsTab and Twig Environment, I needed to stub Twig Environment to add test coverage for the change.

### TODO
- [x] Unit test coverage for merging `pager_options`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.