### PR TITLE
IBX-6815: [REST] Fixed isBookmarked property in load-subtree response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 .DS_Store
 .phpunit.result.cache
 composer.lock
+/var

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "symfony/options-resolver": "^5.0",
         "symfony/asset": "^5.0",
         "symfony/yaml": "^5.0",
+        "symfony/webpack-encore-bundle": "^v1.17",
         "jms/translation-bundle": "^1.5",
         "ibexa/core": "~4.5.0@dev",
         "ibexa/content-forms": "~4.5.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,8 @@
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Bundle\\AdminUi\\": "tests/bundle/",
-            "Ibexa\\Tests\\AdminUi\\": "tests/lib/",
-            "EzSystems\\EzPlatformAdminUi\\Tests\\": "tests/lib/",
-            "Ibexa\\Platform\\Tests\\Assets\\": "tests/lib/"
+            "Ibexa\\Tests\\Integration\\AdminUi\\": "tests/integration/",
+            "Ibexa\\Tests\\AdminUi\\": "tests/lib/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,8 @@
         "ibexa/doctrine-schema": "~4.5.0@dev",
         "ibexa/http-cache": "~4.5.0@dev",
         "ibexa/code-style": "^1.0",
+        "ibexa/test-rest": "^0.1.x-dev",
+        "ibexa/test-core": "^0.1.x-dev",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,12 @@
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
         "check-cs": "@fix-cs --dry-run",
         "phpstan": "phpstan analyse",
