### PR TITLE
IBX-7059: Added align-items for icon-wrapper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11237,11 +11237,6 @@ parameters:
 			path: tests/lib/EventListener/RequestLocaleListenerTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with void will always evaluate to false\\.$#"
-			count: 2
-			path: tests/lib/EventListener/SetViewParametersListenerTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\AdminUi\\\\EventListener\\\\SetViewParametersListenerTest\\:\\:createFieldMock\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject but returns PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
 			count: 1
 			path: tests/lib/EventListener/SetViewParametersListenerTest.php

--- a/src/bundle/Resources/public/scss/_alerts.scss
+++ b/src/bundle/Resources/public/scss/_alerts.scss
@@ -15,7 +15,7 @@
 
     &__icon-wrapper {
         grid-area: icon;
-        margin-top: calculateRem(2px);
+        align-items: center;
         display: flex;
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-7059](https://issues.ibexa.co/browse/IBX-7059)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


The issue also occurs on 4.5, so I created a PR from 4.5


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
