### PR TITLE
IBX-8280: Move previewableTranslations info to node extended info endpoint

### DIFF
--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -269,6 +269,17 @@ class ContentTreeController extends RestController
         Content $content,
         string $languageCode
     ): bool {
+        $canPreview = $this->permissionResolver->canUser(
+            'content',
+            'versionread',
+            $content,
+            [$location]
+        );
+
+        if (!$canPreview) {
+            return false;
+        }
+
         $versionNo = $content->getVersionInfo()->getVersionNo();
 
         $siteAccesses = $this->siteaccessResolver->getSiteAccessesListForLocation(
@@ -277,14 +288,7 @@ class ContentTreeController extends RestController
             $languageCode
         );
 
-        $canPreview = $this->permissionResolver->canUser(
-            'content',
-            'versionread',
-            $content,
-            [$location]
-        );
-
-        return $canPreview && !empty($siteAccesses);
+        return !empty($siteAccesses);
     }
 }
 

--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -13,12 +13,14 @@ use Ibexa\AdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode;
 use Ibexa\AdminUi\REST\Value\ContentTree\Node;
 use Ibexa\AdminUi\REST\Value\ContentTree\NodeExtendedInfo;
 use Ibexa\AdminUi\REST\Value\ContentTree\Root;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\AdminUi\Specification\ContentType\ContentTypeIsUser;
 use Ibexa\AdminUi\UI\Module\ContentTree\NodeFactory;
 use Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface;
 use Ibexa\Contracts\Core\Limitation\Target;
 use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
@@ -44,13 +46,16 @@ class ContentTreeController extends RestController
 
     private ConfigResolverInterface $configResolver;
 
+    private SiteaccessResolverInterface  $siteaccessResolver;
+
     public function __construct(
         LocationService $locationService,
         PermissionCheckerInterface $permissionChecker,
         LookupLimitationsTransformer $lookupLimitationsTransformer,
         NodeFactory $contentTreeNodeFactory,
         PermissionResolver $permissionResolver,
-        ConfigResolverInterface $configResolver
+        ConfigResolverInterface $configResolver,
+        SiteaccessResolverInterface $siteaccessResolver
     ) {
         $this->locationService = $locationService;
         $this->permissionChecker = $permissionChecker;
@@ -58,6 +63,7 @@ class ContentTreeController extends RestController
         $this->contentTreeNodeFactory = $contentTreeNodeFactory;
         $this->permissionResolver = $permissionResolver;
         $this->configResolver = $configResolver;
+        $this->siteaccessResolver = $siteaccessResolver;
     }
 
     /**
@@ -145,7 +151,15 @@ class ContentTreeController extends RestController
     {
         $locationPermissionRestrictions = $this->getLocationPermissionRestrictions($location);
 
-        return new NodeExtendedInfo($locationPermissionRestrictions);
+        $content = $location->getContent();
+        $versionInfo = $content->getVersionInfo();
+        $translations = $versionInfo->languageCodes;
+        $previewableTranslations = array_filter(
+            $translations,
+            fn (string $languageCode): bool => $this->isPreviewable($location, $content, $languageCode)
+        );
+
+        return new NodeExtendedInfo($locationPermissionRestrictions, $previewableTranslations);
     }
 
     /**
@@ -244,6 +258,33 @@ class ContentTreeController extends RestController
             $content,
             [$target]
         );
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    private function isPreviewable(
+        Location $location,
+        Content $content,
+        string $languageCode
+    ): bool {
+        $versionNo = $content->getVersionInfo()->getVersionNo();
+
+        $siteAccesses = $this->siteaccessResolver->getSiteAccessesListForLocation(
+            $location,
+            $versionNo,
+            $languageCode
+        );
+
+        $canPreview = $this->permissionResolver->canUser(
+            'content',
+            'versionread',
+            $content,
+            [$location]
+        );
+
+        return $canPreview && !empty($siteAccesses);
     }
 }
 

--- a/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
+++ b/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
@@ -113,11 +113,13 @@ abstract class AbstractPagerContentToDataMapper
             $this->userLanguagePreferenceProvider->getPreferredLanguages()
         );
 
+        $contentTypesArray = [...$contentTypes];
+
         foreach ($data as $idx => $item) {
             // get content type from bulk-loaded list or fallback to lazy loaded one if not present
             $contentTypeId = $item['contentTypeId'];
             /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType */
-            $contentType = $contentTypes[$contentTypeId] ?? $item['content']->getContentType();
+            $contentType = $contentTypesArray[$contentTypeId] ?? $item['content']->getContentType();
 
             $data[$idx]['type'] = $contentType->getName();
             unset($data[$idx]['content'], $data[$idx]['contentTypeId']);

