### PR TITLE
IBX-7287: Introduced Autosave API

### DIFF
--- a/src/bundle/Resources/config/services/autosave.yaml
+++ b/src/bundle/Resources/config/services/autosave.yaml
@@ -4,6 +4,11 @@ services:
         autowire: true
         public: false
 
+    Ibexa\AdminUi\Autosave\AutosaveService: ~
+
+    Ibexa\Contracts\AdminUi\Autosave\AutosaveServiceInterface:
+        alias: Ibexa\AdminUi\Autosave\AutosaveService
+
     Ibexa\AdminUi\EventListener\ContentProxyCreateDraftListener: ~
 
     Ibexa\AdminUi\Form\Processor\Content\AutosaveProcessor:

--- a/src/contracts/Autosave/AutosaveServiceInterface.php
+++ b/src/contracts/Autosave/AutosaveServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\Autosave;
+
+interface AutosaveServiceInterface
+{
+    public function isEnabled(): bool;
+
+    /**
+     * Returns autosave interval in milliseconds.
+     */
+    public function getInterval(): int;
+
+    public function isInProgress(): bool;
+
+    /**
+     * @internal
+     */
+    public function setInProgress(bool $isInProgress): void;
+}

--- a/src/lib/Autosave/AutosaveService.php
+++ b/src/lib/Autosave/AutosaveService.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Autosave;
+
+use Ibexa\AdminUi\UserSetting\Autosave;
+use Ibexa\AdminUi\UserSetting\AutosaveInterval;
+use Ibexa\Contracts\AdminUi\Autosave\AutosaveServiceInterface;
+use Ibexa\User\UserSetting\UserSettingService;
+
+final class AutosaveService implements AutosaveServiceInterface
+{
+    private UserSettingService $userSettingService;
+
+    private bool $inProgress = false;
+
+    public function __construct(UserSettingService $userSettingService)
+    {
+        $this->userSettingService = $userSettingService;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->userSettingService->getUserSetting(Autosave::IDENTIFIER)->value === Autosave::ENABLED_OPTION;
+    }
+
+    /**
+     * Returns autosave interval in milliseconds.
+     */
+    public function getInterval(): int
+    {
+        return (int)$this->userSettingService->getUserSetting(AutosaveInterval::IDENTIFIER)->value * 1000;
+    }
+
+    public function isInProgress(): bool
+    {
+        return $this->inProgress;
+    }
+
+    public function setInProgress(bool $isInProgress): void
+    {
+        $this->inProgress = $isInProgress;
+    }
+}

--- a/src/lib/EventListener/ContentProxyCreateDraftListener.php
+++ b/src/lib/EventListener/ContentProxyCreateDraftListener.php
@@ -8,41 +8,36 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\EventListener;
 
-use Ibexa\AdminUi\UserSetting\Autosave as AutosaveSetting;
+use Ibexa\Contracts\AdminUi\Autosave\AutosaveServiceInterface;
 use Ibexa\Contracts\AdminUi\Event\ContentProxyCreateEvent;
 use Ibexa\Contracts\AdminUi\Event\ContentProxyTranslateEvent;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
-use Ibexa\User\UserSetting\UserSettingService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\RouterInterface;
 
 class ContentProxyCreateDraftListener implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    private $userSettingService;
+    private AutosaveServiceInterface $autosaveService;
 
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    private $router;
+    private RouterInterface $router;
 
     public function __construct(
         ContentService $contentService,
         LocationService $locationService,
-        UserSettingService $userSettingService,
+        AutosaveServiceInterface $autosaveService,
         RouterInterface $router
     ) {
         $this->contentService = $contentService;
         $this->locationService = $locationService;
-        $this->userSettingService = $userSettingService;
+        $this->autosaveService = $autosaveService;
         $this->router = $router;
     }
 
