### PR TITLE
IBX-6856: Added mimeTypes field to ImageFormMapper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3851,11 +3851,6 @@ parameters:
 			path: src/lib/FieldType/Mapper/ISBNFormMapper.php
 
 		-
-			message: "#^Constructor of class Ibexa\\\\AdminUi\\\\FieldType\\\\Mapper\\\\ImageFormMapper has an unused parameter \\$fieldTypeService\\.$#"
-			count: 1
-			path: src/lib/FieldType/Mapper/ImageFormMapper.php
-
-		-
 			message: "#^Method Ibexa\\\\AdminUi\\\\FieldType\\\\Mapper\\\\ImageFormMapper\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Mapper/ImageFormMapper.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8426,11 +8426,6 @@ parameters:
 			path: src/lib/REST/Input/Parser/Operation.php
 
 		-
-			message: "#^Cannot call method resolve\\(\\) on Ibexa\\\\Contracts\\\\AdminUi\\\\REST\\\\ApplicationConfigRestResolverInterface\\|null\\.$#"
-			count: 1
-			path: src/lib/REST/Output/ValueObjectVisitor/ApplicationConfigVisitor.php
-
-		-
 			message: "#^Method Ibexa\\\\AdminUi\\\\REST\\\\Output\\\\ValueObjectVisitor\\\\BulkOperationResponse\\:\\:visit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/REST/Output/ValueObjectVisitor/BulkOperationResponse.php

--- a/src/bundle/Resources/config/services/fieldtype_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/fieldtype_form_mappers.yaml
@@ -46,6 +46,8 @@ services:
             - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezfloat }
 
     Ibexa\AdminUi\FieldType\Mapper\ImageFormMapper:
+        arguments:
+            $allowedMimeTypes: '%ibexa.field_type.ezimage.mime_types%'
         tags:
             - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: ezimage }
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -16,6 +16,7 @@
             const isRequired = input.required || this.fieldContainer.classList.contains('ibexa-field-edit--required');
             const dataMaxSize = +input.dataset.maxFileSize;
             const maxFileSize = parseInt(dataMaxSize, 10);
+            const { allowedFileTypes } = input.dataset;
             const isEmpty = input.files && !input.files.length && dataContainer && !dataContainer.hasAttribute('hidden');
             let result = { isError: false };
 
@@ -26,8 +27,14 @@
                 };
             }
 
-            if (!isEmpty && maxFileSize > 0 && input.files[0] && input.files[0].size > maxFileSize) {
-                result = this.validateFileSize(event);
+            const file = input.files[0];
+
+            if (!isEmpty && maxFileSize > 0 && file && file.size > maxFileSize) {
+                result = this.validateFileSize();
+            }
+
+            if (!isEmpty && allowedFileTypes.length > 0 && file && !allowedFileTypes.includes(file.type)) {
+                result = this.showFileTypeError();
             }
 
             return result;
@@ -48,6 +55,16 @@
             const result = {
                 isError: true,
                 errorMessage: ibexa.errors.invalidFileSize.replace('{fieldName}', label),
+            };
+
+            return result;
+        }
+
+        showFileTypeError() {
+            const label = this.fieldContainer.querySelector(SELECTOR_FIELD_LABEL).innerHTML;
+            const result = {
+                isError: true,
+                errorMessage: ibexa.errors.invalidFileType.replace('{fieldName}', label),
             };
 
             return result;

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
@@ -87,6 +87,10 @@
                 return this.showFileSizeError();
             }
 
+            if (this.allowedFileTypes.length > 0 && !this.allowedFileTypes.includes(file.type)) {
+                return this.showFileTypeError();
+            }
+
             const changeEvent = new Event('change');
 
             this.inputField.files = event.dataTransfer.files;
@@ -100,6 +104,10 @@
          */
         showFileSizeError() {
             this.inputField.dispatchEvent(new CustomEvent('ibexa-invalid-file-size'));
+        }
+
+        showFileTypeError() {
+            this.inputField.dispatchEvent(new CustomEvent('ibexa-invalid-file-type'));
         }
 
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
@@ -41,6 +41,13 @@
                     callback: 'showFileSizeError',
                     errorNodeSelectors: ['.ibexa-form-error'],
                 },
