### PR TITLE
IBX-7656: Changed quick action to work with fragment

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -57,10 +57,9 @@
         }
     };
     const initExtraActionsWidget = (dataset) => {
-        const url = new URL(window.location.href);
-        const actionsParams = url.searchParams.getAll('actions');
+        const hashes = window.location.hash.split('#');
 
-        if (actionsParams.includes(dataset.actions)) {
+        if (hashes.includes(dataset.actions)) {
             toggleExtraActionsWidget(dataset);
         }
     };


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7656](https://issues.ibexa.co/browse/IBX-7656) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Quick action now will work with `hashes` instead of query parameters. Used by https://github.com/ibexa/dashboard/pull/100

#### Checklist:
- [ ] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
