### PR TITLE
Renamed ImagePicker config provider to DamWidget

### DIFF
--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -79,9 +79,9 @@ parameters:
 
     ibexa.site_access.config.default.admin_ui.default_focus_mode: '1'
 
-    ibexa.image_picker.field_definition_identifiers: [image]
-    ibexa.image_picker.content_type_identifiers: [image]
-    ibexa.image_picker.aggregations:
+    ibexa.dam_widget.image.field_definition_identifiers: [image]
+    ibexa.dam_widget.image.content_type_identifiers: [image]
+    ibexa.dam_widget.image.aggregations:
         KeywordTermAggregation:
             name: keywords
             contentTypeIdentifier: image

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -143,14 +143,15 @@ services:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'userProfile' }
 
-    Ibexa\AdminUi\UI\Config\Provider\Module\ImagePicker:
+    Ibexa\AdminUi\UI\Config\Provider\Module\DamWidget:
         arguments:
             $config:
-                imageFieldDefinitionIdentifiers: '%ibexa.image_picker.field_definition_identifiers%'
-                imageContentTypeIdentifiers: '%ibexa.image_picker.content_type_identifiers%'
-                aggregations: '%ibexa.image_picker.aggregations%'
+                image:
+                    fieldDefinitionIdentifiers: '%ibexa.dam_widget.image.field_definition_identifiers%'
+                    contentTypeIdentifiers: '%ibexa.dam_widget.image.content_type_identifiers%'
+                    aggregations: '%ibexa.dam_widget.image.aggregations%'
         tags:
-            - { name: ibexa.admin_ui.config.provider, key: 'imagePicker' }
+            - { name: ibexa.admin_ui.config.provider, key: 'damWidget' }
 
     # Resolvers
     Ibexa\AdminUi\REST\Generator\ApplicationConfigRestGeneratorRegistry:

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -12,12 +12,14 @@ use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
 
 /**
  * @template TConfig of array{
- *      imageFieldDefinitionIdentifiers: array<string>,
- *      imageContentTypeIdentifiers: array<string>,
- *      aggregations: array<string, array<string, string>>,
+ *     image: array{
+ *         fieldDefinitionIdentifiers: array<string>,
+ *         contentTypeIdentifiers: array<string>,
+ *         aggregations: array<string, array<string, string>>,
+ *     }
  *  }
  */
-final class ImagePicker implements ProviderInterface
+final class DamWidget implements ProviderInterface
 {
     /** @phpstan-var TConfig */
     private array $config;

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -8,15 +8,15 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\AdminUi\UI\Config\Provider\Module;
 
-use Ibexa\AdminUi\UI\Config\Provider\Module\ImagePicker;
+use Ibexa\AdminUi\UI\Config\Provider\Module\DamWidget;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
 use PHPUnit\Framework\TestCase;
 
-final class ImagePickerTest extends TestCase
+final class DamWidgetTest extends TestCase
 {
     private const FIELD_DEFINITION_IDENTIFIERS = ['field_foo', 'field_bar'];
     private const CONTENT_TYPE_IDENTIFIERS = ['content_type_foo', 'content_type_bar'];
-    private const AGGREGATIONS = [
+    private const IMAGE_AGGREGATIONS = [
         'KeywordTermAggregation' => [
             'name' => 'keywords',
             'contentTypeIdentifier' => 'keywords',
@@ -28,11 +28,13 @@ final class ImagePickerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->provider = new ImagePicker(
+        $this->provider = new DamWidget(
             [
-                'imageFieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
-                'imageContentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
-                'aggregations' => self::AGGREGATIONS,
+                'image' => [
+                    'fieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
+                    'contentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
+                    'aggregations' => self::IMAGE_AGGREGATIONS,
+                ],
             ]
         );
     }
@@ -41,9 +43,11 @@ final class ImagePickerTest extends TestCase
     {
         self::assertSame(
             [
-                'imageFieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
-                'imageContentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
-                'aggregations' => self::AGGREGATIONS,
+                'image' => [
+                    'fieldDefinitionIdentifiers' => self::FIELD_DEFINITION_IDENTIFIERS,
+                    'contentTypeIdentifiers' => self::CONTENT_TYPE_IDENTIFIERS,
+                    'aggregations' => self::IMAGE_AGGREGATIONS,
+                ],
             ],
             $this->provider->getConfig()
         );


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | N/A |
| **Type**             | improvement                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

Renamed `ImagePicker` to `DamWidget` and also renamed all related parameters containing `image_picker` to `dam_widget` in name.

There is also added `image` phrase in parameter name to distinguish for which DAM widget part configuration belongs to.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
