### PR TITLE
IBX-7299: Added event emission to allow modification of content type list

### DIFF
--- a/src/lib/Event/FilterContentTypesEvent.php
+++ b/src/lib/Event/FilterContentTypesEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @phpstan-import-type TContentTypeData from \Ibexa\AdminUi\UI\Config\Provider\ContentTypes
+ */
+final class FilterContentTypesEvent extends Event
+{
+    /** @var array<string, array<TContentTypeData>> */
+    private array $contentTypeGroups;
+
+    /**
+     * @param array<string, array<TContentTypeData>> $contentTypeGroups
+     */
+    public function __construct(
+        array $contentTypeGroups
+    ) {
+        $this->contentTypeGroups = $contentTypeGroups;
+    }
+
+    /**
+     * @return array<string, array<TContentTypeData>>
+     */
+    public function getContentTypeGroups(): array
+    {
+        return $this->contentTypeGroups;
+    }
+
+    public function removeContentTypeGroup(string $contentTypeGroupIdentifier): void
+    {
+        unset($this->contentTypeGroups[$contentTypeGroupIdentifier]);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7299
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This will be utilized in the dashboard package (https://github.com/ibexa/dashboard/pull/77). The dashboard group will be removed from the list of available content types. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
