### PR TITLE
IBX-6679: Disabled delete action in field definition form when translating content type

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/field_definition.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definition.html.twig
@@ -3,7 +3,7 @@
 
 {% set extra_actions = [] %}
 
-{% if not field_definition.vars.disable_remove|default(false) %}
+{% if not field_definition.vars.disable_remove|default(false) and not is_translation %}
     {% set extra_actions = extra_actions|merge([
         {
             'icon_name': 'discard',
@@ -12,6 +12,7 @@
         }
     ]) %}
 {% endif %}
+
 {%- embed "@ibexadesign/ui/component/collapse.html.twig" with {
     'is_expanded': false,
     'is_draggable': is_draggable ?? true,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6679
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