+                {
+                    isValueValidator: false,
+                    selector: `input[type="file"]`,
+                    eventName: 'ibexa-invalid-file-type',
+                    callback: 'showFileTypeError',
+                    errorNodeSelectors: ['.ibexa-form-error'],
+                },
             ],
         });
         const previewField = new EzBinaryFilePreviewField({

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -133,10 +133,14 @@
                 },
             ],
         });
+
+        const inputFileFieldContainer = fieldContainer.querySelector(SELECTOR_INPUT_FILE);
+        const { allowedFileTypes } = inputFileFieldContainer.dataset;
         const previewField = new EzImageFilePreviewField({
             validator,
             fieldContainer,
-            fileTypeAccept: fieldContainer.querySelector(SELECTOR_INPUT_FILE).accept,
+            fileTypeAccept: inputFileFieldContainer.accept,
+            allowedFileTypes: typeof allowedFileTypes !== 'undefined' ? allowedFileTypes.split(',') : [],
         });
 
         previewField.init();

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -125,6 +125,13 @@
                 },
                 {
                     isValueValidator: false,
+                    selector: `${SELECTOR_INPUT_FILE}`,
+                    eventName: 'ibexa-invalid-file-type',
+                    callback: 'showFileTypeError',
+                    errorNodeSelectors: ['.ibexa-form-error'],
+                },
+                {
+                    isValueValidator: false,
                     selector: SELECTOR_INPUT_ALT,
                     eventName: EVENT_CANCEL_ERROR,
                     callback: 'cancelErrors',

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -187,11 +187,16 @@
          */
         handleInputChange(event) {
             const [file] = event.currentTarget.files;
-            const { languageCode } = event.currentTarget.dataset;
+            const { languageCode, allowedFileTypes } = event.currentTarget.dataset;
             const isFileSizeLimited = this.maxFileSize > 0;
             const maxFileSizeExceeded = isFileSizeLimited && file.size > this.maxFileSize;
 
             if (maxFileSizeExceeded) {
+                this.resetInputField();
+                return;
+            }
+
+            if (!allowedFileTypes.includes(file.type)) {
                 this.resetInputField();
                 return;
             }
@@ -242,6 +247,13 @@
                     selector: `${SELECTOR_INPUT_FILE}`,
                     eventName: 'ibexa-invalid-file-size',
                     callback: 'showFileSizeError',
+                    errorNodeSelectors: ['.ibexa-form-error'],
+                },
+                {
+                    isValueValidator: false,
+                    selector: `${SELECTOR_INPUT_FILE}`,
+                    eventName: 'ibexa-invalid-file-type',
+                    callback: 'showFileTypeError',
                     errorNodeSelectors: ['.ibexa-form-error'],
                 },
             ],

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -140,6 +140,13 @@
                     errorNodeSelectors: ['.ibexa-field-edit--ezmedia .ibexa-form-error'],
                 },
                 {
+                    isValueValidator: false,
+                    selector: SELECTOR_INPUT_FILE,
+                    eventName: 'ibexa-invalid-file-type',
+                    callback: 'showFileTypeError',
+                    errorNodeSelectors: ['.ibexa-field-edit--ezmedia .ibexa-form-error'],
+                },
+                {
                     selector: '.ibexa-field-edit-preview__dimensions .form-control',
                     eventName: 'blur',
                     callback: 'validateDimensions',

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
@@ -44,7 +44,7 @@
                     color: $ibexa-color-dark-300;
                 }
 
-                &--mime-types,
+                &--image-extensions,
                 &--filesize {
                     color: $ibexa-color-dark-300;
                     font-size: $ibexa-text-font-size-small;

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
@@ -44,6 +44,7 @@
                     color: $ibexa-color-dark-300;
                 }
 
