### PR TITLE
IBX-7655: Added root and starting location id for richtext embeded image UDW config

### DIFF
--- a/src/bundle/Resources/config/universal_discovery_widget.yaml
+++ b/src/bundle/Resources/config/universal_discovery_widget.yaml
@@ -60,6 +60,8 @@ system:
                 richtext_embed_image:
                     multiple: false
                     allowed_content_types: ['image']
+                    root_location_id: 43
+                    starting_location_id: 43
                 image_asset:
                     multiple: false
                 single_user:


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7655](https://issues.ibexa.co/browse/IBX-7655) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

After discussion with @IdaDra, Image library should show Content Tree starting from Media folder. Currently starting location id is 1.

![Screenshot 2024-01-31 at 08 13 21](https://github.com/ibexa/admin-ui/assets/9850711/84ffbf3b-e896-42d9-ab0d-c32d3a71fbfc)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
