### PR TITLE
IBX-8058: Implemented subscriber that adds content type groups to `ContentTypes` UI config event

### DIFF
--- a/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
+++ b/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Event;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class AddContentTypeGroupToUIConfigEvent extends Event
+{
+    /** @var array<ContentTypeGroup> */
+    private array $contentTypeGroups;
+
+    /**
+     * @param array<ContentTypeGroup> $contentTypeGroups
+     */
+    public function __construct(array $contentTypeGroups) {
+        $this->contentTypeGroups = $contentTypeGroups;
+    }
+
+    /**
+     * @return array<ContentTypeGroup>
+     */
+    public function getContentTypeGroups(): array
+    {
+        return $this->contentTypeGroups;
+    }
+
+    public function addContentTypeGroup(
+        ContentTypeGroup $contentTypeGroup
+    ): void {
+        $this->contentTypeGroups[] = $contentTypeGroup;
+    }
+}

--- a/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
+++ b/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
@@ -19,7 +19,8 @@ final class AddContentTypeGroupToUIConfigEvent extends Event
     /**
      * @param array<ContentTypeGroup> $contentTypeGroups
      */
-    public function __construct(array $contentTypeGroups) {
+    public function __construct(array $contentTypeGroups)
+    {
         $this->contentTypeGroups = $contentTypeGroups;
     }
 

--- a/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
+++ b/src/lib/Event/AddContentTypeGroupToUIConfigEvent.php
@@ -13,11 +13,11 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class AddContentTypeGroupToUIConfigEvent extends Event
 {
-    /** @var array<ContentTypeGroup> */
+    /** @var array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup> */
     private array $contentTypeGroups;
 
     /**
-     * @param array<ContentTypeGroup> $contentTypeGroups
+     * @param array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup> $contentTypeGroups
      */
     public function __construct(array $contentTypeGroups)
     {
@@ -25,7 +25,7 @@ final class AddContentTypeGroupToUIConfigEvent extends Event
     }
 
     /**
-     * @return array<ContentTypeGroup>
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup>
      */
     public function getContentTypeGroups(): array
     {

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -76,8 +76,13 @@ class ContentTypes implements ProviderInterface
             $preferredLanguages
         );
 
+        $eventContentTypeGroups = [];
+        foreach ($loadedContentTypeGroups as $contentTypeGroup) {
+            $eventContentTypeGroups[] = $contentTypeGroup;
+        }
+
         /** @var \Ibexa\AdminUi\Event\AddContentTypeGroupToUIConfigEvent $event */
-        $event = $this->eventDispatcher->dispatch(new AddContentTypeGroupToUIConfigEvent($loadedContentTypeGroups));
+        $event = $this->eventDispatcher->dispatch(new AddContentTypeGroupToUIConfigEvent($eventContentTypeGroups));
 
         foreach ($event->getContentTypeGroups() as $contentTypeGroup) {
             $contentTypes = $this->contentTypeService->loadContentTypes(


### PR DESCRIPTION
| :ticket: Issue | IBX-8058|
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/dashboard/pull/122

#### Description:
A new event was added to allow adding additional content type groups to UI config event. 
The `getContentTypeData` method now allows to set `isHidden` parameter as well based on content type group's `system` property.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
