### PR TITLE
IBX-8601: Added extension point allowing to inject components into content create/edit form header

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -14,7 +14,7 @@
         'content_create_struct': content_create_struct
     }) %}
 
-    {% include '@ibexadesign/ui/edit_header.html.twig' with {
+    {% embed '@ibexadesign/ui/edit_header.html.twig' with {
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
         icon_name: content_type.name,
@@ -25,6 +25,14 @@
         })|desc('Location: %location% Translation: %language%' ),
         context_actions: knp_menu_render(content_create_sidebar_right, {'template': '@ibexadesign/ui/menu/context_menu.html.twig'})
     } %}
+        {% block after_title %}
+            {{ ibexa_render_component_group('content-form-create-header-actions', {
+                'parent_location': parent_location,
+                'content_type': content_type,
+                'language': language
+            }) }}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}
 
 {% block form_before %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -15,7 +15,7 @@
         'language': language,
     }) %}
 
-    {% include '@ibexadesign/ui/edit_header.html.twig' with {
+    {% embed '@ibexadesign/ui/edit_header.html.twig' with {
         action_name: 'editing'|trans|desc('Editing'),
         content_type_name: content_type.name,
         title: content.name,
@@ -28,6 +28,16 @@
         })|desc('Location: %location% Translation: %language%'),
         context_actions: knp_menu_render(content_edit_sidebar_right, { 'template': '@ibexadesign/ui/menu/context_menu.html.twig' })
     } %}
+        {% block after_title %}
+            {{ ibexa_render_component_group('content-form-edit-header-actions', {
+                'content': content,
+                'content_type': content_type,
+                'location': location,
+                'parent_location': parent_location,
+                'language': language
+            }) }}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}
 
 {% block form_before %}


### PR DESCRIPTION
| :ticket: Issue | IBX-8601 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Introduced `content-form-create-header-actions` and `content-form-edit-header-actions` components groups. 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
