### PR TITLE
Fixed issue with a menu when a dashboard is created

### DIFF
--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -84,6 +84,10 @@ class ContentCreateType extends AbstractType
             $restrictedLanguageCodes = $limitationsValues[Limitation::LANGUAGE];
         }
 
+        $choiceLoader = $this->contentCreateContentTypeChoiceLoader
+            ->setTargetLocation($location)
+            ->setRestrictedContentTypeIds($restrictedContentTypesIds);
+
         $builder
             ->add(
                 'content_type',
@@ -92,9 +96,7 @@ class ContentCreateType extends AbstractType
                     'label' => false,
                     'multiple' => false,
                     'expanded' => true,
-                    'choice_loader' => $this->contentCreateContentTypeChoiceLoader
-                        ->setTargetLocation($location)
-                        ->setRestrictedContentTypeIds($restrictedContentTypesIds),
+                    'choice_loader' => $choiceLoader,
                 ]
             )
             ->add(
@@ -123,14 +125,13 @@ class ContentCreateType extends AbstractType
 
         $builder->addEventListener(
             FormEvents::PRE_SUBMIT,
-            function (PreSubmitEvent $event): void {
+            function (PreSubmitEvent $event) use ($choiceLoader): void {
                 $location = $this->locationService->loadLocation(
                     (int)$event->getData()['parent_location']
                 );
                 $form = $event->getForm();
                 $opts = $form->get('content_type')->getConfig()->getOptions();
-                $opts['choice_loader'] = $this->contentCreateContentTypeChoiceLoader
-                    ->setTargetLocation($location);
+                $opts['choice_loader'] = $choiceLoader->setTargetLocation($location);
                 $form->remove('content_type');
                 $form->add('content_type', ContentTypeChoiceType::class, $opts);
             }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When the form is sent `$data` is set to `null` https://github.com/ibexa/admin-ui/blob/main/src/bundle/Controller/ContentController.php#L140:
and the target location is not set
https://github.com/ibexa/admin-ui/blob/main/src/lib/Form/Type/Content/Draft/ContentCreateType.php#L80

This issue was spotted when a list of available content types was modified (dashboard content type)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
