### PR TITLE
IBX-7563: Redirect only if user profile is enabled

### DIFF
--- a/src/lib/EventListener/UserProfileListener.php
+++ b/src/lib/EventListener/UserProfileListener.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\EventListener;
 
+use Ibexa\AdminUi\Specification\UserProfile\IsProfileAvailable;
+use Ibexa\AdminUi\UserProfile\UserProfileConfigurationInterface;
 use Ibexa\ContentForms\Data\User\UserUpdateData;
 use Ibexa\ContentForms\Event\ContentFormEvents;
 use Ibexa\ContentForms\Event\FormActionEvent;
@@ -34,18 +36,22 @@ final class UserProfileListener implements EventSubscriberInterface
 
     private UserService $userService;
 
+    private UserProfileConfigurationInterface $configuration;
+
     public function __construct(
         Repository $repository,
         PermissionResolver $permissionResolver,
         ContentService $contentService,
         UserService $userService,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        UserProfileConfigurationInterface $configuration
     ) {
         $this->repository = $repository;
         $this->permissionResolver = $permissionResolver;
         $this->contentService = $contentService;
         $this->userService = $userService;
         $this->urlGenerator = $urlGenerator;
+        $this->configuration = $configuration;
     }
 
     public static function getSubscribedEvents(): array
@@ -140,6 +146,8 @@ final class UserProfileListener implements EventSubscriberInterface
 
     private function canEditUserProfile(User $user): bool
     {
-        return $this->permissionResolver->canUser('user', 'selfedit', $user);
+        return
+            $this->permissionResolver->canUser('user', 'selfedit', $user)
+            && (new IsProfileAvailable($this->configuration))->isSatisfiedBy($user);
     }
 }


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7563](https://issues.ibexa.co/browse/IBX-7563) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

With   
```
user_profile:
    enabled: true 
```
or  currently user content type not being in enabled user profile content types, when self editing user, after saving you are unsuccessfully redirected to profile view even when it is not available.
This checks if user profile is enabled for self user, and if not skips logic (more crucially, skips redirect) in listener.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
