### PR TITLE
IBX-7808: Added possibility to define icons for content type group

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/ContentTypeGroup.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ContentTypeGroup.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\AdminUi\DependencyInjection\Configuration\Parser;
+
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\AbstractParser;
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for content type group icons.
+ *
+ * Example configuration:
+ *
+ * ```yaml
+ * ibexa:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          content_type_group:
+ *             foo:
+ *                thumbnail: '/assets/images/foo.svg'
+ *             bar:
+ *                thumbnail: '/assets/images/bar.svg'
+ * ```
+ */
+class ContentTypeGroup extends AbstractParser
+{
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode('content_type_group')
+                ->useAttributeAsKey('identifier')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('thumbnail')->defaultNull()->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param array<string,mixed> $scopeSettings
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings['content_type_group'])) {
+            return;
+        }
+
+        foreach ($scopeSettings['content_type_group'] as $identifier => $config) {
+            $contextualizer->setContextualParameter("content_type_group.$identifier", $currentScope, $config);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/ContentTypeGroup.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ContentTypeGroup.php
@@ -27,8 +27,10 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *             bar:
  *                thumbnail: '/assets/images/bar.svg'
  * ```
+ *
+ * @internal
  */
-class ContentTypeGroup extends AbstractParser
+final class ContentTypeGroup extends AbstractParser
 {
     public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {

--- a/src/bundle/IbexaAdminUiBundle.php
+++ b/src/bundle/IbexaAdminUiBundle.php
@@ -70,6 +70,7 @@ class IbexaAdminUiBundle extends Bundle
             new Parser\ContentTranslateView(),
             new Parser\AdminUiForms(),
             new Parser\ContentType(),
+            new Parser\ContentTypeGroup(),
             new Parser\SubtreePath(),
             new Parser\LimitationValueTemplates(),
             new Parser\Assets(),

--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -39,11 +39,11 @@ parameters:
     ibexa.site_access.config.default.content_type_group.default-config:
         thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#file'
     ibexa.site_access.config.default.content_type_group.content:
-        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#article'
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#content-type-content'
     ibexa.site_access.config.default.content_type_group.users:
-        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#user_group'
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#user-type'
     ibexa.site_access.config.default.content_type_group.media:
-        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#gallery'
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#media-type'
 
     ibexa.content_view.tabs.default_template: '@@ibexadesign/ui/tab/default.html.twig'
 

--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -36,6 +36,15 @@ parameters:
     ibexa.site_access.config.default.content_type.default-config:
         thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#file'
 
+    ibexa.site_access.config.default.content_type_group.default-config:
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#file'
+    ibexa.site_access.config.default.content_type_group.content:
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#article'
+    ibexa.site_access.config.default.content_type_group.users:
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#user_group'
+    ibexa.site_access.config.default.content_type_group.media:
+        thumbnail: '/bundles/ibexaadminui/img/ibexa-icons.svg#gallery'
+
     ibexa.content_view.tabs.default_template: '@@ibexadesign/ui/tab/default.html.twig'
 
     ibexa.multifile_upload.location.mappings: []

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -139,7 +139,7 @@ services:
         lazy: true
 
     Ibexa\AdminUi\UI\Service\IconResolver:
-        abstract:  true
+        abstract: true
 
     Ibexa\AdminUi\UI\Service\ContentTypeIconResolver:
         parent: Ibexa\AdminUi\UI\Service\IconResolver

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -138,7 +138,14 @@ services:
     Ibexa\Bundle\AdminUi\Templating\Twig\UserPreferencesGlobalExtension:
         lazy: true
 
-    Ibexa\AdminUi\UI\Service\ContentTypeIconResolver: ~
+    Ibexa\AdminUi\UI\Service\IconResolver:
+        abstract:  true
+
+    Ibexa\AdminUi\UI\Service\ContentTypeIconResolver:
+        parent: Ibexa\AdminUi\UI\Service\IconResolver
+
+    Ibexa\AdminUi\UI\Service\ContentTypeGroupIconResolver:
+        parent: Ibexa\AdminUi\UI\Service\IconResolver
 
     Ibexa\ContentForms\ConfigResolver\MaxUploadSize: ~
 

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -100,6 +100,8 @@ services:
 
     Ibexa\Bundle\AdminUi\Templating\Twig\ContentTypeIconExtension: ~
 
+    Ibexa\Bundle\AdminUi\Templating\Twig\ContentTypeGroupIconExtension: ~
+
     Ibexa\Bundle\AdminUi\Templating\Twig\EmbeddedItemEditFormExtension: ~
 
     Ibexa\AdminUi\UI\Config\Provider\UserContentTypes:

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
@@ -128,6 +128,7 @@
             headline: custom_results_headline ?? results_headline(pager.getNbResults()),
             head_cols: [
                 { has_checkbox: true },
+                { has_icon: true },
                 { content: 'content_type_group.view.list.column.identifier'|trans|desc('Name') },
                 { content: 'content_type_group.view.list.column.id'|trans|desc('ID') },
                 { content: 'content_type_group.view.list.column.content_types_count'|trans|desc('Number of content types') },

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
@@ -71,6 +71,16 @@
                 content: col_raw,
                 raw: true,
             }]) %}
+            {% set col_raw %}
+                <svg class="ibexa-icon ibexa-icon--small">
+                    <use xlink:href="{{ ibexa_content_type_group_icon(content_type_group.identifier) }}"></use>
+                </svg>
+            {% endset %}
+            {% set body_row_cols = body_row_cols|merge([{
+                has_icon: true,
+                content: col_raw,
+                raw: true,
+            }]) %}
 
             {% set col_raw %}
                 {% set view_url = path('ibexa.content_type_group.view', {

--- a/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
@@ -12,7 +12,7 @@ use Ibexa\AdminUi\UI\Service\ContentTypeGroupIconResolver;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-class ContentTypeGroupIconExtension extends AbstractExtension
+final class ContentTypeGroupIconExtension extends AbstractExtension
 {
     private ContentTypeGroupIconResolver $contentTypeGroupIconResolver;
 

--- a/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
@@ -12,6 +12,9 @@ use Ibexa\AdminUi\UI\Service\ContentTypeGroupIconResolver;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @internal
+ */
 final class ContentTypeGroupIconExtension extends AbstractExtension
 {
     private ContentTypeGroupIconResolver $contentTypeGroupIconResolver;

--- a/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\AdminUi\Templating\Twig;
+
+use Ibexa\AdminUi\UI\Service\ContentTypeGroupIconResolver;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class ContentTypeGroupIconExtension extends AbstractExtension
+{
+    private ContentTypeGroupIconResolver $contentTypeGroupIconResolver;
+
+    public function __construct(ContentTypeGroupIconResolver $contentTypeGroupIconResolver)
+    {
+        $this->contentTypeGroupIconResolver = $contentTypeGroupIconResolver;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ibexa_content_type_group_icon',
+                [$this->contentTypeGroupIconResolver, 'getContentTypeGroupIcon'],
+                [
+                    'is_safe' => ['html'],
+                ]
+            ),
+        ];
+    }
+}

--- a/src/bundle/Templating/Twig/ContentTypeIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeIconExtension.php
@@ -14,20 +14,13 @@ use Twig\TwigFunction;
 
 class ContentTypeIconExtension extends AbstractExtension
 {
-    /** @var \Ibexa\AdminUi\UI\Service\ContentTypeIconResolver */
-    private $contentTypeIconResolver;
+    private ContentTypeIconResolver $contentTypeIconResolver;
 
-    /**
-     * @param \Ibexa\AdminUi\UI\Service\ContentTypeIconResolver $contentTypeIconResolver
-     */
     public function __construct(ContentTypeIconResolver $contentTypeIconResolver)
     {
         $this->contentTypeIconResolver = $contentTypeIconResolver;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions(): array
     {
         return [

--- a/src/lib/UI/Service/ContentTypeGroupIconResolver.php
+++ b/src/lib/UI/Service/ContentTypeGroupIconResolver.php
@@ -8,20 +8,23 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\UI\Service;
 
-final class ContentTypeIconResolver extends IconResolver
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final class ContentTypeGroupIconResolver extends IconResolver
 {
-    private const PARAM_NAME_FORMAT = 'content_type.%s';
+    private const PARAM_NAME_FORMAT = 'content_type_group.%s';
 
     /**
-     * Returns path to content type icon.
+     * Returns path to content type group icon.
      *
      * Path is resolved based on configuration (ibexa.system.<SCOPE>.content_type.<IDENTIFIER>). If there isn't
      * corresponding entry for given content type, then path to default icon will be returned.
      */
-    public function getContentTypeIcon(string $identifier): string
+    public function getContentTypeGroupIcon(string $identifier): string
     {
+        $slugger = new AsciiSlugger();
+        $identifier = (string)$slugger->slug($identifier, '_')->lower();
+
         return $this->getIcon(self::PARAM_NAME_FORMAT, $identifier);
     }
 }
-
-class_alias(ContentTypeIconResolver::class, 'EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver');

--- a/src/lib/UI/Service/ContentTypeGroupIconResolver.php
+++ b/src/lib/UI/Service/ContentTypeGroupIconResolver.php
@@ -10,6 +10,9 @@ namespace Ibexa\AdminUi\UI\Service;
 
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
+/**
+ * @internal
+ */
 final class ContentTypeGroupIconResolver extends IconResolver
 {
     private const PARAM_NAME_FORMAT = 'content_type_group.%s';

--- a/src/lib/UI/Service/IconResolver.php
+++ b/src/lib/UI/Service/IconResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\UI\Service;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Symfony\Component\Asset\Packages;
+
+abstract class IconResolver
+{
+    protected const DEFAULT_IDENTIFIER = 'default-config';
+    protected const ICON_KEY = 'thumbnail';
+
+    private ConfigResolverInterface $configResolver;
+
+    protected Packages $packages;
+
+    public function __construct(ConfigResolverInterface $configResolver, Packages $packages)
+    {
+        $this->configResolver = $configResolver;
+        $this->packages = $packages;
+    }
+
+    protected function getIcon(string $format, string $identifier): string
+    {
+        $icon = $this->resolveIcon($format, $identifier);
+        $fragment = null;
+        if (strpos($icon, '#') !== false) {
+            [$icon, $fragment] = explode('#', $icon);
+        }
+
+        return $this->packages->getUrl($icon) . ($fragment ? '#' . $fragment : '');
+    }
+
+    private function resolveIcon(string $format, string $identifier): string
+    {
+        $parameterName = $this->getConfigParameterName($format, $identifier);
+        $defaultParameterName = $this->getConfigParameterName($format, static::DEFAULT_IDENTIFIER);
+
+        if ($this->configResolver->hasParameter($parameterName)) {
+            $config = $this->configResolver->getParameter($parameterName);
+        }
+
+        if ((empty($config) || empty($config[static::ICON_KEY])) && $this->configResolver->hasParameter($defaultParameterName)) {
+            $config = $this->configResolver->getParameter($defaultParameterName);
+        }
+
+        return $config[static::ICON_KEY] ?? '';
+    }
+
+    /**
+     * Return configuration parameter name for given content type identifier.
+     */
+    private function getConfigParameterName(string $format, string $identifier): string
+    {
+        return sprintf($format, $identifier);
+    }
+}

--- a/src/lib/UI/Service/IconResolver.php
+++ b/src/lib/UI/Service/IconResolver.php
@@ -57,7 +57,7 @@ abstract class IconResolver
     }
 
     /**
-     * Return configuration parameter name for given content type identifier.
+     * Returns configuration parameter name for given content type identifier.
      */
     private function getConfigParameterName(string $format, string $identifier): string
     {

--- a/src/lib/UI/Service/IconResolver.php
+++ b/src/lib/UI/Service/IconResolver.php
@@ -46,7 +46,10 @@ abstract class IconResolver
             $config = $this->configResolver->getParameter($parameterName);
         }
 
-        if ((empty($config) || empty($config[static::ICON_KEY])) && $this->configResolver->hasParameter($defaultParameterName)) {
+        if (
+            (empty($config) || empty($config[static::ICON_KEY]))
+            && $this->configResolver->hasParameter($defaultParameterName)
+        ) {
             $config = $this->configResolver->getParameter($defaultParameterName);
         }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-7808 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/icons/pull/43 - merged
- https://github.com/ibexa/admin-ui/pull/1230 - merged
- https://github.com/ibexa/dashboard/pull/121
- https://github.com/ibexa/corporate-account/pull/242
- https://github.com/ibexa/admin-ui/pull/1256


#### Description:
icons for all Content type groups should be added and used later in the Dashboard type to inform the user about the displayed element

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
