### PR TITLE
IBX-7367: Added config provider for image picker

### DIFF
--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -79,4 +79,10 @@ parameters:
 
     ibexa.site_access.config.default.admin_ui.default_focus_mode: '1'
 
-    ibexa.image_picker.field_definition_identifiers: ['image']
+    ibexa.image_picker.field_definition_identifiers: [image]
+    ibexa.image_picker.content_type_identifiers: [image]
+    ibexa.image_picker.aggregations:
+        KeywordTermAggregation:
+            name: keywords
+            contentTypeIdentifier: image
+            fieldDefinitionIdentifier: tags

--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -78,3 +78,5 @@ parameters:
     ibexa.admin_ui.content_tree.node_factory.max_location_ids_in_single_aggregation: 100
 
     ibexa.site_access.config.default.admin_ui.default_focus_mode: '1'
+
+    ibexa.image_picker.field_definition_identifiers: ['image']

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -143,6 +143,12 @@ services:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'userProfile' }
 
+    Ibexa\AdminUi\UI\Config\Provider\Module\ImagePicker:
+        arguments:
+            $imageFieldDefinitionIdentifiers: '%ibexa.image_picker.field_definition_identifiers%'
+        tags:
+            - { name: ibexa.admin_ui.config.provider, key: 'imagePicker' }
+
     # Resolvers
     Ibexa\AdminUi\REST\Generator\ApplicationConfigRestGeneratorRegistry:
         arguments:

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -145,7 +145,10 @@ services:
 
     Ibexa\AdminUi\UI\Config\Provider\Module\ImagePicker:
         arguments:
-            $imageFieldDefinitionIdentifiers: '%ibexa.image_picker.field_definition_identifiers%'
+            $config:
+                imageFieldDefinitionIdentifiers: '%ibexa.image_picker.field_definition_identifiers%'
+                imageContentTypeIdentifiers: '%ibexa.image_picker.content_type_identifiers%'
+                aggregations: '%ibexa.image_picker.aggregations%'
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'imagePicker' }
 

--- a/src/lib/UI/Config/Provider/Module/ImagePicker.php
+++ b/src/lib/UI/Config/Provider/Module/ImagePicker.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Config\Provider\Module;
+
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+
+final class ImagePicker implements ProviderInterface
+{
+    /** @var array<string> */
+    private array $imageFieldDefinitionIdentifiers;
+
+    /**
+     * @param array<string> $imageFieldDefinitionIdentifiers
+     */
+    public function __construct(array $imageFieldDefinitionIdentifiers)
+    {
+        $this->imageFieldDefinitionIdentifiers = $imageFieldDefinitionIdentifiers;
+    }
+
+    /**
+     * @return array{
+     *     imageFieldDefinitionIdentifiers: array<string>,
+     * }
+     */
+    public function getConfig(): array
+    {
+        return [
+            'imageFieldDefinitionIdentifiers' => $this->imageFieldDefinitionIdentifiers,
+        ];
+    }
+}

--- a/src/lib/UI/Config/Provider/Module/ImagePicker.php
+++ b/src/lib/UI/Config/Provider/Module/ImagePicker.php
@@ -10,28 +10,31 @@ namespace Ibexa\AdminUi\UI\Config\Provider\Module;
 
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
 
+/**
+ * @template TConfig of array{
+ *      imageFieldDefinitionIdentifiers: array<string>,
+ *      imageContentTypeIdentifiers: array<string>,
+ *      aggregations: array<string, array<string, string>>,
+ *  }
+ */
 final class ImagePicker implements ProviderInterface
 {
-    /** @var array<string> */
-    private array $imageFieldDefinitionIdentifiers;
+    /** @phpstan-var TConfig */
+    private array $config;
 
     /**
-     * @param array<string> $imageFieldDefinitionIdentifiers
+     * @phpstan-param TConfig $config
      */
-    public function __construct(array $imageFieldDefinitionIdentifiers)
+    public function __construct(array $config)
     {
-        $this->imageFieldDefinitionIdentifiers = $imageFieldDefinitionIdentifiers;
+        $this->config = $config;
     }
 
     /**
-     * @return array{
-     *     imageFieldDefinitionIdentifiers: array<string>,
-     * }
+     * @phpstan-return TConfig
      */
     public function getConfig(): array
     {
-        return [
-            'imageFieldDefinitionIdentifiers' => $this->imageFieldDefinitionIdentifiers,
-        ];
+        return $this->config;
     }
 }

--- a/tests/lib/UI/Config/Provider/Module/ImagePickerTest.php
+++ b/tests/lib/UI/Config/Provider/Module/ImagePickerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\UI\Config\Provider\Module;
+
+use Ibexa\AdminUi\UI\Config\Provider\Module\ImagePicker;
+use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ImagePickerTest extends TestCase
+{
+    private const FIELD_DEFINITION_IDENTIFIERS = ['foo', 'bar'];
+
+    private ProviderInterface $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new ImagePicker(self::FIELD_DEFINITION_IDENTIFIERS);
+    }
+
+    public function testGetConfig(): void
+    {
+        self::assertSame(
+            [
+                'imageFieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
+            ],
+            $this->provider->getConfig()
+        );
+    }
+}

--- a/tests/lib/UI/Config/Provider/Module/ImagePickerTest.php
+++ b/tests/lib/UI/Config/Provider/Module/ImagePickerTest.php
@@ -14,13 +14,27 @@ use PHPUnit\Framework\TestCase;
 
 final class ImagePickerTest extends TestCase
 {
-    private const FIELD_DEFINITION_IDENTIFIERS = ['foo', 'bar'];
+    private const FIELD_DEFINITION_IDENTIFIERS = ['field_foo', 'field_bar'];
+    private const CONTENT_TYPE_IDENTIFIERS = ['content_type_foo', 'content_type_bar'];
+    private const AGGREGATIONS = [
+        'KeywordTermAggregation' => [
+            'name' => 'keywords',
+            'contentTypeIdentifier' => 'keywords',
+            'fieldDefinitionIdentifier' => 'keywords',
+        ],
+    ];
 
     private ProviderInterface $provider;
 
     protected function setUp(): void
     {
-        $this->provider = new ImagePicker(self::FIELD_DEFINITION_IDENTIFIERS);
+        $this->provider = new ImagePicker(
+            [
+                'imageFieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
+                'imageContentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
+                'aggregations' => self::AGGREGATIONS,
+            ]
+        );
     }
 
     public function testGetConfig(): void
@@ -28,6 +42,8 @@ final class ImagePickerTest extends TestCase
         self::assertSame(
             [
                 'imageFieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
+                'imageContentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
+                'aggregations' => self::AGGREGATIONS,
             ],
             $this->provider->getConfig()
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7367
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Ref: https://github.com/ibexa/core/blob/main/data/mysql/cleandata.sql#L50

This is required by image picker to be able to run UDW with correct settings and search by correct field definition and content type identifier.

Currently values for field definition and KeywordTermAggregation are hardcoded.

https://github.com/ibexa/image-picker/blob/main/src/bundle/ui-dev/src/modules/image-picker/components/items-view/items.view.js#L198-L202

https://github.com/ibexa/admin-ui/blob/main/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useSearchByQueryFetch.js#L73


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