-        "test": "phpunit -c phpunit.xml"
+        "test-unit": "phpunit -c phpunit.xml",
+        "test-integration": "phpunit -c phpunit.integration.xml",
+        "test": [
+            "@test-unit",
+            "@test-integration"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3701,16 +3701,6 @@ parameters:
 			path: src/lib/Event/Options.php
 
 		-
-			message: "#^Call to method getEntrypointLookup\\(\\) on an unknown class Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\EntrypointLookupCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
-			message: "#^Call to method reset\\(\\) on an unknown class Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\TagRenderer\\.$#"
-			count: 1
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
 			message: "#^Cannot call method log\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
 			count: 1
 			path: src/lib/EventListener/AdminExceptionListener.php
@@ -3727,26 +3717,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$kernelRootDir$#"
-			count: 1
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
-			message: "#^Parameter \\$encoreTagRenderer of method Ibexa\\\\AdminUi\\\\EventListener\\\\AdminExceptionListener\\:\\:__construct\\(\\) has invalid type Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\TagRenderer\\.$#"
-			count: 2
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
-			message: "#^Parameter \\$entrypointLookupCollection of method Ibexa\\\\AdminUi\\\\EventListener\\\\AdminExceptionListener\\:\\:__construct\\(\\) has invalid type Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\EntrypointLookupCollectionInterface\\.$#"
-			count: 2
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
-			message: "#^Property Ibexa\\\\AdminUi\\\\EventListener\\\\AdminExceptionListener\\:\\:\\$encoreTagRenderer has unknown class Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\TagRenderer as its type\\.$#"
-			count: 1
-			path: src/lib/EventListener/AdminExceptionListener.php
-
-		-
-			message: "#^Property Ibexa\\\\AdminUi\\\\EventListener\\\\AdminExceptionListener\\:\\:\\$entrypointLookupCollection has unknown class Symfony\\\\WebpackEncoreBundle\\\\Asset\\\\EntrypointLookupCollectionInterface as its type\\.$#"
 			count: 1
 			path: src/lib/EventListener/AdminExceptionListener.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9921,11 +9921,6 @@ parameters:
 			path: src/lib/UI/Module/ContentTree/NodeFactory.php
 
 		-
-			message: "#^Property Ibexa\\\\AdminUi\\\\UI\\\\Module\\\\ContentTree\\\\NodeFactory\\:\\:\\$bookmarkService is never read, only written\\.$#"
-			count: 1
-			path: src/lib/UI/Module/ContentTree/NodeFactory.php
-
-		-
 			message: "#^Generator expects value type Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\FieldType, Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\FieldType given\\.$#"
 			count: 1
 			path: src/lib/UI/Module/FieldTypeToolbar/FieldTypeToolbarFactory.php

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,0 +1,18 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="tests/integration/bootstrap.php"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnWarning="true"
+         verbose="true">
+    <php>
+        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\AdminUi\AdminUiIbexaTestKernel" />
+        <env name="SEARCH_ENGINE" value="legacy" />
+        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db" />
+    </php>
+    <testsuites>
+        <testsuite name="integration">
+            <directory>tests/integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -95,6 +95,10 @@ final class NodeFactory
     ): Node {
         $uninitializedContentInfoList = [];
         $containerLocations = [];
+
+        $userBookmarks = $this->bookmarkService->loadBookmarks(0, -1);
+        $bookmarkedLocations = array_flip(array_column($userBookmarks->items, 'id'));
+
         $node = $this->buildNode(
             $location,
             $uninitializedContentInfoList,
@@ -103,7 +107,8 @@ final class NodeFactory
             $loadChildren,
             $depth,
             $sortClause,
-            $sortOrder
+            $sortOrder,
+            $bookmarkedLocations
         );
         $versionInfoById = $this->contentService->loadVersionInfoListByContentInfo($uninitializedContentInfoList);
 

--- a/tests/integration/AdminUiIbexaTestKernel.php
+++ b/tests/integration/AdminUiIbexaTestKernel.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\AdminUi;
+
+use Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle;
+use Ibexa\Bundle\AdminUi\IbexaAdminUiBundle;
+use Ibexa\Bundle\ContentForms\IbexaContentFormsBundle;
+use Ibexa\Bundle\DesignEngine\IbexaDesignEngineBundle;
+use Ibexa\Bundle\Rest\IbexaRestBundle;
+use Ibexa\Bundle\Search\IbexaSearchBundle;
+use Ibexa\Bundle\Test\Rest\IbexaTestRestBundle;
+use Ibexa\Bundle\User\IbexaUserBundle;
+use Ibexa\Contracts\Test\Core\IbexaTestKernel;
+use Ibexa\Rest\Server\Controller\JWT;
+use Knp\Bundle\MenuBundle\KnpMenuBundle;
+use Swift_Mailer;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @internal
+ */
+final class AdminUiIbexaTestKernel extends IbexaTestKernel
+{
+    public function registerBundles(): iterable
+    {
+        yield from parent::registerBundles();
+
+        yield new HautelookTemplatedUriBundle();
+        yield new KnpMenuBundle();
+        yield new WebpackEncoreBundle();
+
+        yield new IbexaContentFormsBundle();
+        yield new IbexaDesignEngineBundle();
+        yield new IbexaRestBundle();
+        yield new IbexaSearchBundle();
+        yield new IbexaTestRestBundle();
+        yield new IbexaUserBundle();
+
+        yield new IbexaAdminUiBundle();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        parent::registerContainerConfiguration($loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            self::configureIbexaBundles($container);
+            self::configureThirdPartyBundles($container);
+        });
+    }
+
+    private static function configureIbexaBundles(ContainerBuilder $container): void
+    {
+        // REST
+        $resource = new FileResource(__DIR__ . '/Resources/routing.yaml');
+        $container->addResource($resource);
+        $container->loadFromExtension('framework', [
+            'router' => [
+                'resource' => $resource->getResource(),
+            ],
+        ]);
+        self::addSyntheticService($container, JWT::class);
+
+        $configFileName = __DIR__ . '/Resources/ibexa_test_config.yaml';
+        $resource = new FileResource($configFileName);
+        $container->addResource($resource);
+
+        $extensionConfig = Yaml::parseFile($resource->getResource());
+        foreach ($extensionConfig as $extensionName => $config) {
+            $container->loadFromExtension($extensionName, $config);
+        }
+    }
+
+    private static function configureThirdPartyBundles(ContainerBuilder $container): void
+    {
+        $container->loadFromExtension('webpack_encore', [
+            'output_path' => dirname(__DIR__, 2) . '/var/encore/output',
+        ]);
+
+        self::addSyntheticService($container, Swift_Mailer::class);
+
+        // bazinga's locale_fallback
+        $container->setParameter('locale_fallback', 'en');
+
+        // Symfony
+        $container->setParameter('form.type_extension.csrf.enabled', false);
+    }
+}

