### PR TITLE
IBX-4675: Improved autogenerate field definition name

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -386,6 +386,11 @@ parameters:
 			path: src/bundle/Controller/ContentViewController.php
 
 		-
+			message: "#^Parameter \\#1 \\$fieldTypeIdentifier of method Ibexa\\\\Bundle\\\\AdminUi\\\\Controller\\\\FieldDefinitionController\\:\\:getFieldTypeLabel\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/bundle/Controller/FieldDefinitionController.php
+
+		-
 			message: "#^Parameter \\#2 \\$fieldDefinition of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentTypeService\\:\\:updateFieldDefinition\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\|null given\\.$#"
 			count: 1
 			path: src/bundle/Controller/FieldDefinitionController.php

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.edit.js
@@ -459,7 +459,9 @@
             const targetContainerGroup = targetContainer.closest('.ibexa-collapse--field-definitions-group');
             const targetContainerList = targetContainerGroup.closest('.ibexa-content-type-edit__field-definitions-group-list');
             const fieldTemplate = targetContainerList.dataset.template;
-            const fieldRendered = fieldTemplate.replace('{{ type }}', currentDraggedItem.dataset.itemIdentifier);
+            const fieldRendered = fieldTemplate
+                .replace('{{ name }}', currentDraggedItem.dataset.itemName.toLowerCase())
+                .replace('{{ type }}', currentDraggedItem.dataset.itemIdentifier);
             let draggedItemPosition = [...dragContainerItems].findIndex((item, index, array) => {
                 return item.classList.contains('ibexa-field-definitions-placeholder') && index < array.length - 1;
             });

--- a/src/bundle/Resources/translations/ibexa_content_type.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_type.en.xliff
@@ -322,8 +322,8 @@
         <note>key: content_type.view.edit.content_field_definitions</note>
       </trans-unit>
       <trans-unit id="74aead78c735bbbce032dc9b00f9ca7a3632f166" resname="content_type.view.edit.default_header">
-        <source>New field type</source>
-        <target state="new">New field type</target>
+        <source>New {{ name }} ({{ type }})</source>
+        <target state="new">New {{ name }} ({{ type }})</target>
         <note>key: content_type.view.edit.default_header</note>
       </trans-unit>
       <trans-unit id="a32a5e3d2d67da43b4c5f0f5574c90520868b36a" resname="content_type.view.edit.global_properties">

--- a/src/bundle/Resources/views/themes/admin/content_type/available_field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/available_field_types.html.twig
@@ -18,6 +18,7 @@
         {% for item in field_type_toolbar %}
             <li
                 class="ibexa-available-field-type {{ is_draggable is defined and is_draggable == false ? 'ibexa-available-field-type--immovable' }}"
+                data-item-name="{{ item.name }}"
                 data-item-identifier="{{ item.identifier }}"
             >
                 <div

--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -16,7 +16,7 @@
             'is_draggable': true,
             'class': 'ibexa-collapse--field-definition ibexa-collapse--field-definition-highlight ibexa-collapse--field-definition-loading',
             'body_id': 'loading-collapse',
-            'header_label': 'content_type.view.edit.default_header'|trans|desc('New field type') ~ ' ({{ type }})',
+            'header_label': 'content_type.view.edit.default_header'|trans|desc('New {{ name }} ({{ type }})'),
             'data_attr': {
                 'data-field-definition-identifier': 'loading-collapse',
             },


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-4675](https://issues.ibexa.co/browse/IBX-4675) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Change pattern of autogenerated field definition name from "New field type (%type%)" to "New %name% (%type%)" e.g. "New text line (ezstring)"


#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
