### PR TITLE
IBX-7472: Set view to empty file, when uri value is empty

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/binary_base.html.twig
@@ -2,7 +2,11 @@
 
 {% block binary_base_row %}
     {% if not file_is_empty is defined %}
-        {% set file_is_empty = form.parent.vars.value.value.fileName is null or form.parent.vars.value.value.fileSize is null %}
+        {% set file_is_empty =
+            form.parent.vars.value.value.fileName is null
+            or form.parent.vars.value.value.fileSize is null
+            or form.parent.vars.value.value.uri is null
+        %}
     {% endif %}
     {% set fieldtype = form.parent %}
     {% set translation_mode = fieldtype.vars.mainLanguageCode != fieldtype.vars.languageCode %}


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7472](https://issues.ibexa.co/browse/IBX-7472) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

There is no easy way to retain uploaded image between this and validation, but this at least ~clears up form (ok, not clearing form as this is also not so easy to do, seems errors came from other field)~ change view so user knows that it needs to be uploaded again.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
