### PR TITLE
IBX-7290: Add abort controller to useSearchByQueryFetch

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useSearchByQueryFetch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useSearchByQueryFetch.js
@@ -78,7 +78,7 @@ export const useSearchByQueryFetch = () => {
             }
 
             dispatch({ type: SEARCH_START });
-            findLocationsBySearchQuery({ ...restInfo, query, aggregations, filters, limit, offset, languageCode }, handleFetch);
+            return findLocationsBySearchQuery({ ...restInfo, query, aggregations, filters, limit, offset, languageCode }, handleFetch);
         },
         [restInfo, dispatch],
     );

--- a/src/bundle/ui-dev/src/modules/universal-discovery/services/universal.discovery.service.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/services/universal.discovery.service.js
@@ -205,6 +205,7 @@ export const findLocationsBySearchQuery = (
             },
         },
     });
+    const abortController = new AbortController();
     const request = new Request(`${instanceUrl}${ENDPOINT_CREATE_VIEW}`, {
         method: 'POST',
         headers: getRequestHeaders({
@@ -216,6 +217,7 @@ export const findLocationsBySearchQuery = (
         body,
         mode: getRequestMode({ instanceUrl }),
         credentials: 'same-origin',
+        signal: abortController.signal,
     });
 
     fetch(request)
@@ -231,6 +233,10 @@ export const findLocationsBySearchQuery = (
             });
         })
         .catch(showErrorNotificationAbortWrapper);
+
+    return {
+        abortController,
+    };
 };
 
 export const findLocationsById = (


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       |https://issues.ibexa.co/browse/IBX-7290|
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