--- a/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
+++ b/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
@@ -113,13 +113,11 @@ abstract class AbstractPagerContentToDataMapper
             $this->userLanguagePreferenceProvider->getPreferredLanguages()
         );
 
-        $contentTypesArray = [...$contentTypes];
-
         foreach ($data as $idx => $item) {
             // get content type from bulk-loaded list or fallback to lazy loaded one if not present
             $contentTypeId = $item['contentTypeId'];
             /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType */
-            $contentType = $contentTypesArray[$contentTypeId] ?? $item['content']->getContentType();
+            $contentType = $contentTypes[$contentTypeId] ?? $item['content']->getContentType();
 
             $data[$idx]['type'] = $contentType->getName();
             unset($data[$idx]['content'], $data[$idx]['contentTypeId']);

--- a/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Node.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Node.php
@@ -41,7 +41,7 @@ class Node extends ValueObjectVisitor
 
         $generator->valueElement('translations', implode(',', $data->translations));
 
-        $generator->valueElement('previewableTranslations', implode(',', $data->previewableTranslations));
+        $generator->valueElement('mainLanguageCode', $data->mainLanguageCode);
 
         $generator->startValueElement('name', $data->name);
         $generator->endValueElement('name');

--- a/src/lib/REST/Output/ValueObjectVisitor/ContentTree/NodeExtendedInfoVisitor.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/ContentTree/NodeExtendedInfoVisitor.php
@@ -30,8 +30,23 @@ final class NodeExtendedInfoVisitor extends ValueObjectVisitor
         $visitor->setStatus(Response::HTTP_OK);
 
         $this->buildPermissionNode($data->getPermissionRestrictions(), $generator);
+        $this->buildPreviewableTranslationsNode($data->getPreviewableTranslation(), $generator);
 
         $generator->endObjectElement(self::MAIN_ELEMENT);
+    }
+
+    /**
+     * @param string[]|null $previewableTranslation
+     */
+    protected function buildPreviewableTranslationsNode(
+        ?array $previewableTranslation,
+        Generator $generator
+    ): void {
+        if ($previewableTranslation === null) {
+            return;
+        }
+
+        $generator->valueElement('previewableTranslationsString', implode(',', $previewableTranslation));
     }
 
     /**

--- a/src/lib/REST/Output/ValueObjectVisitor/ContentTree/NodeExtendedInfoVisitor.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/ContentTree/NodeExtendedInfoVisitor.php
@@ -30,23 +30,25 @@ final class NodeExtendedInfoVisitor extends ValueObjectVisitor
         $visitor->setStatus(Response::HTTP_OK);
 
         $this->buildPermissionNode($data->getPermissionRestrictions(), $generator);
-        $this->buildPreviewableTranslationsNode($data->getPreviewableTranslation(), $generator);
+        $this->buildPreviewableTranslationsNode($data->getPreviewableTranslations(), $generator);
 
         $generator->endObjectElement(self::MAIN_ELEMENT);
     }
 
     /**
-     * @param string[]|null $previewableTranslation
+     * @param string[] $previewableTranslations
      */
     protected function buildPreviewableTranslationsNode(
-        ?array $previewableTranslation,
+        array $previewableTranslations,
         Generator $generator
     ): void {
-        if ($previewableTranslation === null) {
-            return;
+        $generator->startHashElement('previewableTranslations');
+        $generator->startList('values');
+        foreach ($previewableTranslations as $value) {
+            $generator->valueElement('value', $value);
         }
-
-        $generator->valueElement('previewableTranslationsString', implode(',', $previewableTranslation));
+        $generator->endList('values');
+        $generator->endHashElement('previewableTranslations');
     }
 
     /**

--- a/src/lib/REST/Value/ContentTree/Node.php
+++ b/src/lib/REST/Value/ContentTree/Node.php
@@ -26,9 +26,6 @@ class Node extends RestValue
     /** @var string[] */
     public array $translations;
 
-    /** @var string[] */
-    public array $previewableTranslations;
-
     /** @var string */
     public $name;
 
@@ -56,12 +53,13 @@ class Node extends RestValue
 
     public string $pathString;
 
+    public string $mainLanguageCode;
+
     /**
      * @param int $depth
      * @param int $locationId
      * @param int $contentId
      * @param string[] $translations
-     * @param string[] $previewableTranslations
      * @param string $name
      * @param string $contentTypeIdentifier
      * @param bool $isContainer
@@ -76,7 +74,6 @@ class Node extends RestValue
         int $contentId,
         int $versionNo,
         array $translations,
-        array $previewableTranslations,
         string $name,
         string $contentTypeIdentifier,
         bool $isContainer,
@@ -85,6 +82,7 @@ class Node extends RestValue
         int $totalChildrenCount,
         int $reverseRelationsCount,
         bool $isBookmarked,
+        string $mainLanguageCode,
         array $children = [],
         string $pathString = ''
     ) {
@@ -93,7 +91,6 @@ class Node extends RestValue
         $this->contentId = $contentId;
         $this->versionNo = $versionNo;
         $this->translations = $translations;
-        $this->previewableTranslations = $previewableTranslations;
         $this->name = $name;
         $this->isInvisible = $isInvisible;
         $this->contentTypeIdentifier = $contentTypeIdentifier;
@@ -104,6 +101,7 @@ class Node extends RestValue
         $this->isBookmarked = $isBookmarked;
         $this->children = $children;
         $this->pathString = $pathString;
+        $this->mainLanguageCode = $mainLanguageCode;
     }
 }
 

--- a/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
+++ b/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
@@ -28,13 +28,20 @@ final class NodeExtendedInfo extends RestValue
     /** @phpstan-var TPermissionRestrictions|null */
     private ?array $permissions;
 
+    /** @var string[]|null */
+    private ?array $previewableTranslation;
+
     /**
      * @phpstan-param TPermissionRestrictions|null $permissions
+     *
+     * @param string[]|null $previewableTranslation
      */
     public function __construct(
-        ?array $permissions = null
+        ?array $permissions = null,
+        ?array $previewableTranslation = null,
     ) {
         $this->permissions = $permissions;
+        $this->previewableTranslation = $previewableTranslation;
     }
 
     /**
@@ -43,5 +50,13 @@ final class NodeExtendedInfo extends RestValue
     public function getPermissionRestrictions(): ?array
     {
         return $this->permissions;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getPreviewableTranslation(): ?array
+    {
+        return $this->previewableTranslation;
     }
 }

--- a/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
+++ b/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
@@ -38,7 +38,7 @@ final class NodeExtendedInfo extends RestValue
      */
     public function __construct(
         ?array $permissions = null,
-        ?array $previewableTranslation = null,
+        ?array $previewableTranslation = null
     ) {
         $this->permissions = $permissions;
         $this->previewableTranslation = $previewableTranslation;

--- a/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
+++ b/src/lib/REST/Value/ContentTree/NodeExtendedInfo.php
@@ -28,20 +28,20 @@ final class NodeExtendedInfo extends RestValue
     /** @phpstan-var TPermissionRestrictions|null */
     private ?array $permissions;
 
-    /** @var string[]|null */
-    private ?array $previewableTranslation;
+    /** @var string[] */
+    private array $previewableTranslations;
 
     /**
      * @phpstan-param TPermissionRestrictions|null $permissions
      *
-     * @param string[]|null $previewableTranslation
+     * @param string[] $previewableTranslation
      */
     public function __construct(
         ?array $permissions = null,
-        ?array $previewableTranslation = null
+        array $previewableTranslation = []
     ) {
         $this->permissions = $permissions;
-        $this->previewableTranslation = $previewableTranslation;
+        $this->previewableTranslations = $previewableTranslation;
     }
 
     /**
@@ -53,10 +53,10 @@ final class NodeExtendedInfo extends RestValue
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
-    public function getPreviewableTranslation(): ?array
+    public function getPreviewableTranslations(): array
     {
-        return $this->previewableTranslation;
+        return $this->previewableTranslations;
     }
 }

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -392,7 +392,7 @@ final class NodeFactory
         }
 
         $translations = $versionInfo->getLanguageCodes();
-        $mainLanguageCode = $content->contentInfo->mainLanguageCode;
+        $mainLanguageCode = $versionInfo->getContentInfo()->getMainLanguageCode();
 
         return new Node(
             $depth,

--- a/tests/integration/REST/GetContentTreeExtendedInfoTest.php
+++ b/tests/integration/REST/GetContentTreeExtendedInfoTest.php
@@ -35,6 +35,7 @@ final class GetContentTreeExtendedInfoTest extends BaseAdminUiRestWebTestCase
                 [
                     'user/login' => [],
                     'content/read' => [],
+                    'content/versionread' => [],
                     'content/create' => [
                         new ContentTypeLimitation(
                             ['limitationValues' => ['1', '16']]

--- a/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.json
+++ b/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.json
@@ -54,14 +54,24 @@
                         ]
                     }
                 },
-                "previewableTranslationsString": {
-                    "type": "string"
-                }
+                "previewableTranslations": {
+                    "type": "object",
+                    "properties": {
+                      "values": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                      }
+                    }
+                  }
             },
             "required": [
                 "_media-type",
                 "permissions",
-                "previewableTranslationsString"
+                "previewableTranslations"
             ]
         }
     },

--- a/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.json
+++ b/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.json
@@ -53,11 +53,15 @@
                             "hasAccess"
                         ]
                     }
+                },
+                "previewableTranslationsString": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_media-type",
-                "permissions"
+                "permissions",
+                "previewableTranslationsString"
             ]
         }
     },

--- a/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.xsd
+++ b/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.xsd
@@ -26,6 +26,7 @@
                         <xs:attribute name="name" type="xs:string" use="required" />
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="previewableTranslationsString" type="xs:string" />
             </xs:sequence>
             <xs:attribute name="media-type" type="xs:string" use="required" />
         </xs:complexType>

--- a/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.xsd
+++ b/tests/integration/Resources/REST/Schemas/ContentTreeNodeExtendedInfo.xsd
@@ -26,7 +26,13 @@
                         <xs:attribute name="name" type="xs:string" use="required" />
                     </xs:complexType>
                 </xs:element>
-                <xs:element name="previewableTranslationsString" type="xs:string" />
+                <xs:element name="previewableTranslations">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" name="value" type="xs:string" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
             </xs:sequence>
             <xs:attribute name="media-type" type="xs:string" use="required" />
         </xs:complexType>

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
@@ -37,7 +37,7 @@
             }
         ],
         "previewableTranslations": {
-            "values": []
+            "values": ["eng-GB"]
         }
     }
 }

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
@@ -35,6 +35,7 @@
                 "_name": "hide",
                 "hasAccess": false
             }
-        ]
+        ],
+        "previewableTranslationsString": ""
     }
 }

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.json
@@ -36,6 +36,8 @@
                 "hasAccess": false
             }
         ],
-        "previewableTranslationsString": ""
+        "previewableTranslations": {
+            "values": []
+        }
     }
 }

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
@@ -23,5 +23,7 @@
     <function name="hide">
         <hasAccess>false</hasAccess>
     </function>
-    <previewableTranslations />
+    <previewableTranslations>
+        <value>eng-GB</value>
+    </previewableTranslations>
 </ContentTreeNodeExtendedInfo>

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
@@ -23,4 +23,5 @@
     <function name="hide">
         <hasAccess>false</hasAccess>
     </function>
+    <previewableTranslationsString />
 </ContentTreeNodeExtendedInfo>

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeNodeExtendedInfo.xml
@@ -23,5 +23,5 @@
     <function name="hide">
         <hasAccess>false</hasAccess>
     </function>
-    <previewableTranslationsString />
+    <previewableTranslations />
 </ContentTreeNodeExtendedInfo>

--- a/tests/integration/Resources/REST/Snapshots/ContentTreeRoot.json
+++ b/tests/integration/Resources/REST/Snapshots/ContentTreeRoot.json
@@ -5,10 +5,10 @@
       {
         "_media-type": "application\/vnd.ibexa.api.ContentTreeNode+json",
         "locationId": 2,
+        "mainLanguageCode": "eng-GB",
         "contentId": 57,
         "versionNo": 1,
         "translations": "eng-GB",
-        "previewableTranslations": "eng-GB",
         "name": "Home",
         "pathString": "/1/2/",
         "contentTypeIdentifier": "landing_page",
@@ -22,10 +22,10 @@
           {
             "_media-type": "application\/vnd.ibexa.api.ContentTreeNode+json",
             "locationId": 60,
+            "mainLanguageCode": "eng-GB",
             "contentId": 58,
             "versionNo": 1,
             "translations": "eng-GB",
-            "previewableTranslations": "eng-GB",
             "name": "Contact Us",
             "pathString": "/1/2/60/",
             "contentTypeIdentifier": "feedback_form",


### PR DESCRIPTION
| :ticket: Issue | IBX-8280, solves also IBX-7911 |
|----------------|-----------|

 
#### Related PRs: 
- https://github.com/ibexa/content-tree/pull/81
- https://github.com/ibexa/image-picker/pull/62

#### Needed for IBX-7911
- https://github.com/ibexa/admin-ui/pull/1212
- https://github.com/ibexa/site-factory/pull/94
- https://github.com/ibexa/user/pull/76
- https://github.com/ibexa/core/pull/347
- https://github.com/ibexa/product-catalog/pull/1150
- https://github.com/ibexa/dashboard/pull/119


#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:

All PRs should be tested together, there will be a combo branch for 2 admin-ui PRs.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
