### PR TITLE
IBX-8837: Distraction free mode: Text obstruction by toolbar's fixed position

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
+++ b/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
@@ -25,7 +25,7 @@
 
             parentElement = parentElement.parentNode;
         }
-    }
+    };
     const restoreAncestorsPositions = () => {
         clearedPositionNodesData.forEach(({ node, originalInlineOverflow, originalInlinePosition }) => {
             if (originalInlineOverflow) {
@@ -42,7 +42,7 @@
         });
 
         clearedPositionNodesData.length = 0;
-    }
+    };
     const changeDistractionFreeModeState = (active) => {
         if (!activeFieldEdit || previousDistractionFreeModeActive === active) {
             return;

--- a/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
+++ b/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
@@ -1,6 +1,7 @@
 (function (global, doc) {
     let activeFieldEdit = null;
-    let clearedPositionNodesData = [];
+    let previousDistractionFreeModeActive = null;
+    const clearedPositionNodesData = [];
     const DISTRACTION_FREE_MODE_ENABLE_EVENT_NAME = 'ibexa-distraction-free:enable';
     const DISTRACTION_FREE_DISABLE_EVENT_NAME = 'ibexa-distraction-free:disable';
     const distractionFreeModeEnableBtns = doc.querySelectorAll('.ibexa-field-edit__distraction-free-mode-control-btn--enable');
@@ -40,12 +41,14 @@
             }
         });
 
-        clearedPositionNodesData = [];
+        clearedPositionNodesData.length = 0;
     }
     const changeDistractionFreeModeState = (active) => {
-        if (!activeFieldEdit) {
+        if (!activeFieldEdit || previousDistractionFreeModeActive === active) {
             return;
         }
+
+        previousDistractionFreeModeActive = active;
 
         const dispatchEventName = active ? DISTRACTION_FREE_MODE_ENABLE_EVENT_NAME : DISTRACTION_FREE_DISABLE_EVENT_NAME;
         const editorSourceElement = activeFieldEdit.querySelector('.ibexa-data-source__richtext');

--- a/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
+++ b/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
@@ -1,5 +1,6 @@
 (function (global, doc) {
     let activeFieldEdit = null;
+    let clearedPositionNodesData = [];
     const DISTRACTION_FREE_MODE_ENABLE_EVENT_NAME = 'ibexa-distraction-free:enable';
     const DISTRACTION_FREE_DISABLE_EVENT_NAME = 'ibexa-distraction-free:disable';
     const distractionFreeModeEnableBtns = doc.querySelectorAll('.ibexa-field-edit__distraction-free-mode-control-btn--enable');
@@ -15,6 +16,43 @@
 
         activeFieldEdit.classList.toggle('ibexa-field-edit--distraction-free-mode-active', active);
         editorInstance.set('distractionFreeModeActive', active);
+
+        if (active) {
+            let parentElement = activeFieldEdit.parentNode;
+
+            while (parentElement && parentElement !== doc.body) {
+                const { overflow, position } = getComputedStyle(parentElement);
+
+                if (overflow !== 'visible' || position === 'absolute') {
+                    clearedPositionNodesData.push({
+                        node: parentElement,
+                        originalInlineOverflow: parentElement.style.overflow,
+                        originalInlinePosition: parentElement.style.position,
+                    });
+
+                    parentElement.style.overflow = 'visible';
+                    parentElement.style.position = 'static';
+                }
+
+                parentElement = parentElement.parentNode;
+            }
+        } else {
+            clearedPositionNodesData.forEach(({ node, originalInlineOverflow, originalInlinePosition }) => {
+                if (originalInlineOverflow) {
+                    node.style.overflow = originalInlineOverflow;
+                } else {
+                    node.style.removeProperty('overflow');
+                }
+
+                if (originalInlinePosition) {
+                    node.style.position = originalInlinePosition;
+                } else {
+                    node.style.removeProperty('position');
+                }
+            });
+
+            clearedPositionNodesData = [];
+        }
 
         doc.body.dispatchEvent(
             new CustomEvent(dispatchEventName, {

--- a/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
+++ b/src/bundle/Resources/public/js/scripts/admin.distraction.free.mode.js
@@ -5,6 +5,43 @@
     const DISTRACTION_FREE_DISABLE_EVENT_NAME = 'ibexa-distraction-free:disable';
     const distractionFreeModeEnableBtns = doc.querySelectorAll('.ibexa-field-edit__distraction-free-mode-control-btn--enable');
     const distractionFreeModeDisableBtns = doc.querySelectorAll('.ibexa-field-edit__distraction-free-mode-control-btn--disable');
+    const resetAncestorsPositions = (field) => {
+        let parentElement = field.parentNode;
+
+        while (parentElement && parentElement !== doc.body) {
+            const { overflow, position } = getComputedStyle(parentElement);
+
+            if (overflow !== 'visible' || position === 'absolute') {
+                clearedPositionNodesData.push({
+                    node: parentElement,
+                    originalInlineOverflow: parentElement.style.overflow,
+                    originalInlinePosition: parentElement.style.position,
+                });
+
+                parentElement.style.overflow = 'visible';
+                parentElement.style.position = 'static';
+            }
+
+            parentElement = parentElement.parentNode;
+        }
+    }
+    const restoreAncestorsPositions = () => {
+        clearedPositionNodesData.forEach(({ node, originalInlineOverflow, originalInlinePosition }) => {
+            if (originalInlineOverflow) {
+                node.style.overflow = originalInlineOverflow;
+            } else {
+                node.style.removeProperty('overflow');
+            }
+
+            if (originalInlinePosition) {
+                node.style.position = originalInlinePosition;
+            } else {
+                node.style.removeProperty('position');
+            }
+        });
+
+        clearedPositionNodesData = [];
+    }
     const changeDistractionFreeModeState = (active) => {
         if (!activeFieldEdit) {
             return;
@@ -18,40 +55,9 @@
         editorInstance.set('distractionFreeModeActive', active);
 
         if (active) {
-            let parentElement = activeFieldEdit.parentNode;
-
-            while (parentElement && parentElement !== doc.body) {
-                const { overflow, position } = getComputedStyle(parentElement);
-
-                if (overflow !== 'visible' || position === 'absolute') {
-                    clearedPositionNodesData.push({
-                        node: parentElement,
-                        originalInlineOverflow: parentElement.style.overflow,
-                        originalInlinePosition: parentElement.style.position,
-                    });
-
-                    parentElement.style.overflow = 'visible';
-                    parentElement.style.position = 'static';
-                }
-
-                parentElement = parentElement.parentNode;
-            }
+            resetAncestorsPositions(activeFieldEdit);
         } else {
-            clearedPositionNodesData.forEach(({ node, originalInlineOverflow, originalInlinePosition }) => {
-                if (originalInlineOverflow) {
-                    node.style.overflow = originalInlineOverflow;
-                } else {
-                    node.style.removeProperty('overflow');
-                }
-
-                if (originalInlinePosition) {
-                    node.style.position = originalInlinePosition;
-                } else {
-                    node.style.removeProperty('position');
-                }
-            });
-
-            clearedPositionNodesData = [];
+            restoreAncestorsPositions();
         }
 
         doc.body.dispatchEvent(


### PR DESCRIPTION
| :ticket: Issue | [IBX-8837](https://issues.ibexa.co/browse/IBX-8837) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This bug is caused by CKEditor code itself, I've created issue there https://github.com/ckeditor/ckeditor5/issues/17241 but I doubt it will be resolved soon (if ever), judging from my experience, so here's fix for it.

I'm basically temporarly removing styles that breaks supossed correct behaviour, as distraction free mode takes whole page, it doesn't matter what happens beneath, as it's not visible. When closing DFM I restore remove my inline styles/restore previous inline styles

#### For QA:
This solves https://issues.ibexa.co/browse/IBX-8965 as well, I think.
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
