### PR TITLE
IBX-6262: Added extension point to allow rendering additional fields in content translation form

### DIFF
--- a/src/bundle/Resources/public/scss/_add-translation.scss
+++ b/src/bundle/Resources/public/scss/_add-translation.scss
@@ -5,6 +5,7 @@
 
     .modal-body {
         display: flex;
+        flex-wrap: wrap;
         padding-bottom: calculateRem(140px);
 
         .ibexa-label {

--- a/src/bundle/Resources/views/themes/admin/content/modal/add_translation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/modal/add_translation.html.twig
@@ -28,6 +28,8 @@
                 'class': 'ibexa-translation__language-wrapper ibexa-translation__language-wrapper--language'
             },
         }) }}
+
+        {{ ibexa_render_component_group('form-content-add-translation-body', { form }) }}
     {% endblock %}
     {% block footer_content %}
         {{ form_widget(form.add, {'attr': {'class': 'btn ibexa-btn ibexa-btn--primary ibexa-btn--create-translation'}}) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6262
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Added `form-content-add-translation-body component` group and adjusted CSS 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
