### PR TITLE
IBX-8163: Upload modal files display too short file names

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_progress.bar.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_progress.bar.scss
@@ -1,7 +1,7 @@
 .c-progress-bar {
     width: 100%;
     display: flex;
-    justify-content: space-between;
+    justify-content: right;
     align-items: center;
 
     &__value {
@@ -9,8 +9,9 @@
         border-radius: calculateRem(4px);
         transition: width 0.2s linear;
         height: calculateRem(8px);
-        width: calculateRem(176px);
+        width: calculateRem(100px);
         position: relative;
+        margin-right: calculateRem(8px);
 
         &::after {
             content: '';

--- a/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_upload.item.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_upload.item.scss
@@ -46,7 +46,7 @@
 
     &__meta {
         padding: 0 calculateRem(8px);
-        max-width: 25vw;
+        max-width: calculateRem(450px);
         height: calculateRem(48px);
         display: flex;
         justify-content: center;
@@ -62,6 +62,7 @@
     }
 
     &__size {
+        min-width: calculateRem(80px);
         color: $ibexa-color-dark-400;
         font-size: $ibexa-text-font-size-small;
     }

--- a/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_upload.item.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/muti-file-upload/_upload.item.scss
@@ -55,7 +55,7 @@
 
     &__name {
         margin-right: calculateRem(8px);
-        max-width: calculateRem(172px);
+        max-width: calculateRem(350px);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
| :ticket: Issue | IBX-8163 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Expanded place for uploaded files name (MFU)

<img width="860" alt="Zrzut ekranu 2024-06-18 o 13 02 38" src="https://github.com/ibexa/admin-ui/assets/24355391/f581b77c-c0aa-467f-8c33-2807e8fae8d1">
<img width="836" alt="Zrzut ekranu 2024-06-18 o 13 03 21" src="https://github.com/ibexa/admin-ui/assets/24355391/2de866ed-821c-4f98-ad5a-6cdf324ab175">

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
