### PR TITLE
IBX-7690: [Full view] Exit full view should redirect user to View tab, not Fields

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.tab.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tab.js
@@ -3,6 +3,7 @@
     const SELECTOR_TAB = '.ibexa-tabs__tab';
     const SELECTOR_TAB_ACTIVE = '.ibexa-tabs__tab--active';
     const CLASS_TAB_ACTIVE = 'ibexa-tabs__tab--active';
+    const contentColumn = doc.querySelector('.ibexa-main-container__content-column');
     const switchActiveTabs = (currentTab, previousTab) => {
         if (previousTab) {
             previousTab.classList.remove(CLASS_TAB_ACTIVE);
@@ -35,6 +36,10 @@
         bootstrap.Tab.getOrCreateInstance(activeHashTabLink).show();
 
         switchActiveTabs(activeHashTab, currentActiveTab);
+
+        setTimeout(() => {
+            contentColumn.scrollTo(0, 0);
+        }, 0);
     };
 
     setActiveHashTab();


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7690 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->
Thanks to this solution when we enter link like `http://localhost:8000/admin/view/content/52/full/1/2#ibexa-tab-location-view-preview` we are redirected to proper tab, but we're not scrolled to element with id `#ibexa-tab-location-view-preview` (which is tab, so we're scrolled to sth like this
![Selection_854](https://github.com/ibexa/admin-ui/assets/4689171/a8c15056-da0b-4553-9496-2121fea2ae8e)
instead of this
![Selection_855](https://github.com/ibexa/admin-ui/assets/4689171/817c48c9-4b82-4e68-a58b-8f9d20e3267b)

IN THEORY it works currently for links like `http://localhost:8000/admin/view/content/52/full/1/2#ibexa-tab-location-view-sub_items#tab` but that's more of a bug - in code to set proper tab we split by `#` and takes only first fragment, omitting `#tab` fragment entirely.
But as it's not correct link (there should be only one hash, or at least browsers recognizes only one hash) browser tries to find element with id `ibexa-tab-location-view-sub_items#tab` (which of course does not exist) and scroll to it, but as it fails to do so, it leaves content on top.

`setTimeout(() => {...}, 0)` is needed, as it's need to be fired in new cycle - if it's run in initial/main one, browser behaviour with scrolling to element is more important (or to say more properly, is done after reading and executing main thread of JS code)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
