### PR TITLE
[Behat] Adapted tests after redirect change

### DIFF
--- a/features/personas/ChangePassword.feature
+++ b/features/personas/ChangePassword.feature
@@ -10,7 +10,7 @@ Feature: Verify that an User allowed to change password can change his password
     And I change password from "Passw0rd-42" to "Passw0rd-43"
     And I perform the "Update" action
     Then success notification that "Your password has been successfully changed." appears
-    And I should be on Dashboard page
+    And I should be on "User settings" page
 
   Scenario: I can log in with new password
     Given I open Login page in admin SiteAccess

--- a/src/lib/Behat/Page/UserSettingsPage.php
+++ b/src/lib/Behat/Page/UserSettingsPage.php
@@ -34,7 +34,6 @@ class UserSettingsPage extends Page
 
     public function verifyIsLoaded(): void
     {
-        $this->contentActionsMenu->verifyIsLoaded();
         $this->getHTMLPage()->find($this->getLocator('title'))->assert()->textEquals('User settings');
     }
 
@@ -55,7 +54,7 @@ class UserSettingsPage extends Page
     {
         return [
             new VisibleCSSLocator('button', '.ibexa-btn'),
-            new VisibleCSSLocator('title', '.ibexa-edit-header__title'),
+            new VisibleCSSLocator('title', '.ibexa-edit-header__title,.ibexa-page-title__content'),
             new VisibleCSSLocator('autosaveDraftValueDropdown', '#user_setting_update_autosave div.ibexa-dropdown__wrapper > ul'),
             new VisibleCSSLocator('autosaveIntervalEdit', '#user_setting_update_autosave_interval_value'),
         ];


### PR DESCRIPTION
Adapting tests to the changes from https://github.com/ibexa/user/pull/66

The User Settings page covers two use cases right now: viewing user settings and editing them

The `verifyIsLoaded` method was written only for the editing use case, I had to adapt it so that it makes sense in the view mode as well.