### PR TITLE
Made template for showing image_field in admin-ui more robust

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -447,7 +447,7 @@
                         <td>{{ 'ezimage.master_dimensions'|trans|desc('Master dimensions') }}:</td>
                         <td>{{ 'ezimage.width_and_height'|trans({'%width%': field.value.width, '%height%': field.value.height})|desc('Width: %width%px height: %height%px') }}</td>
                     </tr>
-                    {% if field.value.height != '0' %}
+                    {% if field.value.height != '0' and field.value.height != '' %}
                         <tr class="ibexa-field-preview__meta-value-row">
                             <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
                             <td>{{ (field.value.width/field.value.height)|round(2) }}</td>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -447,7 +447,7 @@
                         <td>{{ 'ezimage.master_dimensions'|trans|desc('Master dimensions') }}:</td>
                         <td>{{ 'ezimage.width_and_height'|trans({'%width%': field.value.width, '%height%': field.value.height})|desc('Width: %width%px height: %height%px') }}</td>
                     </tr>
-                    {% if field.value.height != '0' and field.value.height != '' %}
+                    {% if field.value.height %}
                         <tr class="ibexa-field-preview__meta-value-row">
                             <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
                             <td>{{ (field.value.width/field.value.height)|round(2) }}</td>


### PR DESCRIPTION
#### Description:
I was not able to reproduce the problem on a fresh 4.6, but on a installation just upgraded to 4.6 (was at some point using 2.5 or maybe even older releases) the database had a lot of images with the following "empty" data in `ezcontentobject_attribute.data_text`:
```
<?xml version="1.0" encoding="UTF-8"?>
<ezimage serial_number=""
         is_valid=""
         filename=""
         suffix=""
         basename=""
         dirpath=""
         url=""
         original_filename=""
         mime_type=""
         width=""
         height=""
         alternative_text=""
         alias_key="1293033771"
         timestamp="1086942459" />
```

In 4.6, the value will simply be `null` if no image is uploaded. However, in earlier versions it was obviously stored like shown above. And one problem here is that `height` has a value set to empty string. The admin-ui template requires `height` to be numeric or a `Unsupported operand types: string / string` exception will be thrown.

It would be nice if twig had a `is numeric` test but that is [not going to happend](https://github.com/twigphp/Twig/issues/1861). For this use-case it is sufficient to check if value is empty string too

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
