### PR TITLE
IBX-8800: Fixed subitems filtering

### DIFF
--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -23,6 +23,7 @@ use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Rest\Message;
@@ -78,7 +79,7 @@ class ContentTreeController extends RestController
         int $parentLocationId,
         int $limit,
         int $offset,
-        Query\Criterion $filter
+        ?Criterion $filter
     ): Node {
         $location = $this->locationService->loadLocation($parentLocationId);
         $loadSubtreeRequestNode = new LoadSubtreeRequestNode($parentLocationId, $limit, $offset);

--- a/src/bundle/ControllerArgumentResolver/ContentTreeChildrenQueryArgumentResolver.php
+++ b/src/bundle/ControllerArgumentResolver/ContentTreeChildrenQueryArgumentResolver.php
@@ -40,13 +40,20 @@ final class ContentTreeChildrenQueryArgumentResolver implements ArgumentValueRes
     }
 
     /**
-     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion>
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion|null>
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        yield new LogicalAnd($this->processFilterQueryCriteria($request));
+        $criteria = $this->processFilterQueryCriteria($request);
+        if ($argument->isNullable() && empty($criteria)) {
+            yield null;
+
+            return;
+        }
+
+        yield new LogicalAnd($criteria);
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | [IBX-8800](https://issues.ibexa.co/browse/IBX-8800) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Currently `LogicalAnd` criterion is always added to query via `ContentTreeChildrenQueryArgumentResolver` and `ContentTreeController::loadChildrenAction`. When using solr or elasticserach engine and filter parameter is not passed to request, exception about `Invalid aggregation in LogicalAnd criterion` is throw. 

This PR changes type hint of `$filter` parameter from `Criterion` to `?Criterion` in `ContentTreeController::loadChildrenAction`. This allows to yield null value in `ContentTreeChildrenQueryArgumentResolver::resolve` when processed array of filter criteria is empty.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
