### PR TITLE
IBX-7401: Fixed input file type validation for image asset field

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -16,7 +16,7 @@
             const isRequired = input.required || this.fieldContainer.classList.contains('ibexa-field-edit--required');
             const dataMaxSize = +input.dataset.maxFileSize;
             const maxFileSize = parseInt(dataMaxSize, 10);
-            const { allowedFileTypes= [] } = input.dataset;
+            const { allowedFileTypes = [] } = input.dataset;
             const isEmpty = input.files && !input.files.length && dataContainer && !dataContainer.hasAttribute('hidden');
             let result = { isError: false };
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -16,7 +16,7 @@
             const isRequired = input.required || this.fieldContainer.classList.contains('ibexa-field-edit--required');
             const dataMaxSize = +input.dataset.maxFileSize;
             const maxFileSize = parseInt(dataMaxSize, 10);
-            const { allowedFileTypes } = input.dataset;
+            const { allowedFileTypes= [] } = input.dataset;
             const isEmpty = input.files && !input.files.length && dataContainer && !dataContainer.hasAttribute('hidden');
             let result = { isError: false };
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -142,12 +142,12 @@
         });
 
         const inputFileFieldContainer = fieldContainer.querySelector(SELECTOR_INPUT_FILE);
-        const { allowedFileTypes } = inputFileFieldContainer.dataset;
+        const { allowedFileTypes = [] } = inputFileFieldContainer.dataset;
         const previewField = new EzImageFilePreviewField({
             validator,
             fieldContainer,
             fileTypeAccept: inputFileFieldContainer.accept,
-            allowedFileTypes: typeof allowedFileTypes !== 'undefined' ? allowedFileTypes.split(',') : [],
+            allowedFileTypes,
         });
 
         previewField.init();

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -187,16 +187,11 @@
          */
         handleInputChange(event) {
             const [file] = event.currentTarget.files;
-            const { languageCode, allowedFileTypes } = event.currentTarget.dataset;
+            const { languageCode } = event.currentTarget.dataset;
             const isFileSizeLimited = this.maxFileSize > 0;
             const maxFileSizeExceeded = isFileSizeLimited && file.size > this.maxFileSize;
 
             if (maxFileSizeExceeded) {
-                this.resetInputField();
-                return;
-            }
-
-            if (!allowedFileTypes.includes(file.type)) {
                 this.resetInputField();
                 return;
             }
@@ -259,10 +254,13 @@
             ],
         });
 
+        const inputFileFieldContainer = fieldContainer.querySelector(SELECTOR_INPUT_FILE);
+        const { allowedFileTypes = [] } = inputFileFieldContainer.dataset;
         const previewField = new EzImageAssetPreviewField({
             validator,
             fieldContainer,
-            fileTypeAccept: fieldContainer.querySelector(SELECTOR_INPUT_FILE).accept,
+            fileTypeAccept: inputFileFieldContainer.accept,
+            allowedFileTypes,
         });
 
         previewField.init();

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -196,6 +196,11 @@
                 return;
             }
 
+            if (this.allowedFileTypes.length > 0 && !this.allowedFileTypes.includes(file.type)) {
+                this.resetInputField();
+                return;
+            }
+
             this.fieldContainer.querySelector('.ibexa-field-edit__option--remove-media').checked = false;
 
             this.createAsset(file, languageCode);


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-7401

| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
