### PR TITLE
IBX-7674: Skip redirection to user profile if user CT is edited via configuration view

### DIFF
--- a/src/bundle/Resources/config/services/events.yaml
+++ b/src/bundle/Resources/config/services/events.yaml
@@ -66,7 +66,3 @@ services:
             $siteAccessGroups: '%ibexa.site_access.groups%'
         tags:
             - { name: kernel.event_subscriber }
-
-    Ibexa\AdminUi\EventListener\UserProfileListener:
-        tags:
-            - { name: kernel.event_subscriber }

--- a/src/lib/EventListener/UserProfileListener.php
+++ b/src/lib/EventListener/UserProfileListener.php
@@ -113,9 +113,10 @@ final class UserProfileListener implements EventSubscriberInterface
 
     private function isSupported(UserUpdateData $data): bool
     {
-        return $this->isUserProfileUpdate($data) &&
-            $this->canEditUserProfile($data->user) &&
-            $this->doesOriginateFromProfileEditing();
+        return
+            $this->doesOriginateFromProfileEditing() &&
+            $this->isUserProfileUpdate($data) &&
+            $this->canEditUserProfile($data->user);
     }
 
     private function createUpdateStruct(UserUpdateData $data, string $languageCode): UserUpdateStruct


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7674](https://issues.ibexa.co/browse/IBX-7674) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

It seems that if `User` (besides default `Editor`) CT was enabled to have "User profile" feature, the redirection was a bit imprecise. `UserProfileListener` now detects if it was triggered from dedicated view. Therefore. if "User" CT is edited in the configuration view of BO, we are not redirected (we basically stay in the same view, as it was before introducing user profiles).

Besides `UserProfileListener` is already automatically registered, so I removed explicit YAML configuration entry.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
