### PR TITLE
IBX-8399: Moved RepositoryConfigurationProvider to Repository layer 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12482,16 +12482,6 @@ parameters:
 			path: tests/lib/Resolver/IconPathResolverTest.php
 
 		-
-			message: "#^Call to an undefined method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:expects\\(\\)\\.$#"
-			count: 6
-			path: tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
-
-		-
-			message: "#^Call to an undefined method Ibexa\\\\Contracts\\\\Core\\\\SiteAccess\\\\ConfigResolverInterface\\:\\:expects\\(\\)\\.$#"
-			count: 8
-			path: tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\AdminUi\\\\Siteaccess\\\\AdminSiteaccessPreviewVoterTest\\:\\:dataProviderForSiteaccessPreviewVoterContext\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php

--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -8,20 +8,18 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Siteaccess;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
 abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    protected $configResolver;
+    protected ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    protected $repositoryConfigurationProvider;
+    protected RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider
     ) {
         $this->configResolver = $configResolver;
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\UI\Config\Provider\Module;
 
-use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
 use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
@@ -164,16 +163,6 @@ final class DamWidget implements ProviderInterface
     {
         $config = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
-        $searchEngineAlias = $config['search']['engine'] ?? null;
-        if (null === $searchEngineAlias) {
-            throw new InvalidSearchEngine(
-                sprintf(
-                    'Ibexa "%s" Repository has no Search Engine configured',
-                    $this->repositoryConfigurationProvider->getCurrentRepositoryAlias()
-                )
-            );
-        }
-
-        return $searchEngineAlias !== 'legacy';
+        return $config['search']['engine'] !== 'legacy';
     }
 }

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\UI\Config\Provider\Module;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\NameSchema\SchemaIdentifierExtractorInterface;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -56,7 +56,7 @@ final class DamWidget implements ProviderInterface
 
     private ContentTypeService $contentTypeService;
 
-    private RepositoryConfigurationProvider $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     private SchemaIdentifierExtractorInterface $schemaIdentifierExtractor;
 
@@ -66,7 +66,7 @@ final class DamWidget implements ProviderInterface
     public function __construct(
         array $config,
         ContentTypeService $contentTypeService,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         SchemaIdentifierExtractorInterface $schemaIdentifierExtractor
     ) {
         $this->config = $config;

--- a/tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
+++ b/tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
@@ -10,7 +10,7 @@ namespace Ibexa\Tests\AdminUi\Siteaccess;
 
 use Ibexa\AdminUi\Siteaccess\AdminSiteaccessPreviewVoter;
 use Ibexa\AdminUi\Siteaccess\SiteaccessPreviewVoterContext;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Repository\Values\Content\Location;
@@ -21,19 +21,18 @@ class AdminSiteaccessPreviewVoterTest extends TestCase
 {
     private const LANGUAGE_CODE = 'eng-GB';
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    /** @var \Ibexa\AdminUi\Siteaccess\AdminSiteaccessPreviewVoter */
-    private $adminSiteaccessPreviewVoter;
+    private AdminSiteaccessPreviewVoter $adminSiteaccessPreviewVoter;
 
     public function setUp(): void
     {
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
-        $this->repositoryConfigurationProvider = $this->createMock(RepositoryConfigurationProvider::class);
+        $this->repositoryConfigurationProvider = $this->createMock(RepositoryConfigurationProviderInterface::class);
 
         $this->adminSiteaccessPreviewVoter = new AdminSiteaccessPreviewVoter(
             $this->configResolver,

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\Tests\AdminUi\UI\Config\Provider\Module;
 
 use Ibexa\AdminUi\UI\Config\Provider\Module\DamWidget;
-use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
 use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
@@ -144,20 +143,6 @@ final class DamWidgetTest extends TestCase
         );
     }
 
-    public function testGetConfigThrowInvalidSearchEngine(): void
-    {
-        $repositoryAlias = 'foo';
-        $this->mockRepositoryConfigurationProviderGetRepositoryConfig(
-            ['alias' => $repositoryAlias]
-        );
-        $this->mockRepositoryConfigurationProviderGetCurrentRepositoryAlias($repositoryAlias);
-
-        $this->expectException(InvalidSearchEngine::class);
-        $this->expectExceptionMessage('Ibexa "foo" Repository has no Search Engine configured');
-
-        $this->provider->getConfig();
-    }
-
     /**
      * @return iterable<array{
      *     TDamWidgetConfig,
@@ -281,12 +266,5 @@ final class DamWidgetTest extends TestCase
         $this->repositoryConfigurationProvider
             ->method('getRepositoryConfig')
             ->willReturn($config);
-    }
-
-    private function mockRepositoryConfigurationProviderGetCurrentRepositoryAlias(string $repositoryAlias): void
-    {
-        $this->repositoryConfigurationProvider
-            ->method('getCurrentRepositoryAlias')
-            ->willReturn($repositoryAlias);
     }
 }

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -10,8 +10,8 @@ namespace Ibexa\Tests\AdminUi\UI\Config\Provider\Module;
 
 use Ibexa\AdminUi\UI\Config\Provider\Module\DamWidget;
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Contracts\AdminUi\UI\Config\ProviderInterface;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\NameSchema\SchemaIdentifierExtractorInterface;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -81,8 +81,8 @@ final class DamWidgetTest extends TestCase
 
     private ProviderInterface $provider;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider&\PHPUnit\Framework\MockObject\MockObject */
-    private RepositoryConfigurationProvider $repositoryConfigurationProvider;
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService&\PHPUnit\Framework\MockObject\MockObject */
     private ContentTypeService $contentTypeService;
@@ -92,7 +92,7 @@ final class DamWidgetTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repositoryConfigurationProvider = $this->createMock(RepositoryConfigurationProvider::class);
+        $this->repositoryConfigurationProvider = $this->createMock(RepositoryConfigurationProviderInterface::class);
         $this->contentTypeService = $this->createMock(ContentTypeService::class);
         $this->schemaIdentifierExtractor = $this->createMock(SchemaIdentifierExtractorInterface::class);
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8399  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Fixed failing tests due to changed introduced in IBX-8399. For example: 

```
/home/runner/work/admin-ui/admin-ui/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php:95

8) Ibexa\Tests\AdminUi\UI\Config\Provider\Module\DamWidgetTest::testGetConfigThrowInvalidSearchEngine
PHPUnit\Framework\MockObject\ClassIsFinalException: Class "Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider" is declared "final" and cannot be doubled
```


#### For QA:

N/A

#### Documentation:

N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
