### PR TITLE
IBX-7029: Fixed invalid content type icon when creating Content with Content On The Fly

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -31,7 +31,7 @@
     {% include '@ibexadesign/ui/edit_header.html.twig' with {
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        icon_name: 'content-type',
+        icon_name: content_type.identifier,
         show_autosave_status: true,
         description: content_type.description,
         context_actions: context_actions,

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -31,7 +31,7 @@
     {% include '@ibexadesign/ui/edit_header.html.twig' with {
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
-        icon_name: 'content-type',
+        icon_name: 'edit',
         content_type_name: content_type.name,
         show_autosave_status: true,
         description: content_type.description,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7029
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Before:

![image](https://github.com/ibexa/admin-ui/assets/211967/f9de704d-5657-40f5-92fb-205369fcf3f4)

After:

![image](https://github.com/ibexa/admin-ui/assets/211967/90a8553d-964b-4183-8664-ec9a802c3859)

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
