### PR TITLE
IBX-7482: Misaligned dropdown when creating new translation fixed

### DIFF
--- a/src/bundle/Resources/public/scss/_add-translation.scss
+++ b/src/bundle/Resources/public/scss/_add-translation.scss
@@ -8,6 +8,7 @@
         flex-wrap: wrap;
         padding-bottom: calculateRem(140px);
 
+        .form-group:first-of-type .ibexa-label,
         .ibexa-label {
             margin-top: 0;
         }


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7482](https://issues.ibexa.co/browse/IBX-7482) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Misaligned dropdown when creating new translation fixed

Issue occured after https://github.com/ibexa/product-catalog/pull/1063/files changes.
It allso applied to translation modal.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
