### PR TITLE
IBX-8829: [Richtext] Distraction free mode button should be disabled when richtext field isn't translatable

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -532,7 +532,7 @@
                 {{- form_label(form) -}}
             </div>
             <div class="ibexa-field-edit__distraction-free-mode-btns">
-                 <button type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small ibexa-field-edit__distraction-free-mode-control-btn ibexa-field-edit__distraction-free-mode-control-btn--enable">
+                 <button {{ (fieldtype_is_not_translatable or disabled) ? 'disabled' }} type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small ibexa-field-edit__distraction-free-mode-control-btn ibexa-field-edit__distraction-free-mode-control-btn--enable">
                     <svg class="ibexa-icon ibexa-icon--tiny-small">
                         <use xlink:href="{{ ibexa_icon_path('focus') }}"></use>
                     </svg>
@@ -543,7 +543,7 @@
                         {{ 'distraction_free_mode.enable.label'|trans|desc('Distraction free mode') }}
                     </span>
                 </button>
-                <button type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small ibexa-field-edit__distraction-free-mode-control-btn ibexa-field-edit__distraction-free-mode-control-btn--disable">
+                <button {{ (fieldtype_is_not_translatable or disabled) ? 'disabled' }} type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small ibexa-field-edit__distraction-free-mode-control-btn ibexa-field-edit__distraction-free-mode-control-btn--disable">
                     <svg class="ibexa-icon ibexa-icon--tiny-small">
                         <use xlink:href="{{ ibexa_icon_path('un-focus') }}"></use>
                     </svg>


### PR DESCRIPTION
| :ticket: Issue | IBX-8829 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
