### PR TITLE
IBX-7030: [UDW] Inactive edit button in grid view

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.helpers.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.helpers.js
@@ -1,0 +1,9 @@
+export const getLoadedLocationsLimitedMap = (loadedLocationsFullMap, activeLocationId) => {
+    const itemIndex = loadedLocationsFullMap.findIndex(({ parentLocationId }) => parentLocationId === activeLocationId);
+
+    if (itemIndex === -1) {
+        return [];
+    }
+
+    return loadedLocationsFullMap.slice(0, itemIndex + 1);
+};

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
@@ -3,12 +3,22 @@ import React, { useContext, useState, useMemo, useEffect, useCallback } from 're
 import Icon from '../../../common/icon/icon';
 
 import { createCssClassNames } from '../../../common/helpers/css.class.names';
-import { LoadedLocationsMapContext } from '../../universal.discovery.module';
+import { LoadedLocationsMapContext, MarkedLocationIdContext } from '../../universal.discovery.module';
+import { ActiveLocationIdContext } from '../grid-view/grid.view';
 import { getTranslator } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/context.helper';
+
+const getLoadedLocationsLimitedMap = (loadedLocationsFullMap, activeLocationId) => {
+    const itemIndex = loadedLocationsFullMap.findIndex(({ parentLocationId }) => parentLocationId === activeLocationId);
+
+    return loadedLocationsFullMap.slice(0, itemIndex + 1);
+};
 
 const Breadcrumbs = () => {
     const Translator = getTranslator();
-    const [loadedLocationsMap, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
+    const [, setMarkedLocationId] = useContext(MarkedLocationIdContext);
+    const [activeLocationId, setActiveLocationId] = useContext(ActiveLocationIdContext);
+    const [loadedLocationsFullMap, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
+    const loadedLocationsMap = getLoadedLocationsLimitedMap(loadedLocationsFullMap, activeLocationId);
     const [hiddenListVisible, setHiddenListVisible] = useState(false);
     const { visibleItems, hiddenItems } = useMemo(() => {
         return loadedLocationsMap.reduce(
@@ -31,6 +41,8 @@ const Breadcrumbs = () => {
         updatedLoadedLocations[updatedLoadedLocations.length - 1].subitems = [];
 
         dispatchLoadedLocationsAction({ type: 'SET_LOCATIONS', data: updatedLoadedLocations });
+        setMarkedLocationId(locationId);
+        setActiveLocationId(locationId);
     };
     const toggleHiddenListVisible = useCallback(() => {
         setHiddenListVisible(!hiddenListVisible);

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
@@ -2,15 +2,10 @@ import React, { useContext, useState, useMemo, useEffect, useCallback } from 're
 
 import Icon from '../../../common/icon/icon';
 
-import { createCssClassNames } from '../../../common/helpers/css.class.names';
-import { LoadedLocationsMapContext, MarkedLocationIdContext, GridActiveLocationIdContext } from '../../universal.discovery.module';
 import { getTranslator } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/context.helper';
-
-const getLoadedLocationsLimitedMap = (loadedLocationsFullMap, activeLocationId) => {
-    const itemIndex = loadedLocationsFullMap.findIndex(({ parentLocationId }) => parentLocationId === activeLocationId);
-
-    return loadedLocationsFullMap.slice(0, itemIndex + 1);
-};
+import { createCssClassNames } from '../../../common/helpers/css.class.names';
+import { getLoadedLocationsLimitedMap } from './breadcrumbs.helpers';
+import { LoadedLocationsMapContext, MarkedLocationIdContext, GridActiveLocationIdContext } from '../../universal.discovery.module';
 
 const Breadcrumbs = () => {
     const Translator = getTranslator();

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/breadcrumbs/breadcrumbs.js
@@ -3,8 +3,7 @@ import React, { useContext, useState, useMemo, useEffect, useCallback } from 're
 import Icon from '../../../common/icon/icon';
 
 import { createCssClassNames } from '../../../common/helpers/css.class.names';
-import { LoadedLocationsMapContext, MarkedLocationIdContext } from '../../universal.discovery.module';
-import { ActiveLocationIdContext } from '../grid-view/grid.view';
+import { LoadedLocationsMapContext, MarkedLocationIdContext, GridActiveLocationIdContext } from '../../universal.discovery.module';
 import { getTranslator } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/context.helper';
 
 const getLoadedLocationsLimitedMap = (loadedLocationsFullMap, activeLocationId) => {
@@ -16,9 +15,9 @@ const getLoadedLocationsLimitedMap = (loadedLocationsFullMap, activeLocationId) 
 const Breadcrumbs = () => {
     const Translator = getTranslator();
     const [, setMarkedLocationId] = useContext(MarkedLocationIdContext);
-    const [activeLocationId, setActiveLocationId] = useContext(ActiveLocationIdContext);
+    const [gridActiveLocationId, setGridActiveLocationId] = useContext(GridActiveLocationIdContext);
     const [loadedLocationsFullMap, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
-    const loadedLocationsMap = getLoadedLocationsLimitedMap(loadedLocationsFullMap, activeLocationId);
+    const loadedLocationsMap = getLoadedLocationsLimitedMap(loadedLocationsFullMap, gridActiveLocationId);
     const [hiddenListVisible, setHiddenListVisible] = useState(false);
     const { visibleItems, hiddenItems } = useMemo(() => {
         return loadedLocationsMap.reduce(
@@ -42,7 +41,7 @@ const Breadcrumbs = () => {
 
         dispatchLoadedLocationsAction({ type: 'SET_LOCATIONS', data: updatedLoadedLocations });
         setMarkedLocationId(locationId);
-        setActiveLocationId(locationId);
+        setGridActiveLocationId(locationId);
     };
     const toggleHiddenListVisible = useCallback(() => {
         setHiddenListVisible(!hiddenListVisible);

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.item.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.item.js
@@ -13,15 +13,15 @@ import {
     MultipleConfigContext,
     ContainersOnlyContext,
     AllowedContentTypesContext,
+    GridActiveLocationIdContext,
 } from '../../universal.discovery.module';
-import { ActiveLocationIdContext } from './grid.view';
 
 const isSelectionButtonClicked = (event) => {
     return event.target.closest('.c-udw-toggle-selection');
 };
 
 const GridViewItem = ({ location, version }) => {
-    const [, setActiveLocationId] = useContext(ActiveLocationIdContext);
+    const [, setGridActiveLocationId] = useContext(GridActiveLocationIdContext);
     const [markedLocationId, setMarkedLocationId] = useContext(MarkedLocationIdContext);
     const [, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
     const contentTypesMap = useContext(ContentTypesMapContext);
@@ -63,7 +63,7 @@ const GridViewItem = ({ location, version }) => {
         }
 
         dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data: { parentLocationId: location.id, subitems: [] } });
-        setActiveLocationId(location.id);
+        setGridActiveLocationId(location.id);
     };
     const renderToggleSelection = () => {
         return (

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.item.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.item.js
@@ -14,12 +14,14 @@ import {
     ContainersOnlyContext,
     AllowedContentTypesContext,
 } from '../../universal.discovery.module';
+import { ActiveLocationIdContext } from './grid.view';
 
 const isSelectionButtonClicked = (event) => {
     return event.target.closest('.c-udw-toggle-selection');
 };
 
 const GridViewItem = ({ location, version }) => {
+    const [, setActiveLocationId] = useContext(ActiveLocationIdContext);
     const [markedLocationId, setMarkedLocationId] = useContext(MarkedLocationIdContext);
     const [, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
     const contentTypesMap = useContext(ContentTypesMapContext);
@@ -44,6 +46,8 @@ const GridViewItem = ({ location, version }) => {
         }
 
         setMarkedLocationId(location.id);
+        dispatchLoadedLocationsAction({ type: 'CUT_LOCATIONS', locationId: location.id });
+        dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data: { parentLocationId: location.id, subitems: [] } });
 
         if (!multiple) {
             dispatchSelectedLocationsAction({ type: 'CLEAR_SELECTED_LOCATIONS' });
@@ -59,6 +63,7 @@ const GridViewItem = ({ location, version }) => {
         }
 
         dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data: { parentLocationId: location.id, subitems: [] } });
+        setActiveLocationId(location.id);
     };
     const renderToggleSelection = () => {
         return (

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/grid-view/grid.view.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, createContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import GridViewItem from './grid.view.item';
@@ -10,22 +10,19 @@ import {
     LoadedLocationsMapContext,
     SortingContext,
     SortOrderContext,
-    MarkedLocationIdContext,
+    GridActiveLocationIdContext,
 } from '../../universal.discovery.module';
-
-export const ActiveLocationIdContext = createContext();
 
 const SCROLL_OFFSET = 200;
 
 const GridView = ({ itemsPerPage }) => {
     const [offset, setOffset] = useState(0);
-    const [markedLocationId] = useContext(MarkedLocationIdContext);
     const [loadedLocationsMap, dispatchLoadedLocationsAction] = useContext(LoadedLocationsMapContext);
     const [sorting] = useContext(SortingContext);
     const [sortOrder] = useContext(SortOrderContext);
-    const [activeLocationId, setActiveLocationId] = useState(markedLocationId ?? loadedLocationsMap[0]?.parentLocationId);
+    const [gridActiveLocationId] = useContext(GridActiveLocationIdContext);
     const sortingOptions = SORTING_OPTIONS.find((option) => option.sortClause === sorting);
-    const locationData = loadedLocationsMap.find(({ parentLocationId }) => parentLocationId === activeLocationId);
+    const locationData = loadedLocationsMap.find(({ parentLocationId }) => parentLocationId === gridActiveLocationId);
     const locationDataToLoad = loadedLocationsMap.length ? loadedLocationsMap[loadedLocationsMap.length - 1] : { subitems: [] };
     const [loadedLocations, isLoading] = useFindLocationsByParentLocationIdFetch(
         locationDataToLoad,
@@ -64,14 +61,12 @@ const GridView = ({ itemsPerPage }) => {
     }, [loadedLocations, dispatchLoadedLocationsAction, isLoading]);
 
     return (
-        <ActiveLocationIdContext.Provider value={[activeLocationId, setActiveLocationId]}>
-            <div className="c-grid">
-                <Breadcrumbs />
-                <div className="ibexa-grid-view c-grid__items-wrapper" onScroll={loadMore}>
-                    {locationData.subitems.map(renderItem)}
-                </div>
+        <div className="c-grid">
+            <Breadcrumbs />
+            <div className="ibexa-grid-view c-grid__items-wrapper" onScroll={loadMore}>
+                {locationData?.subitems.map(renderItem)}
             </div>
-        </ActiveLocationIdContext.Provider>
+        </div>
     );
 };
 

--- a/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
@@ -182,6 +182,7 @@ export const BlockFetchLocationHookContext = createContext();
 export const SearchTextContext = createContext();
 export const DropdownPortalRefContext = createContext();
 export const SuggestionsStorageContext = createContext();
+export const GridActiveLocationIdContext = createContext();
 
 const UniversalDiscoveryModule = (props) => {
     const { restInfo } = props;
@@ -212,6 +213,7 @@ const UniversalDiscoveryModule = (props) => {
     );
     const [searchText, setSearchText] = useState('');
     const [suggestionsStorage, setSuggestionsStorage] = useState({});
+    const [gridActiveLocationId, setGridActiveLocationId] = useState(markedLocationId);
     const [loadedLocationsMap, dispatchLoadedLocationsAction] = useLoadedLocationsReducer([
         { parentLocationId: props.rootLocationId, subitems: [] },
     ]);
@@ -438,6 +440,12 @@ const UniversalDiscoveryModule = (props) => {
         dispatchLoadedLocationsAction({ type: 'SET_LOCATIONS', data: locationsMap });
     }, [sorting, sortOrder]);
 
+    useEffect(() => {
+        if (currentView === 'grid') {
+            setGridActiveLocationId(markedLocationId);
+        }
+    }, [currentView]);
+
     return (
         <div className={className}>
             <UDWContext.Provider value={true}>
@@ -468,72 +476,79 @@ const UniversalDiscoveryModule = (props) => {
                                                                                         <MarkedLocationIdContext.Provider
                                                                                             value={[markedLocationId, setMarkedLocationId]}
                                                                                         >
-                                                                                            <LoadedLocationsMapContext.Provider
+                                                                                            <GridActiveLocationIdContext.Provider
                                                                                                 value={[
-                                                                                                    loadedLocationsMap,
-                                                                                                    dispatchLoadedLocationsAction,
+                                                                                                    gridActiveLocationId,
+                                                                                                    setGridActiveLocationId,
                                                                                                 ]}
                                                                                             >
-                                                                                                <RootLocationIdContext.Provider
-                                                                                                    value={props.rootLocationId}
+                                                                                                <LoadedLocationsMapContext.Provider
+                                                                                                    value={[
+                                                                                                        loadedLocationsMap,
+                                                                                                        dispatchLoadedLocationsAction,
+                                                                                                    ]}
                                                                                                 >
-                                                                                                    <SelectedLocationsContext.Provider
-                                                                                                        value={[
-                                                                                                            selectedLocations,
-                                                                                                            dispatchSelectedLocationsAction,
-                                                                                                        ]}
+                                                                                                    <RootLocationIdContext.Provider
+                                                                                                        value={props.rootLocationId}
                                                                                                     >
-                                                                                                        <CreateContentWidgetContext.Provider
+                                                                                                        <SelectedLocationsContext.Provider
                                                                                                             value={[
-                                                                                                                createContentVisible,
-                                                                                                                setCreateContentVisible,
+                                                                                                                selectedLocations,
+                                                                                                                dispatchSelectedLocationsAction,
                                                                                                             ]}
                                                                                                         >
-                                                                                                            <SuggestionsStorageContext.Provider
+                                                                                                            <CreateContentWidgetContext.Provider
                                                                                                                 value={[
-                                                                                                                    suggestionsStorage,
-                                                                                                                    setSuggestionsStorage,
+                                                                                                                    createContentVisible,
+                                                                                                                    setCreateContentVisible,
                                                                                                                 ]}
                                                                                                             >
-                                                                                                                <ContentOnTheFlyDataContext.Provider
+                                                                                                                <SuggestionsStorageContext.Provider
                                                                                                                     value={[
-                                                                                                                        contentOnTheFlyData,
-                                                                                                                        setContentOnTheFlyData,
+                                                                                                                        suggestionsStorage,
+                                                                                                                        setSuggestionsStorage,
                                                                                                                     ]}
                                                                                                                 >
-                                                                                                                    <ContentOnTheFlyConfigContext.Provider
-                                                                                                                        value={
-                                                                                                                            props.contentOnTheFly
-                                                                                                                        }
+                                                                                                                    <ContentOnTheFlyDataContext.Provider
+                                                                                                                        value={[
+                                                                                                                            contentOnTheFlyData,
+                                                                                                                            setContentOnTheFlyData,
+                                                                                                                        ]}
                                                                                                                     >
-                                                                                                                        <EditOnTheFlyDataContext.Provider
-                                                                                                                            value={[
-                                                                                                                                editOnTheFlyData,
-                                                                                                                                setEditOnTheFlyData,
-                                                                                                                            ]}
+                                                                                                                        <ContentOnTheFlyConfigContext.Provider
+                                                                                                                            value={
+                                                                                                                                props.contentOnTheFly
+                                                                                                                            }
                                                                                                                         >
-                                                                                                                            <SearchTextContext.Provider
+                                                                                                                            <EditOnTheFlyDataContext.Provider
                                                                                                                                 value={[
-                                                                                                                                    searchText,
-                                                                                                                                    setSearchText,
+                                                                                                                                    editOnTheFlyData,
+                                                                                                                                    setEditOnTheFlyData,
                                                                                                                                 ]}
                                                                                                                             >
-                                                                                                                                <DropdownPortalRefContext.Provider
-                                                                                                                                    value={
-                                                                                                                                        dropdownPortalRef
-                                                                                                                                    }
+                                                                                                                                <SearchTextContext.Provider
+                                                                                                                                    value={[
+                                                                                                                                        searchText,
+                                                                                                                                        setSearchText,
+                                                                                                                                    ]}
                                                                                                                                 >
-                                                                                                                                    <Tab />
-                                                                                                                                </DropdownPortalRefContext.Provider>
-                                                                                                                            </SearchTextContext.Provider>
-                                                                                                                        </EditOnTheFlyDataContext.Provider>
-                                                                                                                    </ContentOnTheFlyConfigContext.Provider>
-                                                                                                                </ContentOnTheFlyDataContext.Provider>
-                                                                                                            </SuggestionsStorageContext.Provider>
-                                                                                                        </CreateContentWidgetContext.Provider>
-                                                                                                    </SelectedLocationsContext.Provider>
-                                                                                                </RootLocationIdContext.Provider>
-                                                                                            </LoadedLocationsMapContext.Provider>
+                                                                                                                                    <DropdownPortalRefContext.Provider
+                                                                                                                                        value={
+                                                                                                                                            dropdownPortalRef
+                                                                                                                                        }
+                                                                                                                                    >
+                                                                                                                                        <Tab />
+                                                                                                                                    </DropdownPortalRefContext.Provider>
+                                                                                                                                </SearchTextContext.Provider>
+                                                                                                                            </EditOnTheFlyDataContext.Provider>
+                                                                                                                        </ContentOnTheFlyConfigContext.Provider>
+                                                                                                                    </ContentOnTheFlyDataContext.Provider>
+                                                                                                                </SuggestionsStorageContext.Provider>
+                                                                                                            </CreateContentWidgetContext.Provider>
+                                                                                                        </SelectedLocationsContext.Provider>
+                                                                                                    </RootLocationIdContext.Provider>
+                                                                                                </LoadedLocationsMapContext.Provider>
+                                                                                            </GridActiveLocationIdContext.Provider>
                                                                                         </MarkedLocationIdContext.Provider>
                                                                                     </CurrentViewContext.Provider>
                                                                                 </SortOrderContext.Provider>


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7030 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->
For whole UDW markedLocationId is used as both item that is detailed in sidebar and parent of last/active branch. 
It changes however in grid view, where markedLocationId keeps data about details in sidebar, but it's not necessary parent of visible items, therefore I've added extra state variable `gridActiveLocationId` that is used only in grid view and keeps info about parent of visible subitems.

At first I wanted to keep it only in GridView component, but I had to move it to the top, as entering CotF destroyes everything except top layer, so state for activeLocationId was lost as well and we need this info after closing CotF.

#### Checklist:
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