--- a/tests/integration/AdminUiIbexaTestKernel.php
+++ b/tests/integration/AdminUiIbexaTestKernel.php
@@ -16,6 +16,7 @@ use Ibexa\Bundle\Rest\IbexaRestBundle;
 use Ibexa\Bundle\Search\IbexaSearchBundle;
 use Ibexa\Bundle\Test\Rest\IbexaTestRestBundle;
 use Ibexa\Bundle\User\IbexaUserBundle;
+use Ibexa\Contracts\Core\Repository\BookmarkService;
 use Ibexa\Contracts\Test\Core\IbexaTestKernel;
 use Ibexa\Rest\Server\Controller\JWT;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
@@ -47,6 +48,13 @@ final class AdminUiIbexaTestKernel extends IbexaTestKernel
         yield new IbexaUserBundle();
 
         yield new IbexaAdminUiBundle();
+    }
+
+    protected static function getExposedServicesByClass(): iterable
+    {
+        yield from parent::getExposedServicesByClass();
+
+        yield BookmarkService::class;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void

--- a/tests/integration/REST/BaseAdminUiRestWebTestCase.php
+++ b/tests/integration/REST/BaseAdminUiRestWebTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\AdminUi\REST;
+
+use Ibexa\Contracts\Test\Rest\BaseRestWebTestCase;
+
+/**
+ * Requires \Ibexa\Tests\Integration\AdminUi\AdminUiIbexaTestKernel kernel.
+ *
+ * @see \Ibexa\Tests\Integration\AdminUi\AdminUiIbexaTestKernel
+ */
+abstract class BaseAdminUiRestWebTestCase extends BaseRestWebTestCase
+{
+    protected function getSchemaFileBasePath(string $resourceType, string $format): string
+    {
+        return dirname(__DIR__) . '/Resources/REST/Schemas/' . $resourceType;
+    }
+
+    protected static function getSnapshotDirectory(): ?string
+    {
+        return dirname(__DIR__) . '/Resources/REST/Snapshots';
+    }
+}

--- a/tests/integration/REST/PostPostLoadSubtreeTest.php
+++ b/tests/integration/REST/PostPostLoadSubtreeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\AdminUi\REST;
+
+use Ibexa\Contracts\Core\Repository\BookmarkService;
+use Ibexa\Contracts\Test\Rest\Input\PayloadLoader;
+use Ibexa\Contracts\Test\Rest\Request\Value\EndpointRequestDefinition;
+
+/**
+ * Coverage for /location/load-subtree REST endpoint.
+ */
+final class PostPostLoadSubtreeTest extends BaseAdminUiRestWebTestCase
+{
+    private const INPUT_MEDIA_TYPE = 'ContentTreeLoadSubtreeRequest';
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\Exception
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $ibexaTestCore = $this->getIbexaTestCore();
+        $ibexaTestCore->setAdministratorUser();
+        $bookmarkService = $ibexaTestCore->getServiceByClassName(BookmarkService::class);
+        $locationService = $ibexaTestCore->getLocationService();
+        $location = $locationService->loadLocation(2);
+        $bookmarkService->createBookmark($location);
+    }
+
+    protected static function getEndpointsToTest(): iterable
+    {
+        $payloadLoader = new PayloadLoader(dirname(__DIR__) . '/Resources/REST/InputPayloads');
+
+        yield new EndpointRequestDefinition(
+            'POST',
+            '/api/ibexa/v2/location/tree/load-subtree',
+            'ContentTreeRoot',
+            'application/vnd.ibexa.api.ContentTreeRoot+json',
+            ['HTTP_X-SiteAccess' => 'admin'],
+            $payloadLoader->loadPayload(self::INPUT_MEDIA_TYPE, 'json'),
+            null,
+            'ContentTreeRoot'
+        );
+    }
+}

