### PR TITLE
[Behat] Increased the timeout for opening Content update Page

### DIFF
--- a/src/lib/Behat/Page/ContentUpdateItemPage.php
+++ b/src/lib/Behat/Page/ContentUpdateItemPage.php
@@ -65,11 +65,14 @@ class ContentUpdateItemPage extends Page
             Assert::assertEquals(
                 $this->pageTitle,
                 $this->getHTMLPage()
-                    ->setTimeout(10)
+                    ->setTimeout(20)
                     ->find($this->getLocator('pageTitle'))->getText()
             );
         }
-        $this->getHTMLPage()->setTimeout(10)->find($this->getLocator('formElement'))->assert()->isVisible();
+        $this->getHTMLPage()
+            ->setTimeout(20)
+            ->find($this->getLocator('formElement'))
+            ->assert()->isVisible();
         $this->contentActionsMenu->verifyIsLoaded();
 
         // close notification about new draft created successfully if it's still visible


### PR DESCRIPTION
This is a quick fix and something that we should investigate in a more convienent time.

Example failure:
https://github.com/ibexa/commerce/actions/runs/7160506519/job/19495050988

```
     And I set content fields                                    # Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext::iSetFields()
      | label       | value          |
      | Identifier  | TagIdentifier  |
      | Name        | TagName        |
      | Description | TagDescription |
      Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'formElement': 'form.ibexa-form, .ibexa-edit-content' not found in 10 seconds. in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79
      Stack trace:
      #0 vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php(105): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
      #1 vendor/ibexa/admin-ui/src/lib/Behat/Page/ContentUpdateItemPage.php(72): Ibexa\Behat\Browser\Element\BaseElement->find()
      #2 vendor/ibexa/admin-ui/src/lib/Behat/BrowserContext/ContentUpdateContext.php(37): Ibexa\AdminUi\Behat\Page\ContentUpdateItemPage->verifyIsLoaded()
```

I've played with this on Nightly and I think it's possible that the explanation is very simple - the page does not load (open) in 10 seconds after clicking.

Here's a recording from Nightly:


https://github.com/ibexa/admin-ui/assets/10993858/d5c8a4ed-87ab-44e7-80d0-51a901ce2b3a

You can see that the delay between clicking the button and the page opening is almost 7 seconds - is it possible that on CI it sometimes takes more than 10 seconds? I believe it is.

We need Blackfire Player Scenarios for this kind of actions, with constant monitoring - but that's not doable right now (today).