### PR TITLE
IBX-8477: Removed check whether the draft belongs to the user

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
@@ -107,19 +107,16 @@
                                 {% block action_btns_content %}
                                     {{ custom_actions_column }}
                                     {% if is_draft_conflict %}
-                                        {% set edit_draft_disabled = (version.author and version.author.id != ibexa_admin_ui_config.user.user.id) %}
                                         <a
                                             href="{{ edit_url }}"
-                                            class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text {% if edit_draft_disabled %}ibexa-btn--prevented{% endif %}"
+                                            class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text"
                                             title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit') }}"
-                                            {% if edit_draft_disabled %}disabled{% endif %}
                                         >
                                             <svg class="ibexa-icon ibexa-icon--small ibexa-icon--edit">
                                                 <use xlink:href="{{ ibexa_icon_path('edit') }}"></use>
                                             </svg>
                                         </a>
                                     {% elseif is_draft %}
-                                        {% set edit_draft_disabled = (version.author and version.author.id != ibexa_admin_ui_config.user.user.id) %}
                                         <button
                                             data-content-draft-edit-url="{{ edit_url }}"
                                             data-version-has-conflict-url="{{ path('ibexa.version.has_no_conflict', {
@@ -129,9 +126,8 @@
                                             }) }}"
                                             data-content-id="{{ version.contentInfo.id }}"
                                             data-language-code="{{ version.initialLanguageCode }}"
-                                            class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text mx-2 ibexa-btn--content-draft-edit {% if edit_draft_disabled %}ibexa-btn--prevented{% endif %}"
+                                            class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text mx-2 ibexa-btn--content-draft-edit"
                                             title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit') }}"
-                                            {% if edit_draft_disabled %}disabled{% endif %}
                                         >
                                             <svg class="ibexa-icon ibexa-icon--small ibexa-icon--edit">
                                                 <use xlink:href="{{ ibexa_icon_path('edit') }}"></use>


### PR DESCRIPTION
| :ticket: Issue | IBX-8477 |
|----------------|-----------|

Only in twig it was checked whether the draft belonged to the user and based on this it turned off the edit button or not. anyone with permission to edit content can edit another user's draft (blocking this is a mechanism that is being implemented (or at least was))

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
