### PR TITLE
Fixed duplicated CSS class in field_definitions.html.twig

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_definitions.html.twig
@@ -75,7 +75,7 @@
     <div class="ibexa-content-type-edit__add-field-definitions-group">
         <button
             type="button"
-            class="ibexa-content-type-edit__add-field-definitions-group-btn btn ibexa-btn ibexa-btn ibexa-btn--info"
+            class="ibexa-content-type-edit__add-field-definitions-group-btn btn ibexa-btn ibexa-btn--info"
             data-is-disabled="{{ is_field_definitions_draggable ? 'false' : 'true' }}"
         >
             <svg class="ibexa-icon ibexa-icon--small">


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixed duplicated `ibexa-btn` class in field_definitions.html.twig

#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
