### PR TITLE
IBX-8807: Fixed duplicated GraphQL subitems request

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -108,6 +108,7 @@ export default class SubItemsModule extends Component {
         this.bulkActionModalContainer = null;
         this.udwContainer = null;
         this.adminUiConfig = getAdminUiConfig();
+        this.requestInProgress = false;
 
         const sortClauseData = this.getDefaultSortClause(props.sortClauses);
 
@@ -184,7 +185,7 @@ export default class SubItemsModule extends Component {
 
         const shouldLoadPage = !activePageItems;
 
-        if (shouldLoadPage) {
+        if (shouldLoadPage && !this.requestInProgress) {
             this.loadPage(activePageIndex);
         }
 
@@ -244,7 +245,9 @@ export default class SubItemsModule extends Component {
         const cursor = page ? page.cursor : null;
         const queryConfig = { locationId, limit: itemsPerPage, sortClause, sortOrder, cursor };
 
+        this.requestInProgress = true;
         loadLocation(restInfo, queryConfig, (response) => {
+            this.requestInProgress = false;
             const { totalCount, pages, edges } = response.data._repository.location.children;
             const activePageItems = edges.map((edge) => edge.node);
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8807|
|----------------|-----------|

#### Description:
The issue is caused by the fact that `componentDidUpdate` runs whilst the `loadPage` request is still running in `componentDidMount`. 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
