### PR TITLE
IBX-7926: [Distraction free mode] Black screen when user exceeds RTE field input in distraction free mode

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -128,6 +128,7 @@
         left: 0;
         z-index: 1080;
         flex-direction: column;
+        flex-wrap: nowrap;
         width: 100vw;
         height: 100vh;
         margin-top: 0;


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7926 |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

<!-- Replace this comment with Pull Request description -->
By exceeding input we made data source div too big and header and input weren't able to fit into one column so it broke into two (in left there was header; in right, beyond screen there was data source), adding nowrap ensures it's always in one column.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
