### PR TITLE
IBX-8059: Validate Content Type's Group in the Content Type view action

### DIFF
--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -697,7 +697,7 @@ class ContentTypeController extends Controller
         if (!in_array($group->id, $contentTypeGroupsIds, true)) {
             throw $this->createNotFoundException(
                 sprintf(
-                    '%s Content Type does not belong to %s Content Type Group.',
+                    '%s content type does not belong to %s content type group.',
                     $contentType->getName(),
                     $group->identifier,
                 ),

--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -692,6 +692,18 @@ class ContentTypeController extends Controller
         ContentType $contentType,
         Request $request
     ): Response {
+        $contentTypeGroups = $contentType->getContentTypeGroups();
+        $contentTypeGroupsIds = array_column($contentTypeGroups, 'id');
+        if (!in_array($group->id, $contentTypeGroupsIds, true)) {
+            throw $this->createNotFoundException(
+                sprintf(
+                    "%s Content Type does not belong to %s Content Type Group.",
+                    $contentType->getName(),
+                    $group->identifier,
+                ),
+            );
+        }
+
         $fieldDefinitionsByGroup = [];
         foreach ($contentType->fieldDefinitions as $fieldDefinition) {
             $fieldDefinitionsByGroup[$fieldDefinition->fieldGroup ?: 'content'][] = $fieldDefinition;

--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -697,7 +697,7 @@ class ContentTypeController extends Controller
         if (!in_array($group->id, $contentTypeGroupsIds, true)) {
             throw $this->createNotFoundException(
                 sprintf(
-                    "%s Content Type does not belong to %s Content Type Group.",
+                    '%s Content Type does not belong to %s Content Type Group.',
                     $contentType->getName(),
                     $group->identifier,
                 ),


### PR DESCRIPTION
| :ticket: Issue | IBX-8059|
|----------------|-----------|

#### Description:
A simple validation of Content Type Group was added to avoid loading certain Content Types inside non-matching Content Type Groups.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
