### PR TITLE
IBX-7448: Fixed siteaccess dropdown values

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
@@ -23,14 +23,14 @@
         </div>
         <div class="ibexa-preview-header__item ibexa-preview-header__item--siteaccess">
             {% set value = '' %}
-            {% set choices = siteaccesses|map((site_accesses_name, site_access_label) => {
+            {% set choices = siteaccesses|map((site_access_label, site_access_name) => {
                 value: path(
                     'ibexa.version.preview',
                     {
                         'contentId': content.id,
                         'versionNo': version_no,
                         'language': language_code,
-                        'siteAccessName': site_accesses_name
+                        'siteAccessName': site_access_name
                     }
                 ),
                 label: site_access_label|trans({}, 'ezplatform_siteaccess')


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7448](https://issues.ibexa.co/browse/IBX-7448) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.5`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

`map` takes parameters in other order, it was changed from `for` loop during redesign so it is fine for 3.3.
(for 4.6, I had created https://github.com/ibexa/admin-ui/pull/1075 as a fix for other bug tho.)
It was working fine for most of the cases as usually siteaccess identifier is equal to siteaccess name.


QA:
This does not solve the issue with preview for `corporate` site access as this is completely different story - https://issues.ibexa.co/browse/IBX-7536

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