--- a/tests/integration/Resources/REST/InputPayloads/ContentTreeLoadSubtreeRequest.json
+++ b/tests/integration/Resources/REST/InputPayloads/ContentTreeLoadSubtreeRequest.json
@@ -1,0 +1,22 @@
+{
+  "LoadSubtreeRequest": {
+    "_media-type": "application/vnd.ibexa.api.ContentTreeLoadSubtreeRequest",
+    "nodes": [
+      {
+        "_media-type": "application/vnd.ibexa.api.ContentTreeLoadSubtreeRequestNode",
+        "locationId": 2,
+        "limit": 30,
+        "offset": 0,
+        "children": [
+          {
+            "_media-type": "application/vnd.ibexa.api.ContentTreeLoadSubtreeRequestNode",
+            "locationId": 1,
+            "limit": 200,
+            "offset": 0,
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/integration/Resources/REST/Schemas/ContentTreeRoot.json
+++ b/tests/integration/Resources/REST/Schemas/ContentTreeRoot.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "ContentTreeRoot": {
+      "type": "object",
+      "properties": {
+        "_media-type": {
+          "type": "string"
+        },
+        "ContentTreeNodeList": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "_media-type": {
+                  "type": "string"
+                },
+                "locationId": {
+                  "type": "integer"
+                },
+                "contentId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "contentTypeIdentifier": {
+                  "type": "string"
+                },
+                "isContainer": {
+                  "type": "boolean"
+                },
+                "isInvisible": {
+                  "type": "boolean"
+                },
+                "displayLimit": {
+                  "type": "integer"
+                },
+                "totalChildrenCount": {
+                  "type": "integer"
+                },
+                "reverseRelationsCount": {
+                  "type": "integer"
+                },
+                "isBookmarked": {
+                  "type": "boolean"
+                },
+                "children": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "_media-type": {
+                          "type": "string"
+                        },
+                        "locationId": {
+                          "type": "integer"
+                        },
+                        "contentId": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "contentTypeIdentifier": {
+                          "type": "string"
+                        },
+                        "isContainer": {
+                          "type": "boolean"
+                        },
+                        "isInvisible": {
+                          "type": "boolean"
+                        },
+                        "displayLimit": {
+                          "type": "integer"
+                        },
+                        "totalChildrenCount": {
+                          "type": "integer"
+                        },
+                        "reverseRelationsCount": {
+                          "type": "integer"
+                        },
+                        "isBookmarked": {
+                          "type": "boolean"
+                        },
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "_media-type",
+                        "locationId",
+                        "contentId",
+                        "name",
+                        "contentTypeIdentifier",
+                        "isContainer",
+                        "isInvisible",
+                        "displayLimit",
+                        "totalChildrenCount",
+                        "reverseRelationsCount",
+                        "isBookmarked",
+                        "children"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "_media-type",
+                "locationId",
+                "contentId",
+                "name",
+                "contentTypeIdentifier",
+                "isContainer",
+                "isInvisible",
+                "displayLimit",
+                "totalChildrenCount",
+                "reverseRelationsCount",
+                "isBookmarked",
+                "children"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "_media-type",
+        "ContentTreeNodeList"
+      ]
+    }
+  },
+  "required": [
+    "ContentTreeRoot"
+  ]
+}

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeRoot.json
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeRoot.json
@@ -1,0 +1,36 @@
+{
+  "ContentTreeRoot": {
+    "_media-type": "application\/vnd.ibexa.api.ContentTreeRoot+json",
+    "ContentTreeNodeList": [
+      {
+        "_media-type": "application\/vnd.ibexa.api.ContentTreeNode+json",
+        "locationId": 2,
+        "contentId": 57,
+        "name": "Home",
+        "contentTypeIdentifier": "landing_page",
+        "isContainer": true,
+        "isInvisible": false,
+        "displayLimit": 30,
+        "totalChildrenCount": 1,
+        "reverseRelationsCount": 0,
+        "isBookmarked": true,
+        "children": [
+          {
+            "_media-type": "application\/vnd.ibexa.api.ContentTreeNode+json",
+            "locationId": 60,
+            "contentId": 58,
+            "name": "Contact Us",
+            "contentTypeIdentifier": "feedback_form",
+            "isContainer": true,
+            "isInvisible": false,
+            "displayLimit": 30,
+            "totalChildrenCount": 0,
+            "reverseRelationsCount": 0,
+            "isBookmarked": false,
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/integration/Resources/ibexa_test_config.yaml
+++ b/tests/integration/Resources/ibexa_test_config.yaml
@@ -1,0 +1,9 @@
+ibexa:
+    siteaccess:
+        list: [admin]
+        groups:
+            admin_group: [admin]
+    system:
+        default:
+            content_tree_module:
+                load_more_limit: 30

--- a/tests/integration/Resources/routing.yaml
+++ b/tests/integration/Resources/routing.yaml
@@ -1,0 +1,7 @@
+ibexa.admin_ui.rest:
+    resource: '@IbexaAdminUiBundle/Resources/config/routing_rest.yaml'
+    prefix: '%ibexa.rest.path_prefix%'
+
+ibexa.rest:
+    resource: '@IbexaRestBundle/Resources/config/routing.yml'
+    prefix: '%ibexa.rest.path_prefix%'

--- a/tests/integration/Resources/routing.yaml
+++ b/tests/integration/Resources/routing.yaml
@@ -5,3 +5,6 @@ ibexa.admin_ui.rest:
 ibexa.rest:
     resource: '@IbexaRestBundle/Resources/config/routing.yml'
     prefix: '%ibexa.rest.path_prefix%'
+
+ibexa.user:
+    resource: '@IbexaUserBundle/Resources/config/routing.yaml'

--- a/tests/integration/SetupValidationTest.php
+++ b/tests/integration/SetupValidationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\AdminUi;
+
+use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
+
+/**
+ * @group integration
+ *
+ * @coversNothing
+ */
+final class SetupValidationTest extends IbexaKernelTestCase
+{
+    public function testCompilesSuccessfully(): void
+    {
+        self::bootKernel();
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Core\Test\Persistence\Fixture\FixtureImporter;
+use Ibexa\Tests\Core\Repository\LegacySchemaImporter;
+use Ibexa\Tests\Integration\AdminUi\AdminUiIbexaTestKernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+chdir(dirname(__DIR__, 2));
+
+$kernel = new AdminUiIbexaTestKernel('test', true);
+$kernel->boot();
+
+$application = new Application($kernel);
+$application->setAutoExit(false);
+
+if (getenv('DATABASE_URL') !== false && strpos(getenv('DATABASE_URL'), 'sqlite') !== 0) {
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:database:drop',
+        '--if-exists' => '1',
+        '--force' => '1',
+        '--quiet' => true,
+    ]));
+}
+
+$application->run(new ArrayInput([
+    'command' => 'doctrine:database:create',
+    '--quiet' => true,
+]));
+
+/** @var \Psr\Container\ContainerInterface $testContainer */
+$testContainer = $kernel->getContainer()->get('test.service_container');
+
+$schemaImporter = $testContainer->get(LegacySchemaImporter::class);
+foreach ($kernel->getSchemaFiles() as $file) {
+    $schemaImporter->importSchema($file);
+}
+
+$fixtureImporter = $testContainer->get(FixtureImporter::class);
+foreach ($kernel->getFixtures() as $fixture) {
+    $fixtureImporter->import($fixture);
+}
+$kernel->shutdown();


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6815](https://issues.ibexa.co/browse/IBX-6815) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.5`              |
| **BC breaks**            | no                                              |

A [merge up](https://github.com/ibexa/admin-ui/pull/856/files#diff-f65a7556df790de631de3760e0ceff5e35c69ad0185bfd7c23092a2823b7fa54L100) caused the regression which resulted in Location bookmark information not being propagated when building ContentTree REST response (`/load-subtree` endpoint).

We need some minimal test coverage for that endpoint, as the issue was almost impossible to detect due to the complexity of the changes.

#### TODO
- [x] tests

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.