+                &--mime-types,
                 &--filesize {
                     color: $ibexa-color-dark-300;
                     font-size: $ibexa-text-font-size-small;

--- a/src/bundle/Resources/translations/ibexa_content_forms_content.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_forms_content.en.xliff
@@ -166,6 +166,11 @@
         <target state="new">Max file size: %size%</target>
         <note>key: fieldtype.binary_base.max_file_size</note>
       </trans-unit>
+      <trans-unit id="b19a26b0ded06a8d2bfc9490e2645ba682c8ca30" resname="fieldtype.binary_base.mime_types">
+        <source>Allowed mime types: %mime_types%</source>
+        <target state="new">Allowed mime types: %mime_types%</target>
+        <note>key: fieldtype.binary_base.mime_types</note>
+      </trans-unit>
       <trans-unit id="763e9b64f4f0024e90753727ccc212a3596bfccd" resname="fieldtype.binary_base.upload_file">
         <source>Upload file</source>
         <target state="new">Upload file</target>

--- a/src/bundle/Resources/translations/ibexa_content_forms_content.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_forms_content.en.xliff
@@ -161,15 +161,15 @@
         <target state="new">or</target>
         <note>key: fieldtype.binary_base.drag_drop.or</note>
       </trans-unit>
+      <trans-unit id="0f71380bdf7b1b566dfd532ec3611aa13b2f0c38" resname="fieldtype.binary_base.image_extensions">
+        <source>Allowed extensions: %extensions%</source>
+        <target state="new">Allowed extensions: %extensions%</target>
+        <note>key: fieldtype.binary_base.image_extensions</note>
+      </trans-unit>
       <trans-unit id="858c986173f1ef87d7acda017535b86f01bca87d" resname="fieldtype.binary_base.max_file_size">
         <source>Max file size: %size%</source>
         <target state="new">Max file size: %size%</target>
         <note>key: fieldtype.binary_base.max_file_size</note>
-      </trans-unit>
-      <trans-unit id="b19a26b0ded06a8d2bfc9490e2645ba682c8ca30" resname="fieldtype.binary_base.mime_types">
-        <source>Allowed mime types: %mime_types%</source>
-        <target state="new">Allowed mime types: %mime_types%</target>
-        <note>key: fieldtype.binary_base.mime_types</note>
       </trans-unit>
       <trans-unit id="763e9b64f4f0024e90753727ccc212a3596bfccd" resname="fieldtype.binary_base.upload_file">
         <source>Upload file</source>

--- a/src/bundle/Resources/translations/ibexa_content_type.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_type.en.xliff
@@ -601,6 +601,11 @@
         <target state="new">Minimum value</target>
         <note>key: field_definition.ezfloat.min_value</note>
       </trans-unit>
+      <trans-unit id="8959be663eef40d92147918da792f8677772ea0c" resname="field_definition.ezimage.image_types">
+        <source>Image types</source>
+        <target state="new">Image types</target>
+        <note>key: field_definition.ezimage.image_types</note>
+      </trans-unit>
       <trans-unit id="5e8015fbf9269d3ee1bbb99b09005cf6b165ab53" resname="field_definition.ezimage.is_alternative_text_required">
         <source>Alternative text is required</source>
         <target state="new">Alternative text is required</target>

--- a/src/bundle/Resources/translations/validators.en.xliff
+++ b/src/bundle/Resources/translations/validators.en.xliff
@@ -96,6 +96,11 @@
         <target state="new">{fieldName}: Cannot upload. File exceeds file size limit.</target>
         <note>key: js.error.invalid_file_size</note>
       </trans-unit>
+      <trans-unit id="e34fdb2fe0c2a86056b2e9084b9226c921044df6" resname="js.error.invalid_file_type">
+        <source>{fieldName}: Cannot upload. File has wrong type.</source>
+        <target state="new">{fieldName}: Cannot upload. File has wrong type.</target>
+        <note>key: js.error.invalid_file_type</note>
+      </trans-unit>
       <trans-unit id="21c38818d1cb73ff54f0dc0b184d6de25058f24d" resname="js.error.invalid_url">
         <source>A valid URL is required</source>
         <target state="new">A valid URL is required</target>

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -87,6 +87,10 @@
         {{- form_row(form.maxSize) -}}
     </div>
 
+    <div class="ezimage-validator mime-types{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_row(form.mimeTypes) -}}
+    </div>
+
     <div class="ezimage-validator is-alternative-text-required"{% if group_class is not empty %} {{ group_class }}{% endif %}>
         {{ form_row(form.isAlternativeTextRequired) }}
     </div>

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -87,9 +87,11 @@
         {{- form_row(form.maxSize) -}}
     </div>
 
-    <div class="ezimage-validator mime-types{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.mimeTypes) -}}
-    </div>
+    {% if form.mimeTypes is defined %}
+        <div class="ezimage-validator mime-types{% if group_class is not empty %} {{ group_class }}{% endif %}">
+            {{- form_row(form.mimeTypes) -}}
+        </div>
+    {% endif %}
 
     <div class="ezimage-validator is-alternative-text-required"{% if group_class is not empty %} {{ group_class }}{% endif %}>
         {{ form_row(form.isAlternativeTextRequired) }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
@@ -53,9 +53,15 @@
         <div class="ibexa-data-source__message--filesize">{{ 'fieldtype.binary_base.max_file_size'|trans({'%size%': max_file_size|default(0)|ibexa_file_size(2)})|desc('Max file size: %size%') }}</div>
     {% endif %}
 
-    {% if mime_types is defined %}
-        <div class="ibexa-data-source__message--mime-types">
-            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(', ')})|desc('Allowed mime types: %mime_types%') }}
+    {% if image_extensions is defined %}
+        {% set extensions = [] %}
+
+        {% for mime_type in mime_types %}
+            {% set extensions = extensions|merge(image_extensions[mime_type]) %}
+        {% endfor %}
+
+        <div class="ibexa-data-source__message--image-extensions">
+            {{ 'fieldtype.binary_base.image_extensions'|trans({'%extensions%': extensions|join(', ')})|desc('Allowed extensions: %extensions%') }}
         </div>
     {% endif %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
@@ -53,6 +53,12 @@
         <div class="ibexa-data-source__message--filesize">{{ 'fieldtype.binary_base.max_file_size'|trans({'%size%': max_file_size|default(0)|ibexa_file_size(2)})|desc('Max file size: %size%') }}</div>
     {% endif %}
 
+    {% if mime_types is defined %}
+        <div class="ibexa-data-source__message--mime-types">
+            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(',')})|desc('Allowed mime types: %mime_types%') }}
+        </div>
+    {% endif %}
+
     {% set attr = attr|merge({ hidden: 'hidden' }) %}
 
     {{- form_widget(form.file, {'attr': attr}) -}}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
