### PR TITLE
IBX-7448: Fixed wrong used of name instead of identifier for siteaccess form dropdown value

### DIFF
--- a/src/lib/Form/Type/ChoiceList/Loader/SiteAccessPreviewChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/SiteAccessPreviewChoiceLoader.php
@@ -44,8 +44,8 @@ final class SiteAccessPreviewChoiceLoader extends BaseChoiceLoader
         $baseChoiceList = $this->siteAccessChoiceLoader->getChoiceList();
 
         $choiceList = [];
-        foreach ($baseChoiceList as $siteAccessKey => $siteAccessName) {
-            $choiceList[$siteAccessKey] = $this->urlGenerator->generate(
+        foreach ($baseChoiceList as $siteAccessName => $siteAccessKey) {
+            $choiceList[$siteAccessName] = $this->urlGenerator->generate(
                 'ibexa.version.preview',
                 [
                     'contentId' => $this->contentId,


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7448](https://issues.ibexa.co/browse/IBX-7448) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

As in first place this was build upon bug in twig form, I made that same mistake as there :sweat_smile: 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
