### PR TITLE
IBX-7911: Replaced usage of magic getters for load subtree code paths

### DIFF
--- a/src/lib/EventListener/InContextTranslationListener.php
+++ b/src/lib/EventListener/InContextTranslationListener.php
@@ -59,7 +59,7 @@ final class InContextTranslationListener implements EventSubscriberInterface
             return;
         }
 
-        $inContextSetting = $this->userSettingService->getUserSetting('in_context_translation')->value;
+        $inContextSetting = $this->userSettingService->getUserSetting('in_context_translation')->getValue();
 
         if ($inContextSetting !== InContextTranslation::ENABLED_OPTION) {
             return;

--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -36,7 +36,7 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
         $location = $context->getLocation();
         $languageCode = $context->getLanguageCode();
 
-        if (empty(array_intersect($this->getRootLocationIds($siteAccess), $location->path))) {
+        if (empty(array_intersect($this->getRootLocationIds($siteAccess), $location->getPath()))) {
             return false;
         }
 

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -81,7 +81,7 @@ class SiteaccessResolver implements SiteaccessResolverInterface
     ): array {
         $contentInfo = $location->getContentInfo();
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $versionNo);
-        $languageCode = $languageCode ?? $contentInfo->mainLanguageCode;
+        $languageCode = $languageCode ?? $contentInfo->getMainLanguageCode();
 
         $eligibleSiteAccesses = [];
         /** @var \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess */

--- a/src/lib/Strategy/ContentTypeThumbnailStrategy.php
+++ b/src/lib/Strategy/ContentTypeThumbnailStrategy.php
@@ -34,7 +34,7 @@ final class ContentTypeThumbnailStrategy implements ThumbnailStrategy
         ?VersionInfo $versionInfo = null
     ): ?Thumbnail {
         try {
-            $contentTypeIcon = $this->contentTypeIconResolver->getContentTypeIcon($contentType->identifier);
+            $contentTypeIcon = $this->contentTypeIconResolver->getContentTypeIcon($contentType->getIdentifier());
 
             return new Thumbnail([
                 'resource' => $contentTypeIcon,

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -411,7 +411,7 @@ final class NodeFactory
             $previewableTranslations,
             '', // node name will be provided later by `supplyTranslatedContentName` method
             null !== $contentType ? $contentType->getIdentifier() : '',
-            !(null !== $contentType) || $contentType->isContainer(),
+            null === $contentType || $contentType->isContainer(),
             $location->isInvisible() || $location->isHidden(),
             $limit,
             $totalChildrenCount,

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -181,7 +181,7 @@ final class NodeFactory
             $contentTypeCriterion = new Criterion\ContentTypeIdentifier($this->getSetting('allowed_content_types'));
         }
 
-        if (empty($this->allowedContentTypes) && !empty($this->getSetting('ignored_content_types'))) {
+        if (!empty($this->getSetting('ignored_content_types'))) {
             $contentTypeCriterion = new Criterion\LogicalNot(
                 new Criterion\ContentTypeIdentifier($this->getSetting('ignored_content_types'))
             );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7911](https://issues.ibexa.co/browse/IBX-7911)
| **Requires** | ibexa/core#347, ibexa/user#76
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR replaces usages of magic getters with strict ones introduced via ibexa/core#347. See the ibexa/core PR for the reasoning behind this change. The scope of the changes is limited to code paths executed when calling `ContentTreeController::loadSubreeAction` controller.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [ ] Asked for a review.