@@ -55,7 +55,7 @@
 
     {% if mime_types is defined %}
         <div class="ibexa-data-source__message--mime-types">
-            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(',')})|desc('Allowed mime types: %mime_types%') }}
+            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(', ')})|desc('Allowed mime types: %mime_types%') }}
         </div>
     {% endif %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -11,6 +11,7 @@
     {% else %}
         {% set attr = attr|merge({'accept': 'image/*' }) %}
     {% endif %}
+
     {{ block('binary_base_row') }}
 {%- endblock -%}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -5,6 +5,7 @@
 {%- block ezplatform_fieldtype_ezimage_row -%}
     {% set preview_block_name = 'ezimage_preview' %}
     {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size|round) %}
+
     {% if mime_types is defined %}
         {% set attr = attr|merge({'data-allowed-file-types': mime_types|join(',') }) %}
     {% else %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -5,7 +5,11 @@
 {%- block ezplatform_fieldtype_ezimage_row -%}
     {% set preview_block_name = 'ezimage_preview' %}
     {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size|round) %}
-    {% set attr = attr|merge({'accept': 'image/*'}) %}
+    {% if mime_types is defined %}
+        {% set attr = attr|merge({'data-allowed-file-types': mime_types|join(',') }) %}
+    {% else %}
+        {% set attr = attr|merge({'accept': 'image/*' }) %}
+    {% endif %}
     {{ block('binary_base_row') }}
 {%- endblock -%}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -52,7 +52,7 @@
 
     {% if mime_types is defined %}
         <div class="ibexa-data-source__message--mime-types">