@@ -56,9 +51,7 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
 
     public function create(ContentProxyCreateEvent $event): void
     {
-        $isAutosaveEnabled = $this->userSettingService->getUserSetting('autosave')->value === AutosaveSetting::ENABLED_OPTION;
-
-        if (!$isAutosaveEnabled) {
+        if (!$this->autosaveService->isEnabled()) {
             return;
         }
 
@@ -103,9 +96,7 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
 
     public function translate(ContentProxyTranslateEvent $event): void
     {
-        $isAutosaveEnabled = $this->userSettingService->getUserSetting('autosave')->value === AutosaveSetting::ENABLED_OPTION;
-
-        if (!$isAutosaveEnabled) {
+        if (!$this->autosaveService->isEnabled()) {
             return;
         }
 

--- a/src/lib/UI/Config/Provider/Autosave.php
+++ b/src/lib/UI/Config/Provider/Autosave.php
@@ -8,29 +8,23 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\UI\Config\Provider;
 
-use Ibexa\AdminUi\UserSetting\Autosave as AutosaveSetting;
+use Ibexa\Contracts\AdminUi\Autosave\AutosaveServiceInterface;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
-use Ibexa\User\UserSetting\UserSettingService;
 
 class Autosave implements ProviderInterface
 {
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    private $userSettingService;
+    private AutosaveServiceInterface $autosaveService;
 
-    public function __construct(
-        UserSettingService $userSettingService
-    ) {
-        $this->userSettingService = $userSettingService;
+    public function __construct(AutosaveServiceInterface $autosaveService)
+    {
+        $this->autosaveService = $autosaveService;
     }
 
     public function getConfig(): array
     {
-        $isEnabled = $this->userSettingService->getUserSetting('autosave')->value === AutosaveSetting::ENABLED_OPTION;
-        $interval = (int)$this->userSettingService->getUserSetting('autosave_interval')->value * 1000;
-
         return [
-            'enabled' => $isEnabled,
-            'interval' => $interval,
+            'enabled' => $this->autosaveService->isEnabled(),
+            'interval' => $this->autosaveService->getInterval(),
         ];
     }
 }

--- a/src/lib/UserSetting/Autosave.php
+++ b/src/lib/UserSetting/Autosave.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Autosave implements ValueDefinitionInterface, FormMapperInterface
 {
+    public const IDENTIFIER = 'autosave';
+
     public const ENABLED_OPTION = 'enabled';
     public const DISABLED_OPTION = 'disabled';
 

--- a/src/lib/UserSetting/AutosaveInterval.php
+++ b/src/lib/UserSetting/AutosaveInterval.php
@@ -18,6 +18,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AutosaveInterval implements ValueDefinitionInterface, FormMapperInterface
 {
+    public const IDENTIFIER = 'autosave_interval';
+
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
 

--- a/tests/lib/Autosave/AutosaveServiceTest.php
+++ b/tests/lib/Autosave/AutosaveServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Autosave;
+
+use Ibexa\AdminUi\Autosave\AutosaveService;
+use Ibexa\AdminUi\UserSetting\Autosave;
+use Ibexa\AdminUi\UserSetting\AutosaveInterval;
+use Ibexa\User\UserSetting\UserSetting;
+use Ibexa\User\UserSetting\UserSettingService;
+use PHPUnit\Framework\TestCase;
+
+final class AutosaveServiceTest extends TestCase
+{
+    /** @var \Ibexa\User\UserSetting\UserSettingService&\PHPUnit\Framework\MockObject\MockObject */
+    private UserSettingService $userSettingService;
+
+    private AutosaveService $autosaveService;
+
+    protected function setUp(): void
+    {
+        $this->userSettingService = $this->createMock(UserSettingService::class);
+        $this->autosaveService = new AutosaveService($this->userSettingService);
+    }
+
+    public function testIsEnabled(): void
+    {
+        $this->userSettingService
+            ->method('getUserSetting')
+            ->with(Autosave::IDENTIFIER)
+            ->willReturn($this->createUserSettingWithValue(Autosave::ENABLED_OPTION));
+
+        self::assertTrue($this->autosaveService->isEnabled());
+    }
+
+    public function testGetInterval(): void
+    {
+        $this->userSettingService
+            ->method('getUserSetting')
+            ->with(AutosaveInterval::IDENTIFIER)
+            ->willReturn($this->createUserSettingWithValue('30'));
+
+        self::assertEquals(30000, $this->autosaveService->getInterval());
+    }
+
+    public function testIsInProgress(): void
+    {
+        self::assertFalse($this->autosaveService->isInProgress());
+        $this->autosaveService->setInProgress(true);
+        self::assertTrue($this->autosaveService->isInProgress());
+    }
+
+    private function createUserSettingWithValue(string $value): UserSetting
+    {
+        return new UserSetting([
+            'value' => $value,
+        ]);
+    }
+}

--- a/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
+++ b/tests/lib/EventListener/ContentProxyCreateDraftListenerTest.php
@@ -10,7 +10,7 @@ namespace Ibexa\Tests\AdminUi\EventListener;
 
 use Ibexa\AdminUi\Event\Options;
 use Ibexa\AdminUi\EventListener\ContentProxyCreateDraftListener;
-use Ibexa\AdminUi\UserSetting\Autosave;
+use Ibexa\Contracts\AdminUi\Autosave\AutosaveServiceInterface;
 use Ibexa\Contracts\AdminUi\Event\ContentProxyCreateEvent;
 use Ibexa\Contracts\AdminUi\Event\ContentProxyTranslateEvent;
 use Ibexa\Contracts\Core\FieldType\Value;
@@ -22,8 +22,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinitionCollection;
-use Ibexa\User\UserSetting\UserSetting;
-use Ibexa\User\UserSetting\UserSettingService;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -33,15 +31,8 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
 {
     public function testCreateContentAutosaveEnabled(): void
     {
-        $userSettingService = $this->createMock(UserSettingService::class);
-        $userSettingService
-            ->method('getUserSetting')
-            ->with('autosave')
-            ->willReturn(
-                new UserSetting([
-                    'value' => Autosave::ENABLED_OPTION,
-                ])
-            );
+        $autosaveService = $this->createMock(AutosaveServiceInterface::class);
+        $autosaveService->method('isEnabled')->willReturn(true);
 
         $contentService = $this->createMock(ContentService::class);
         $contentService
@@ -69,7 +60,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             new ContentProxyCreateDraftListener(
                 $contentService,
                 $this->createMock(LocationService::class),
-                $userSettingService,
+                $autosaveService,
                 $router
             )
         );
@@ -85,15 +76,8 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
 
     public function testCreateContentOnTheFlyAutosaveEnabled(): void
     {
-        $userSettingService = $this->createMock(UserSettingService::class);
-        $userSettingService
-            ->method('getUserSetting')
-            ->with('autosave')
-            ->willReturn(
-                new UserSetting([
-                    'value' => Autosave::ENABLED_OPTION,
-                ])
-            );
+        $autosaveService = $this->createMock(AutosaveServiceInterface::class);
+        $autosaveService->method('isEnabled')->willReturn(true);
 
         $contentInfo = $this->createMock(ContentInfo::class);
 
@@ -138,7 +122,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             new ContentProxyCreateDraftListener(
                 $contentService,
                 $this->createMock(LocationService::class),
-                $userSettingService,
+                $autosaveService,
                 $router
             )
         );
@@ -154,15 +138,8 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
 
     public function testTranslateContentAutosaveEnabled(): void
     {
-        $userSettingService = $this->createMock(UserSettingService::class);
-        $userSettingService
-            ->method('getUserSetting')
-            ->with('autosave')
-            ->willReturn(
-                new UserSetting([
-                    'value' => Autosave::ENABLED_OPTION,
-                ])
-            );
+        $autosaveService = $this->createMock(AutosaveServiceInterface::class);
+        $autosaveService->method('isEnabled')->willReturn(true);
 
         $contentType = $this->getContentType([
             $this->getFieldDefinition('field_a', true),
@@ -222,7 +199,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             new ContentProxyCreateDraftListener(
                 $contentService,
                 $this->createMock(LocationService::class),
-                $userSettingService,
+                $autosaveService,
                 $router
             )
         );
@@ -234,15 +211,8 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
 
     public function testAutosaveDisabled(): void
     {
-        $userSettingService = $this->createMock(UserSettingService::class);
-        $userSettingService
-            ->method('getUserSetting')
-            ->with('autosave')
-            ->willReturn(
-                new UserSetting([
-                    'value' => Autosave::DISABLED_OPTION,
-                ])
-            );
+        $autosaveService = $this->createMock(AutosaveServiceInterface::class);
+        $autosaveService->method('isEnabled')->willReturn(true);
 
         $contentService = $this->createMock(ContentService::class);
         $contentService
@@ -275,7 +245,7 @@ final class ContentProxyCreateDraftListenerTest extends TestCase
             new ContentProxyCreateDraftListener(
                 $contentService,
                 $this->createMock(LocationService::class),
-                $userSettingService,
+                $autosaveService,
                 $this->createMock(RouterInterface::class)
             )
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7287?filter=18027
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Introduced Autosave API which unifiers access to autosave settings and status:

```php
interface AutosaveServiceInterface
{
    public function isEnabled(): bool;

    /**
     * Returns autosave interval in milliseconds.
     */
    public function getInterval(): int;

    public function isInProgress(): bool;

    /**
     * @internal
     */
    public function setInProgress(bool $isInProgress): void;
}
``` 

Required for XXX

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
