### PR TITLE
IBX-7731: Prevented container element display on empty user profile

### DIFF
--- a/src/bundle/Resources/views/themes/admin/account/profile/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/profile/view.html.twig
@@ -102,11 +102,15 @@
                 {% endif %}
             </aside>
 
-            <main class="ibexa-user-profile__blocks">
-                <div class="ibexa-container container">
-                    {{ ibexa_render_component_group('user-profile-blocks', { user }) }}
-                </div>
-            </main>
+            {%- set user_profile_output -%}
+                {{- ibexa_render_component_group('user-profile-blocks', { user }) -}}
+            {%- endset -%}
+
+            {% if user_profile_output is not empty %}
+                <main class="ibexa-user-profile__blocks">
+                    <div class="ibexa-container container">{{ user_profile_output }}</div>
+                </main>
+            {% endif %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7731](https://issues.ibexa.co/browse/IBX-7731) |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |

Do not display container on empty user profile component.

### Non empty

![image](https://github.com/ibexa/admin-ui/assets/3183926/747fa318-fb8e-47bf-abb9-363ee1092112)

### Original empty
![image](https://github.com/ibexa/admin-ui/assets/3183926/4a280948-3ab1-4ab4-9180-634fd4204e55)

### New empty
![image](https://github.com/ibexa/admin-ui/assets/3183926/079a4047-08b5-44e8-b339-1a870ce16885)


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
