### PR TITLE
[Behat] Changed mouseOverAndClick to Click action

### DIFF
--- a/src/lib/Behat/Component/Table/TableRow.php
+++ b/src/lib/Behat/Component/Table/TableRow.php
@@ -43,7 +43,7 @@ class TableRow extends Component
 
     public function edit(): void
     {
-        $this->element->find($this->getLocator('edit'))->execute(new MouseOverAndClick());
+        $this->element->find($this->getLocator('edit'))->execute(new Click());
     }
 
     public function copy(): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7163
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

This PR is an attempt to fix https://github.com/ibexa/workflow/actions/runs/7046869067/job/19179534401?pr=86. It seems that MouseOverAndClick action scroll to high up, a simple Click should be better here.