-            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(',')})|desc('Allowed mime types: %mime_types%') }}
+            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(', ')})|desc('Allowed mime types: %mime_types%') }}
         </div>
     {% endif %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -50,6 +50,12 @@
         </div>
     {% endif %}
 
+    {% if mime_types is defined %}
+        <div class="ibexa-data-source__message--mime-types">
+            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(',')})|desc('Allowed mime types: %mime_types%') }}
+        </div>
+    {% endif %}
+
     {% set attr = attr|merge({ hidden: 'hidden' }) %}
 
     {{- form_widget(form.file, {'attr': attr}) -}}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -17,6 +17,10 @@
         'accept': 'image/*'
     }) %}
 
+    {% if mime_types is defined %}
+        {% set attr = attr|merge({'data-allowed-file-types': mime_types|join(',') }) %}
+    {% endif %}
+
     {{ block('binary_base_row') }}
 {%- endblock -%}
 
@@ -50,9 +54,15 @@
         </div>
     {% endif %}
 
-    {% if mime_types is defined %}
-        <div class="ibexa-data-source__message--mime-types">
-            {{ 'fieldtype.binary_base.mime_types'|trans({'%mime_types%': mime_types|join(', ')})|desc('Allowed mime types: %mime_types%') }}
+    {% if image_extensions is defined %}
+        {% set extensions = [] %}
+
+        {% for mime_type in mime_types %}
+            {% set extensions = extensions|merge(image_extensions[mime_type]) %}
+        {% endfor %}
+
+        <div class="ibexa-data-source__message--image-extensions">
+            {{ 'fieldtype.binary_base.image_extensions'|trans({'%extensions%': extensions|join(', ')})|desc('Allowed extensions: %extensions%') }}
         </div>
     {% endif %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -72,6 +72,7 @@
                 isLess: '{{ 'js.error.is_less'|trans({}, 'validators')|desc('{fieldName} value must be greater than or equal to {minValue}') }}',
                 isGreater: '{{ 'js.error.is_greater'|trans({}, 'validators')|desc('{fieldName} value must be less than or equal to {maxValue}') }}',
                 invalidFileSize: '{{ 'js.error.invalid_file_size'|trans({}, 'validators')|desc('{fieldName}: Cannot upload. File exceeds file size limit.') }}',
+                invalidFileType: '{{ 'js.error.invalid_file_type'|trans({}, 'validators')|desc('{fieldName}: Cannot upload. File has wrong type.') }}',
                 provideLatitudeValue: '{{ 'js.error.provide_latitude_value'|trans({}, 'validators')|desc('Provide latitude value in the Latitude field') }}',
                 provideLongitudeValue: '{{ 'js.error.provide_longitude_value'|trans({}, 'validators')|desc('Provide longitude value in the Longitude field') }}',
                 addressNotFound: '{{ 'js.error.address_not_found'|trans({}, 'validators')|desc('Provided address does not exist') }}',

--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -9,22 +9,36 @@ namespace Ibexa\AdminUi\FieldType\Mapper;
 use Ibexa\AdminUi\FieldType\FieldDefinitionFormMapperInterface;
 use Ibexa\AdminUi\Form\Data\FieldDefinitionData;
 use Ibexa\ContentForms\ConfigResolver\MaxUploadSize;
-use Ibexa\Contracts\Core\Repository\FieldTypeService;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Range;
 
 class ImageFormMapper implements FieldDefinitionFormMapperInterface
 {
+    /** @var array<string> */
+    private array $allowedMimeTypes;
+
     /** @var \Ibexa\ContentForms\ConfigResolver\MaxUploadSize */
     private $maxUploadSize;
 
-    public function __construct(FieldTypeService $fieldTypeService, MaxUploadSize $maxUploadSize)
-    {
+    private MimeTypesInterface $mimeTypes;
+
+    /**
+     * @param string[] $allowedMimeTypes
+     */
+    public function __construct(
+        array $allowedMimeTypes,
+        MaxUploadSize $maxUploadSize,
+        MimeTypesInterface $mimeTypes
+    ) {
+        $this->allowedMimeTypes = $allowedMimeTypes;
         $this->maxUploadSize = $maxUploadSize;
+        $this->mimeTypes = $mimeTypes;
     }
 
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data): void
@@ -48,6 +62,13 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
                 'disabled' => $isTranslation,
                 'scale' => 1,
             ])
