### PR TITLE
IBX-7595: Removed :focus styles for ibexa-header-user-menu

### DIFF
--- a/src/bundle/Resources/public/scss/_header-user-menu.scss
+++ b/src/bundle/Resources/public/scss/_header-user-menu.scss
@@ -55,11 +55,6 @@
             right: calculateRem(10px);
         }
 
-        &:focus {
-            border-color: $ibexa-color-white;
-            box-shadow: 0 0 0 calculateRem(4px) rgba($ibexa-color-white, 0.2);
-        }
-
         &:hover {
             &::before,
             &::after {


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7595](https://issues.ibexa.co/browse/IBX-7595) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Removed styles for `:focus` state for `.ibexa-header-user-menu`

![Screenshot from 2024-01-23 15-14-58](https://github.com/ibexa/admin-ui/assets/24355391/9557d17a-f191-462a-bbd5-2fbbbbbd33c4)

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
