### PR TITLE
Fixed wrong resolving path to `flatpickr.js` making `yarn encore [env]` command failing

### DIFF
--- a/src/bundle/Resources/public/js/scripts/widgets/flatpickr.js
+++ b/src/bundle/Resources/public/js/scripts/widgets/flatpickr.js
@@ -1,4 +1,4 @@
-import flatpickrLanguages from '../../../../../../../../../../public/bundles/ibexaadminuiassets/vendors/flatpickr/dist/l10n';
+import flatpickrLanguages from '@ibexa-admin-ui-assets/src/bundle/Resources/public/vendors/flatpickr/dist/l10n';
 
 (function (global, doc, ibexa, flatpickr) {
     const { backOfficeLanguage } = ibexa.adminUiConfig;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