+            ->add('mimeTypes', ChoiceType::class, [
+                'required' => false,
+                'multiple' => true,
+                'choices' => $this->getMimeTypesChoiceList(),
+                'property_path' => 'fieldSettings[mimeTypes]',
+                'label' => /** @Desc("Image types") */ 'field_definition.ezimage.image_types',
+            ])
             ->add('isAlternativeTextRequired', CheckboxType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[AlternativeTextValidator][required]',
@@ -67,6 +88,21 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
             ->setDefaults([
                 'translation_domain' => 'ibexa_content_type',
             ]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMimeTypesChoiceList(): array
+    {
+        $mimeTypeChoiceList = [];
+        foreach ($this->allowedMimeTypes as $mimeType) {
+            $extensions = implode(', ', $this->mimeTypes->getExtensions($mimeType));
+            $label = explode('image/', $mimeType);
+            $mimeTypeChoiceList[$label[1] . " ($extensions)"] = $mimeType;
+        }
+
+        return $mimeTypeChoiceList;
     }
 }
 

--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -97,7 +97,15 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
     {
         $mimeTypeChoiceList = [];
         foreach ($this->allowedMimeTypes as $mimeType) {
-            $extensions = implode(', ', $this->mimeTypes->getExtensions($mimeType));
+            $extensions = implode(
+                ', ',
+                array_map(
+                    static function (string $extension): string {
+                        return '*.' . $extension;
+                    },
+                    $this->mimeTypes->getExtensions($mimeType)
+                )
+            );
             $label = explode('image/', $mimeType);
             $mimeTypeChoiceList[$label[1] . " ($extensions)"] = $mimeType;
         }

--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -44,6 +44,18 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data): void
     {
         $isTranslation = $data->contentTypeData->languageCode !== $data->contentTypeData->mainLanguageCode;
+
+        if (!empty($this->allowedMimeTypes)) {
+            $fieldDefinitionForm
+                ->add('mimeTypes', ChoiceType::class, [
+                    'required' => false,
+                    'multiple' => true,
+                    'choices' => $this->getMimeTypesChoiceList(),
+                    'property_path' => 'fieldSettings[mimeTypes]',
+                    'label' => /** @Desc("Image types") */ 'field_definition.ezimage.image_types',
+                ]);
+        }
+
         $fieldDefinitionForm
             ->add('maxSize', NumberType::class, [
                 'required' => false,
@@ -61,13 +73,6 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
                 ],
                 'disabled' => $isTranslation,
                 'scale' => 1,
-            ])
-            ->add('mimeTypes', ChoiceType::class, [
-                'required' => false,
-                'multiple' => true,
-                'choices' => $this->getMimeTypesChoiceList(),
-                'property_path' => 'fieldSettings[mimeTypes]',
-                'label' => /** @Desc("Image types") */ 'field_definition.ezimage.image_types',
             ])
             ->add('isAlternativeTextRequired', CheckboxType::class, [
                 'required' => false,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6856
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

https://github.com/ibexa/core/pull/300
https://github.com/ibexa/content-forms/pull/55
https://github.com/ibexa/image-editor/pull/80

![Screen Shot 2023-12-04 at 13 04 24](https://github.com/ibexa/admin-ui/assets/9850711/edb18fd8-2b8f-4b6c-bb3d-e1ccbe097ee5)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
