### PR TITLE
IBX-7517: [Dashboard] Quick actions: selected tags aren't fully displayed

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/dropdown.js
@@ -65,6 +65,9 @@
 
                 this.container.classList.toggle('is-invalid', isInvalid);
             });
+            this.resizeObserver = new ResizeObserver(() => {
+                this.fitItems();
+            });
             this.currentSelectedValue = this.sourceInput.value;
 
             this.createSelectedItem = this.createSelectedItem.bind(this);
@@ -565,6 +568,7 @@
                 attributes: true,
                 attributeFilter: ['class'],
             });
+            this.resizeObserver.observe(this.container);
 
             const selectedItems = this.container.querySelectorAll(
                 '.ibexa-dropdown__selected-item:not(.ibexa-dropdown__selected-overflow-number):not(.ibexa-dropdown__selected-placeholder)',


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7517 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->
Dropdown is initialized (thefore - its fitItems method is run) before it's visible on screen. That causes that in calculation, dropdown width is 0 and condition to hide elements is always met.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
