### PR TITLE
IBX-8195: Content items are displayed multiple times in UDW after adding item to bookmarks

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_finder.branch.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_finder.branch.scss
@@ -69,6 +69,6 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        margin-top: calculateRem(50px);
+        margin: calculateRem(50px) 0;
     }
 }

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
@@ -39,14 +39,14 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
     let resizeStartPositionX = 0;
     let branchCurrentWidth = 0;
     const loadMore = ({ target }) => {
-        const areAllItemsLoaded = locationData.subitems.length >= loadedLocations.totalCount;
+        const areAllItemsLoaded = locationData.subitems.length >= locationData.totalCount;
         const isOffsetReached = target.scrollHeight - target.clientHeight - target.scrollTop < SCROLL_OFFSET;
 
         if (areAllItemsLoaded || !isOffsetReached || isLoading) {
             return;
         }
 
-        setOffset(Math.min(offset + itemsPerPage, loadedLocations.totalCount));
+        setOffset(Math.min(offset + itemsPerPage, locationData.totalCount));
     };
     const expandBranch = () => {
         dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data: { ...locationData, collapsed: false } });

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
@@ -27,7 +27,6 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
     const [sortOrder] = useContext(SortOrderContext);
     const contentTypesMap = useContext(ContentTypesMapContext);
     const [markedLocationId] = useContext(MarkedLocationIdContext);
-    const totalCount = useRef(0);
     const branchRef = useRef(null);
     const sortingOptions = SORTING_OPTIONS.find((option) => option.sortClause === sorting);
     const [loadedLocations, isLoading] = useFindLocationsByParentLocationIdFetch(
@@ -40,14 +39,14 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
     let resizeStartPositionX = 0;
     let branchCurrentWidth = 0;
     const loadMore = ({ target }) => {
-        const areAllItemsLoaded = locationData.subitems.length >= totalCount.current;
+        const areAllItemsLoaded = locationData.subitems.length >= loadedLocations.totalCount;
         const isOffsetReached = target.scrollHeight - target.clientHeight - target.scrollTop < SCROLL_OFFSET;
 
         if (areAllItemsLoaded || !isOffsetReached || isLoading) {
             return;
         }
 
-        setOffset(offset + itemsPerPage);
+        setOffset(Math.min(offset + itemsPerPage, loadedLocations.totalCount));
     };
     const expandBranch = () => {
         dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data: { ...locationData, collapsed: false } });
@@ -113,11 +112,11 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
         return (
             <Fragment>
                 <div className="c-finder-branch__items-wrapper" onScroll={loadMore} style={{ width }}>
-                    {renderLoadingSpinner()}
-
                     {subitems.map(({ location }) => (
                         <FinderLeaf key={location.id} location={location} />
                     ))}
+
+                    {renderLoadingSpinner()}
                 </div>
                 {renderDragHandler()}
             </Fragment>
@@ -137,14 +136,12 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
 
     useEffect(() => {
         setOffset(0);
-        totalCount.current = 0;
     }, [sortingOptions.sortClause, sortOrder]);
 
     useEffect(() => {
         if (loadedLocations.subitems) {
             const data = { ...locationData, ...loadedLocations, subitems: [...locationData.subitems, ...loadedLocations.subitems] };
 
-            totalCount.current = loadedLocations.totalCount;
             dispatchLoadedLocationsAction({ type: 'UPDATE_LOCATIONS', data });
         }
     }, [loadedLocations, dispatchLoadedLocationsAction, isLoading]);

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
@@ -169,6 +169,7 @@ FinderBranch.propTypes = {
         parentLocationId: PropTypes.number.isRequired,
         subitems: PropTypes.array.isRequired,
         location: PropTypes.object.isRequired,
+        totalCount: PropTypes.number.isRequired,
         collapsed: PropTypes.bool,
     }).isRequired,
     itemsPerPage: PropTypes.number,

--- a/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useFindLocationsByParentLocationIdFetch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useFindLocationsByParentLocationIdFetch.js
@@ -66,17 +66,15 @@ export const useFindLocationsByParentLocationIdFetch = (locationData, { sortClau
 
         let effectCleaned = false;
 
-        if (state.dataFetched) {
-            if (
-                !locationData.parentLocationId ||
-                locationData.collapsed ||
-                locationData.subitems.length >= locationData.totalCount ||
-                locationData.subitems.length >= limit + offset
-            ) {
-                dispatch({ type: 'FETCH_END', data: {} });
+        if (
+            !locationData.parentLocationId ||
+            locationData.collapsed ||
+            locationData.subitems.length >= locationData.totalCount ||
+            locationData.subitems.length >= limit + offset
+        ) {
+            dispatch({ type: 'FETCH_END', data: state.data });
 
-                return;
-            }
+            return;
         }
 
         dispatch({ type: 'FETCH_START' });


### PR DESCRIPTION
| :ticket: Issue | https://issues.ibexa.co/browse/IBX-8195 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->
Test case with loading more items (so > 50 items) thoroughly, I had some problems with it (infinite loading of items - after one batch was loaded, it tried to load next one (non-existing) by showing loader. After my fixes I couldn't reproduce these unnecessary loaders, so it should be fixed, but maybe there's still some corner case.
Also - this PR modifies solution from this issues https://issues.ibexa.co/browse/IBX-7839 as that one introduced IBX-8195 bug, so probably should be tested as well (checked that as well, looked that it works as well)

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
