### PR TITLE
IBX-8602: Always load root location using `sudo` in the `ContentTreeController`

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/bundle/Controller/BookmarkController.php
 
 		-
-			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
-			count: 1
-			path: src/bundle/Controller/Content/ContentTreeController.php
-
-		-
 			message: "#^Parameter \\#1 \\$stack of function array_shift expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
 			count: 1
 			path: src/bundle/Controller/Content/VersionDraftConflictController.php

--- a/phpstan-baseline-8.0.neon
+++ b/phpstan-baseline-8.0.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
-			count: 1
-			path: src/bundle/Controller/Content/ContentTreeController.php
-
-		-
 			message: "#^Parameter \\#1 \\$array of function array_shift expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
 			count: 1
 			path: src/bundle/Controller/Content/VersionDraftConflictController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8621,6 +8621,11 @@ parameters:
 			path: src/lib/Siteaccess/SiteaccessResolver.php
 
 		-
+			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, iterable\\<Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\> given\\.$#"
+			count: 1
+			path: src/lib/Siteaccess/SiteaccessResolver.php
+
+		-
 			message: "#^Property Ibexa\\\\AdminUi\\\\Siteaccess\\\\SiteaccessResolver\\:\\:\\$siteAccessPreviewVoters \\(array\\<Ibexa\\\\AdminUi\\\\Siteaccess\\\\SiteaccessPreviewVoterInterface\\>\\) does not accept iterable\\.$#"
 			count: 1
 			path: src/lib/Siteaccess/SiteaccessResolver.php
@@ -10910,6 +10915,11 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\AdminUi\\\\Form\\\\Data\\\\ContentTranslationDataTest\\:\\:testAddFieldData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Form/Data/ContentTranslationDataTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, iterable\\<string, Ibexa\\\\AdminUi\\\\Form\\\\Data\\\\FieldDefinitionData\\> given\\.$#"
+			count: 1
+			path: tests/lib/Form/Data/ContentTypeDataTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\AdminUi\\\\Form\\\\Data\\\\FieldDefinitionDataTest\\:\\:testFieldDefinition\\(\\) has no return type specified\\.$#"

--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -131,7 +131,7 @@ class ContentTreeController extends RestController
 
         // Load rest of locations with proper permission checks
         if ($locationIdList !== []) {
-            $locations = array_merge($locations, (array)$this->locationService->loadLocationList($locationIdList));
+            $locations += (array)$this->locationService->loadLocationList($locationIdList);
         }
 
         $elements = [];

--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -122,16 +122,20 @@ class ContentTreeController extends RestController
 
         // Always load root location using `sudo`
         if (in_array(self::ROOT_LOCATION_ID, $locationIdList, true)) {
-            $locations = $this->repository->sudo(function (): iterable {
-                return (array)$this->locationService->loadLocationList([self::ROOT_LOCATION_ID]);
-            });
+            $rootLocation = $this->repository->sudo(
+                fn (): Location => $this->locationService->loadLocation(self::ROOT_LOCATION_ID)
+            );
+            $locations[$rootLocation->getId()] = $rootLocation;
 
             $locationIdList = array_diff($locationIdList, [self::ROOT_LOCATION_ID]);
         }
 
         // Load rest of locations with proper permission checks
         if ($locationIdList !== []) {
-            $locations += (array)$this->locationService->loadLocationList($locationIdList);
+            $loadedLocations = $this->locationService->loadLocationList($locationIdList);
+            foreach ($loadedLocations as $location) {
+                $locations[$location->getId()] = $location;
+            }
         }
 
         $elements = [];


### PR DESCRIPTION
| :ticket: Issue | IBX-8602|
|----------------|-----------|

#### Description:
The issue stems from the fact that we are loading the location of ID = `1`. If a user has some limitations on locations or subtrees, even if he selected all of them he won't be able to load the root location of ID = `1`. Another limitation is that we cannot select the root location in limitations.

The following PR proposes to always load the root location using `sudo` and the rest of them using a standard call with policies validation. 

If we won't go with this solution we have probably one option and that is to load multiple tree roots in the frontend simultaneously, it probably requires a lot of work.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
