### PR TITLE
IBX-7901: [UDW] Removing from bookmarks content is still visible on bookmark list

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/bookmarks.tab.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/bookmarks.tab.module.js
@@ -102,7 +102,7 @@ const BookmarksTabModule = () => {
     return (
         <div className="m-bookmarks-tab">
             <Tab>
-                {restorationStateRef.current ? (
+                {restorationStateRef.current && (
                     <>
                         <BookmarksList
                             itemsPerPage={tabsConfig.bookmarks.itemsPerPage}
@@ -110,7 +110,7 @@ const BookmarksTabModule = () => {
                         />
                         {renderBrowseLocations()}
                     </>
-                ) : null}
+                )}
             </Tab>
         </div>
     );

--- a/src/bundle/ui-dev/src/modules/universal-discovery/bookmarks.tab.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/bookmarks.tab.module.js
@@ -102,8 +102,15 @@ const BookmarksTabModule = () => {
     return (
         <div className="m-bookmarks-tab">
             <Tab>
-                <BookmarksList itemsPerPage={tabsConfig.bookmarks.itemsPerPage} setBookmarkedLocationMarked={setBookmarkedLocationMarked} />
-                {isMarkedLocationSetByBookmarksRef.current && renderBrowseLocations()}
+                {restorationStateRef.current ? (
+                    <>
+                        <BookmarksList
+                            itemsPerPage={tabsConfig.bookmarks.itemsPerPage}
+                            setBookmarkedLocationMarked={setBookmarkedLocationMarked}
+                        />
+                        {renderBrowseLocations()}
+                    </>
+                ) : null}
             </Tab>
         </div>
     );

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/bookmarks-list/bookmarks.list.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/bookmarks-list/bookmarks.list.js
@@ -77,6 +77,9 @@ const BookmarksList = ({ setBookmarkedLocationMarked, itemsPerPage }) => {
             reloadBookmarks();
             setBookmarks([]);
             setMarkedLocationId(null);
+        } else if (!isBookmarkMarked && markedLocationData.bookmarked) {
+            reloadBookmarks();
+            setBookmarks([]);
         }
     }, [markedLocationData.bookmarked]);
 

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/tree-view/tree.view.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/tree-view/tree.view.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 
 import { getId as getUserId } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/user.helper';
 import { createCssClassNames } from '../../../common/helpers/css.class.names';
+import { findMarkedLocation } from '../../helpers/locations.helper';
 
 import ContentTreeModule from '../../../content-tree/content.tree.module';
 import { loadAccordionData } from '../../services/universal.discovery.service';
-import { getLocationData } from '../../content.meta.preview.module';
 import {
     AllowedContentTypesContext,
     ContainersOnlyContext,
@@ -35,7 +35,7 @@ const TreeView = ({ itemsPerPage }) => {
     const contentTypesMap = useContext(ContentTypesMapContext);
     const restInfo = useContext(RestInfoContext);
     const rootLocationId = useContext(RootLocationIdContext);
-    const locationData = useMemo(() => getLocationData(loadedLocationsMap, markedLocationId), [markedLocationId, loadedLocationsMap]);
+    const locationData = useMemo(() => findMarkedLocation(loadedLocationsMap, markedLocationId), [markedLocationId, loadedLocationsMap]);
     const userId = getUserId();
     const expandItem = (item, event) => {
         event.preventDefault();

--- a/src/bundle/ui-dev/src/modules/universal-discovery/content.meta.preview.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/content.meta.preview.module.js
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import Icon from '../common/icon/icon';
 import Thumbnail from '../common/thumbnail/thumbnail';
 import { createCssClassNames } from '../common/helpers/css.class.names';
+import { findMarkedLocation } from './helpers/locations.helper';
 import { addBookmark, removeBookmark } from './services/universal.discovery.service';
 import ContentEditButton from './components/content-edit-button/content.edit.button';
 import {
@@ -17,11 +18,6 @@ import { formatShortDateTime } from '@ibexa-admin-ui/src/bundle/Resources/public
 import { parse as parseTooltip } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper';
 import { getTranslator, getRouting, getAdminUiConfig } from '@ibexa-admin-ui/src/bundle/Resources/public/js/scripts/helpers/context.helper';
 
-export const getLocationData = (loadedLocationsMap, markedLocationId) =>
-    loadedLocationsMap.find((loadedLocation) => loadedLocation.parentLocationId === markedLocationId) ||
-    (loadedLocationsMap.length &&
-        loadedLocationsMap[loadedLocationsMap.length - 1].subitems.find((subitem) => subitem.location.id === markedLocationId));
-
 const ContentMetaPreview = () => {
     const Translator = getTranslator();
     const Routing = getRouting();
@@ -32,7 +28,7 @@ const ContentMetaPreview = () => {
     const contentTypesMap = useContext(ContentTypesMapContext);
     const restInfo = useContext(RestInfoContext);
     const allowRedirects = useContext(AllowRedirectsContext);
-    const locationData = useMemo(() => getLocationData(loadedLocationsMap, markedLocationId), [markedLocationId, loadedLocationsMap]);
+    const locationData = useMemo(() => findMarkedLocation(loadedLocationsMap, markedLocationId), [markedLocationId, loadedLocationsMap]);
     const lastModifiedLabel = Translator.trans(/*@Desc("Modified")*/ 'meta_preview.last_modified', {}, 'ibexa_universal_discovery_widget');
     const creationDateLabel = Translator.trans(/*@Desc("Created")*/ 'meta_preview.creation_date', {}, 'ibexa_universal_discovery_widget');
     const translationsLabel = Translator.trans(

--- a/src/bundle/ui-dev/src/modules/universal-discovery/helpers/locations.helper.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/helpers/locations.helper.js
@@ -1,0 +1,13 @@
+export const findMarkedLocation = (loadedLocationsMap, markedLocationId) => {
+    const markedLocation = loadedLocationsMap.find(({ parentLocationId }) => parentLocationId === markedLocationId);
+
+    if (markedLocation) {
+        return markedLocation;
+    } else if (!loadedLocationsMap.length) {
+        return {};
+    }
+
+    const lastLoadedLocation = loadedLocationsMap[loadedLocationsMap.length - 1];
+
+    return lastLoadedLocation.subitems.find(({ location }) => location.id === markedLocationId) ?? {};
+};

--- a/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useLoadBookmarksFetch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useLoadBookmarksFetch.js
@@ -1,4 +1,4 @@
-import { useEffect, useContext, useReducer } from 'react';
+import { useEffect, useContext, useReducer, useRef } from 'react';
 
 import { loadBookmarks } from '../services/universal.discovery.service';
 import { RestInfoContext } from '../universal.discovery.module';
@@ -20,11 +20,11 @@ const fetchReducer = (state, action) => {
 };
 
 export const useLoadBookmarksFetch = (limit, offset) => {
+    const effectCleanedRef = useRef(false);
     const restInfo = useContext(RestInfoContext);
     const [state, dispatch] = useReducer(fetchReducer, fetchInitialState);
-
-    useEffect(() => {
-        let effectCleaned = false;
+    const reload = () => {
+        effectCleanedRef.current = false;
 
         dispatch({ type: 'FETCH_START' });
         loadBookmarks(
@@ -34,7 +34,27 @@ export const useLoadBookmarksFetch = (limit, offset) => {
                 offset,
             },
             (response) => {
-                if (effectCleaned) {
+                if (effectCleanedRef.current) {
+                    return;
+                }
+
+                dispatch({ type: 'FETCH_END', data: response });
+            },
+        );
+    };
+
+    useEffect(() => {
+        effectCleanedRef.current = false;
+
+        dispatch({ type: 'FETCH_START' });
+        loadBookmarks(
+            {
+                ...restInfo,
+                limit,
+                offset,
+            },
+            (response) => {
+                if (effectCleanedRef.current) {
                     return;
                 }
 
@@ -43,9 +63,9 @@ export const useLoadBookmarksFetch = (limit, offset) => {
         );
 
         return () => {
-            effectCleaned = true;
+            effectCleanedRef.current = true;
         };
     }, [restInfo, limit, offset]);
 
-    return [state.data, !state.dataFetched];
+    return [state.data, !state.dataFetched, reload];
 };


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7901 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->
Bookmarks are kept in other place than LoadedLocationsMapContext (which is modified after clicking "Remove from bookmarks", so bookmarks state has to be reload as well.

Bookmark children (BookmarksList and Browse) are rendered conditionally now on existing `restorationStateRef.current`.
This ref is set on first call of useEffect when `markedLocationId` is cleared to be ready to work with bookmarks module.
It serves as guardian - without it there's a moment, when `markedLocationId` has some garbage data from previous screen and this data is used inside bookmarks (in my case - in bookmarks list) and shows bugged screens therefore.

### How it worked:
1. `BookmarksTabModule` (BTM) was initialized, there was some previous data in `markedLocationId`
2. first render of BTM occured, its useEffect was called (see no5)
3. children of BTM were initialized (`BookmarksList` (BL) to be specific)
4. first render of BL occured, its useEffect was called. Both were using `markedLocationId` with previous data, because of it sth unexpected happened
5. useEffect of BTM (from no2) has executed, it properly cleared `markedLocationId`
6. BTM was rerendered after state changed (from no5), most notably BL was rerendered and called its useEffect, as `markedLocationId` has been changed - now everything SHOULD BE ok
7. But it's not, because as `markedLocationId` changed according to BL component, it loaded wrong data (it showed bookmarks twice in specific scenario)

### How it should work (and works after these changes):
1. `BookmarksTabModule` (BTM) was initialized, there was some previous data in `markedLocationId`
2. first render of BTM occured, its useEffect was called (see no5)
3. children of NTM **AREN'T** initialized, as they show based on `restorationStateRef` which is set inside useEffect (from no2)
4. useEffect of BTM (from no2) has executed, it properly cleared `markedLocationId` and set `restorationStateRef`
5. BTM was rerendered after state changed (from no4), as now `restorationStateRef` exists, BTM renders its children as well
6. `BookmarksList` (BL) was initialized, it was rendered at its useEffect was called, this time with empty `markedLocationId`
7. Now everything is ok, as there was no state change and useEffect was called only once, there was no duplicating bookmarks this time



#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
