### PR TITLE
Dropped ibexa/polyfill-php82

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ibexa/core": "~5.0.x-dev",
         "ibexa/design-engine": "~5.0.x-dev",
         "ibexa/fieldtype-richtext": "~5.0.x-dev",
-        "ibexa/polyfill-php82": "^1.0",
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",

--- a/src/bundle/ControllerArgumentResolver/ContentTreeChildrenQueryArgumentResolver.php
+++ b/src/bundle/ControllerArgumentResolver/ContentTreeChildrenQueryArgumentResolver.php
@@ -11,7 +11,6 @@ namespace Ibexa\Bundle\AdminUi\ControllerArgumentResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use Ibexa\Contracts\Rest\Input\Parser\Query\Criterion\CriterionProcessorInterface;
-use function Ibexa\PolyfillPhp82\iterator_to_array;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Since PHP 8.3 supports functions added in `ibexa/polyfill-php82`, so this bundle is no longer needed.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
