### PR TITLE
IBX-7492: Fixed error when editing image in user profile

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -45,12 +45,18 @@
                         </svg>
                         <span class="ibexa-btn__label">{{ 'content.field_type.ezimage.preview'|trans|desc('Preview') }}</span>
                     </a>
+
+                    {% if version_info is defined %}
+                        {% set content_id = version_info.contentInfo.id %}
+                        {% set version_no = version_info.versionNo %}
+                    {% endif %}
+
                     {{ ibexa_render_component_group(
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId'),
-                            'versionNo' : app.request.get('versionNo'),
+                            'contentId' : content_id|default(app.request.get('contentId')),
+                            'versionNo' : version_no|default(app.request.get('versionNo')),
                             'disabled': readonly ? true : false,
                         }
                     ) }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -135,12 +135,18 @@
                         </svg>
                         <span class="ibexa-btn__label">{{ 'content.field_type.ezimage.preview'|trans|desc('Preview') }}</span>
                     </a>
+
+                    {% if version_info is defined %}
+                        {% set content_id = version_info.contentInfo.id %}
+                        {% set version_no = version_info.versionNo %}
+                    {% endif %}
+
                     {{ ibexa_render_component_group(
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId'),
-                            'versionNo' : app.request.get('versionNo'),
+                            'contentId' : content_id|default(app.request.get('contentId')),
+                            'versionNo' : version_no|default(app.request.get('versionNo')),
                             'disabled': readonly ? true : false,
                         }
                     ) }}


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7492](https://issues.ibexa.co/browse/IBX-7492)   |
| **Depends on**       |                                                       |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Currently ezimage and ezimageasset editing forms view depends on `contentId` and `versionNo` route params, which are not available in user profile edit view. 

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
