### PR TITLE
IBX-7804: Fix dropdown offsetHeight error when ibexa-main-header not present

### DIFF
--- a/src/bundle/ui-dev/src/modules/common/dropdown/dropdown.js
+++ b/src/bundle/ui-dev/src/modules/common/dropdown/dropdown.js
@@ -106,7 +106,7 @@ const Dropdown = ({
             itemsStyles.maxHeight = window.innerHeight - bottom - ITEMS_LIST_SITE_MARGIN;
         } else {
             const headerContainer = document.querySelector('.ibexa-main-header');
-            const headerHeight = headerContainer.offsetHeight;
+            const headerHeight = headerContainer?.offsetHeight ?? 0;
 
             itemsStyles.top = top - ITEMS_LIST_WIDGET_MARGIN;
             itemsStyles.maxHeight = top - headerHeight - ITEMS_LIST_SITE_MARGIN;


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       |  https://issues.ibexa.co/browse/IBX-7804 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
