### PR TITLE
IBX-8588: [Image Picker] Clicking edit button on multi-file upload modal causes an error

### DIFF
--- a/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.item.component.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.item.component.js
@@ -377,7 +377,7 @@ export default class UploadItemComponent extends Component {
         const { uploaded, failed, struct } = this.state;
         const canEdit = uploaded && !failed;
 
-        if (!canEdit || this.isExternalInstance) {
+        if (!canEdit || this.isExternalInstance || !this.props.enableUploadedItemEdit) {
             return null;
         }
 
@@ -496,6 +496,7 @@ UploadItemComponent.propTypes = {
     removeItemsToUpload: PropTypes.func,
     onCreateError: PropTypes.func,
     errorMsgs: PropTypes.array,
+    enableUploadedItemEdit: PropTypes.bool,
 };
 
 UploadItemComponent.defaultProps = {
@@ -513,4 +514,5 @@ UploadItemComponent.defaultProps = {
     removeItemsToUpload: () => {},
     onCreateError: () => {},
     errorMsgs: [],
+    enableUploadedItemEdit: true,
 };

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.list.component.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.list.component.js
@@ -80,7 +80,6 @@ export default class UploadListComponent extends Component {
             isUploaded: true,
             deleteFile: this.props.deleteFile,
             onAfterDelete: this.handleAfterDelete.bind(this),
-            enableUploadedItemEdit: this.props.enableUploadedItemEdit,
         });
     }
 
@@ -102,6 +101,7 @@ export default class UploadListComponent extends Component {
             contentCreatePermissionsConfig,
             contentTypesMap,
             currentLanguage,
+            enableUploadedItemEdit: this.props.enableUploadedItemEdit,
             ...customAttrs,
         };
 

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.list.component.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-list/upload.list.component.js
@@ -80,6 +80,7 @@ export default class UploadListComponent extends Component {
             isUploaded: true,
             deleteFile: this.props.deleteFile,
             onAfterDelete: this.handleAfterDelete.bind(this),
+            enableUploadedItemEdit: this.props.enableUploadedItemEdit,
         });
     }
 
@@ -148,10 +149,12 @@ UploadListComponent.propTypes = {
     currentLanguage: PropTypes.string,
     removeItemsToUpload: PropTypes.func.isRequired,
     onAfterDelete: PropTypes.func,
+    enableUploadedItemEdit: PropTypes.bool,
 };
 
 UploadListComponent.defaultProps = {
     itemsToUpload: [],
     currentLanguage: '',
     onAfterDelete: () => {},
+    enableUploadedItemEdit: true,
 };

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-popup/upload.popup.component.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/components/upload-popup/upload.popup.component.js
@@ -81,6 +81,7 @@ export default class UploadPopupModule extends Component {
             removeItemsToUpload,
             preventDefaultAction,
             processUploadedFiles,
+            enableUploadedItemEdit,
         } = this.props;
         const tooltipAttrs = {
             subtitle,
@@ -111,6 +112,7 @@ export default class UploadPopupModule extends Component {
             onAfterDelete,
             itemsToUpload,
             removeItemsToUpload,
+            enableUploadedItemEdit,
         };
 
         return (
@@ -163,6 +165,7 @@ UploadPopupModule.propTypes = {
     onConfirm: PropTypes.func,
     onClose: PropTypes.func,
     onAfterDelete: PropTypes.func,
+    enableUploadedItemEdit: PropTypes.bool,
 };
 
 UploadPopupModule.defaultProps = {
@@ -175,4 +178,5 @@ UploadPopupModule.defaultProps = {
     onConfirm: () => {},
     onClose: () => {},
     onAfterDelete: () => {},
+    enableUploadedItemEdit: true,
 };

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/multi.file.upload.module.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/multi.file.upload.module.js
@@ -225,6 +225,7 @@ export default class MultiFileUploadModule extends Component {
             addItemsToUpload: this.addItemsToUpload,
             removeItemsToUpload: this.removeItemsToUpload,
             contentCreatePermissionsConfig: this.props.contentCreatePermissionsConfig,
+            enableUploadedItemEdit: this.props.triggerId === SUBITEMS_TRIGGER_ID,
         };
 
         return createPortal(<UploadPopupComponent {...attrs} />, this.configRootNode);


### PR DESCRIPTION
| :ticket: Issue | IBX-8588 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Error occurs because we don’t have form for edit like in subitems. After discuss with UX/UI team we decided to remove edit button for image picker because we will implement edit in different way in https://issues.ibexa.co/browse/IBX-8110

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
