### PR TITLE
[Behat] Increased timeout for UDW searching

### DIFF
--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -171,7 +171,7 @@ class UniversalDiscoveryWidget extends Component
 
     public function searchForContent(string $name): void
     {
-        $this->getHTMLPage()->find($this->getLocator('inputField'))->setValue($name);
+        $this->getHTMLPage()->setTimeout(3)->find($this->getLocator('inputField'))->setValue($name);
         $this->getHTMLPage()->find($this->getLocator('searchButton'))->click();
 
         $this->getHTMLPage()


### PR DESCRIPTION
Example failure: https://github.com/ibexa/headless/actions/runs/7153741371/job/19480535119

```
    And I search for content item "folderUDW" through UDW       # Ibexa\AdminUi\Behat\BrowserContext\UDWContext::searchForContentItem()
      Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'inputField': '.c-top-menu-search-input__search-input' not found in 1 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79
      Stack trace:
      #0 vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php(105): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
      #1 vendor/ibexa/admin-ui/src/lib/Behat/Component/UniversalDiscoveryWidget.php(174): Ibexa\Behat\Browser\Element\BaseElement->find()
      #2 vendor/ibexa/admin-ui/src/lib/Behat/BrowserContext/UDWContext.php(114): Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget->searchForContent()
```