### PR TITLE
Get getNotificationsStatusLoop interval from YAML config

### DIFF
--- a/src/bundle/Controller/NotificationController.php
+++ b/src/bundle/Controller/NotificationController.php
@@ -108,7 +108,7 @@ class NotificationController extends Controller
             'page' => $page,
             'pagination' => $pagination,
             'notifications' => $notifications,
-            'notifications_count_interval' => $this->configResolver->getParameter('notifications.count.interval'),
+            'notifications_count_interval' => $this->configResolver->getParameter('notification_count.interval'),
             'pager' => $pagerfanta,
         ])->getContent());
     }

--- a/src/bundle/Controller/NotificationController.php
+++ b/src/bundle/Controller/NotificationController.php
@@ -108,6 +108,7 @@ class NotificationController extends Controller
             'page' => $page,
             'pagination' => $pagination,
             'notifications' => $notifications,
+            'notifications_count_interval' => $this->configResolver->getParameter('notifications.count.interval'),
             'pager' => $pagerfanta,
         ])->getContent());
     }

--- a/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *              warning: # type of notification
  *                  timeout: 5000 # in milliseconds
  *          notification_count:
- *               interval: 60000 # in milliseconds
+ *              interval: 60000 # in milliseconds
  * ```
  */
 class Notifications extends AbstractParser

--- a/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
@@ -25,7 +25,6 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *                  timeout: 5000 # in milliseconds
  *          notification_count:
  *               interval: # type of notification
- *                   timeout: 60000 # in milliseconds
  * ```
  */
 class Notifications extends AbstractParser

--- a/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *              warning: # type of notification
  *                  timeout: 5000 # in milliseconds
  *          notification_count:
- *               interval: 60000
+ *               interval: 60000 # in milliseconds
  * ```
  */
 class Notifications extends AbstractParser

--- a/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *              warning: # type of notification
  *                  timeout: 5000 # in milliseconds
  *          notification_count:
- *               interval: # type of notification
+ *               interval: 60000
  * ```
  */
 class Notifications extends AbstractParser

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -44,6 +44,7 @@ parameters:
     ibexa.site_access.config.admin_group.subtree_operations.copy_subtree.limit: 100
 
     # Notifications
+    ibexa.site_access.config.admin_group.notifications.count.interval: 30000
     ibexa.site_access.config.admin_group.notifications.error.timeout: 0
     ibexa.site_access.config.admin_group.notifications.warning.timeout: 0
     ibexa.site_access.config.admin_group.notifications.success.timeout: 5000

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -44,7 +44,7 @@ parameters:
     ibexa.site_access.config.admin_group.subtree_operations.copy_subtree.limit: 100
 
     # Notifications
-    ibexa.site_access.config.admin_group.notifications.count.interval: 30000
+    ibexa.site_access.config.admin_group.notification_count.interval: 30000
     ibexa.site_access.config.admin_group.notifications.error.timeout: 0
     ibexa.site_access.config.admin_group.notifications.warning.timeout: 0
     ibexa.site_access.config.admin_group.notifications.success.timeout: 5000

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -166,12 +166,13 @@
 
     const notificationsTable = modal.querySelector(SELECTOR_TABLE);
     currentPageLink = notificationsTable.dataset.notifications;
+    const interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval, 10) || INTERVAL;
 
     modal.querySelectorAll(SELECTOR_MODAL_RESULTS).forEach((link) => link.addEventListener('click', handleModalResultsClick, false));
 
     const getNotificationsStatusLoop = () => {
         getNotificationsStatus().finally(() => {
-            global.setTimeout(getNotificationsStatusLoop, INTERVAL);
+            global.setTimeout(getNotificationsStatusLoop, interval);
         });
     };
 

--- a/src/bundle/Resources/views/themes/admin/account/notifications/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/notifications/list.html.twig
@@ -10,6 +10,7 @@
     attr: {
         'data-notifications': path('ibexa.notifications.render.page'),
         'data-notifications-count': path('ibexa.notifications.count'),
+        'data-notifications-count-interval': notifications_count_interval,
         'data-notifications-total': pager.nbResults,
     }
 } %}


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | N/A |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

(conversion of ezsystems/ezplatform-admin-ui#1396)

Get `getNotificationsStatusLoop` (`notifications/count`) interval from YAML config parameters.

One could want (or need) to increase this interval to reduce server activity.

Config doc could be added around https://doc.ibexa.co/en/latest/administration/back_office/notifications/#notification-timeout

To install this on top of a Commerce 4.6.1:
```shell
composer config minimum-stability dev
composer require ibexa/commerce 4.6.x-dev --with-dependencies --no-scripts
composer require ibexa/admin-ui-assets 4.6.1 --no-scripts # to have vendor/ibexa/admin-ui-assets/src/bundle/Resources/public/vendors/
composer require ibexa/admin-ui "dev-config_notifications_count_interval as 4.6.x-dev"
```
#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
