### PR TITLE
IBX-7124: Aligned confirmation/discard action labels in User settings with design

### DIFF
--- a/features/personas/ChangePassword.feature
+++ b/features/personas/ChangePassword.feature
@@ -8,7 +8,7 @@ Feature: Verify that an User allowed to change password can change his password
     And I switch to "Account settings" tab in User settings
     And I click on the change password button
     And I change password from "Passw0rd-42" to "Passw0rd-43"
-    And I perform the "Update" action
+    And I perform the "Save and close" action
     Then success notification that "Your password has been successfully changed." appears
     And I should be on "User settings" page
 

--- a/features/standard/Autosave.feature
+++ b/features/standard/Autosave.feature
@@ -38,7 +38,7 @@ Feature: Content Items creation
     And I'm on Content view Page for root
     And I go to user settings
     And I disable autosave
-    And I perform the "Save" action
+    And I perform the "Save and close" action
     And I'm on Content view Page for root
     When I start creating a new content "Article"
     And I set content fields

--- a/src/bundle/Resources/translations/ibexa_menu.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_menu.en.xliff
@@ -567,14 +567,24 @@
         <note>key: user_edit__sidebar_right__update</note>
       </trans-unit>
       <trans-unit id="d79a55ddd58ecf56b4edb39c794c858d649481e2" resname="user_password_change__sidebar_right__cancel">
-        <source>Discard changes</source>
-        <target state="new">Discard changes</target>
+        <source>Discard</source>
+        <target state="new">Discard</target>
         <note>key: user_password_change__sidebar_right__cancel</note>
       </trans-unit>
       <trans-unit id="ab8629add84cbd9cebfdf326f7242044ae7650af" resname="user_password_change__sidebar_right__update">
-        <source>Update</source>
-        <target state="new">Update</target>
+        <source>Save and close</source>
+        <target state="new">Save and close</target>
         <note>key: user_password_change__sidebar_right__update</note>
+      </trans-unit>
+      <trans-unit id="bbcc94ae51bb5c4c0a3222b554e32140bc542266" resname="user_setting_edit__sidebar_right__cancel">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note>key: user_setting_edit__sidebar_right__cancel</note>
+      </trans-unit>
+      <trans-unit id="89bff903c56f538cb7ee5da8ac57a8eb8229707a" resname="user_setting_edit__sidebar_right__save">
+        <source>Save and close</source>
+        <target state="new">Save and close</target>
+        <note>key: user_setting_edit__sidebar_right__save</note>
       </trans-unit>
     </body>
   </file>

--- a/src/lib/EventListener/UserPasswordChangeRightSidebarListener.php
+++ b/src/lib/EventListener/UserPasswordChangeRightSidebarListener.php
@@ -68,8 +68,8 @@ class UserPasswordChangeRightSidebarListener implements EventSubscriberInterface
     public static function getTranslationMessages(): array
     {
         return [
-            (new Message(self::ITEM__UPDATE, 'ibexa_menu'))->setDesc('Update'),
-            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard changes'),
+            (new Message(self::ITEM__UPDATE, 'ibexa_menu'))->setDesc('Save and close'),
+            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard'),
         ];
     }
 }

--- a/src/lib/Menu/UserPasswordChangeRightSidebarBuilder.php
+++ b/src/lib/Menu/UserPasswordChangeRightSidebarBuilder.php
@@ -90,8 +90,8 @@ class UserPasswordChangeRightSidebarBuilder extends AbstractBuilder implements T
     public static function getTranslationMessages(): array
     {
         return [
-            (new Message(self::ITEM__UPDATE, 'ibexa_menu'))->setDesc('Update'),
-            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard changes'),
+            (new Message(self::ITEM__UPDATE, 'ibexa_menu'))->setDesc('Save and close'),
+            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard'),
         ];
     }
 }

--- a/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
+++ b/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
@@ -25,8 +25,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
 {
     /* Menu items */
-    public const ITEM__SAVE = 'object_state_edit__sidebar_right__save';
-    public const ITEM__CANCEL = 'object_state_edit__sidebar_right__cancel';
+    public const ITEM__SAVE = 'user_setting_edit__sidebar_right__save';
+    public const ITEM__CANCEL = 'user_setting_edit__sidebar_right__cancel';
 
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
@@ -88,8 +88,8 @@ class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements Tr
     public static function getTranslationMessages(): array
     {
         return [
-            (new Message(self::ITEM__SAVE, 'ibexa_menu'))->setDesc('Save'),
-            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard changes'),
+            (new Message(self::ITEM__SAVE, 'ibexa_menu'))->setDesc('Save and close'),
+            (new Message(self::ITEM__CANCEL, 'ibexa_menu'))->setDesc('Discard'),
         ];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-7124
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![image](https://github.com/ibexa/admin-ui/assets/211967/c378fd56-a0c8-4da8-b3d7-1ce238e8d282)

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
