### PR TITLE
IBX-8058: Do not render leafs of contents with missing Content Types in UDW

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.leaf.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.leaf.js
@@ -28,6 +28,10 @@ const FinderLeaf = ({ location }) => {
     const containersOnly = useContext(ContainersOnlyContext);
     const allowedContentTypes = useContext(AllowedContentTypesContext);
     const contentTypeInfo = contentTypesMap[location.ContentInfo.Content.ContentType._href];
+    if (contentTypeInfo === undefined) {
+        return;
+    }
+
     const { isContainer } = contentTypeInfo;
     const isSelected = selectedLocations.some((selectedLocation) => selectedLocation.location.id === location.id);
     const isNotSelectable =


### PR DESCRIPTION
| :ticket: Issue | IBX-8058 |
|----------------|-----------|


#### Description:
As Dashboard Content Types is a `system` Content Type such Content Types won't be loaded properly in UDW because such Content Types are not loaded inside the `ContentTypesMapContext`. Moreover, such Content Types will be removed from UDW due to https://github.com/ibexa/dashboard/blob/main/src/lib/EventSubscriber/RemoveDashboardContentTypeSubscriber.php so we should probably skip loading them at all.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
