### PR TITLE
Improved PHPDoc descriptions

### DIFF
--- a/src/contracts/Menu/CopyFormContextMenuBuilder.php
+++ b/src/contracts/Menu/CopyFormContextMenuBuilder.php
@@ -11,7 +11,7 @@ namespace Ibexa\Contracts\AdminUi\Menu;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
- * Builds menu with "Copy" nad "Cancel" items.
+ * Builds menu with "Copy" and "Cancel" items.
  */
 final class CopyFormContextMenuBuilder extends AbstractFormContextMenuBuilder implements TranslationContainerInterface
 {

--- a/src/contracts/Menu/CreateFormContextMenuBuilder.php
+++ b/src/contracts/Menu/CreateFormContextMenuBuilder.php
@@ -11,7 +11,7 @@ namespace Ibexa\Contracts\AdminUi\Menu;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
- * Builds menu with "Create" nad "Cancel" items.
+ * Builds menu with "Create" and "Cancel" items.
  */
 final class CreateFormContextMenuBuilder extends AbstractFormContextMenuBuilder implements TranslationContainerInterface
 {

--- a/src/contracts/Menu/MenuItemFactoryInterface.php
+++ b/src/contracts/Menu/MenuItemFactoryInterface.php
@@ -13,7 +13,7 @@ use Knp\Menu\ItemInterface;
 interface MenuItemFactoryInterface extends FactoryInterface
 {
     /**
-     * Creates Location menu item only when user has content:read permission.
+     * Creates Location menu item only when user has content/read permission.
      *
      * @param array<mixed> $options
      *

--- a/src/contracts/Menu/UpdateFormContextMenuBuilder.php
+++ b/src/contracts/Menu/UpdateFormContextMenuBuilder.php
@@ -11,7 +11,7 @@ namespace Ibexa\Contracts\AdminUi\Menu;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
- * Builds menu with "Update" nad "Cancel" items.
+ * Builds menu with "Update" and "Cancel" items.
  */
 final class UpdateFormContextMenuBuilder extends AbstractFormContextMenuBuilder implements TranslationContainerInterface
 {


### PR DESCRIPTION
1) `Nad` is clearly a typo
2) Usually we write the policies divided with a slash

These things become visible in the PHP API reference, hence why I'm improving them.