### PR TITLE
IBX-9274: Context menu does not show up in 'Location' folder

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/common/_spinner.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/common/_spinner.scss
@@ -1,11 +1,22 @@
+@use 'sass:list';
+
 .c-spinner {
-    @include spinner(calculateRem(26px), calculateRem(3px), $ibexa-color-primary);
+    $color-variants: (
+        '--primary': $ibexa-color-primary,
+        '--light': $ibexa-color-white,
+    );
 
-    &--small {
-        @include spinner(calculateRem(16px), calculateRem(2px), $ibexa-color-primary);
-    }
+    $size-variants: (
+        '--small': calculateRem(16px) calculateRem(2px),
+        '--medium': calculateRem(26px) calculateRem(3px),
+        '--large': calculateRem(86px) calculateRem(6px),
+    );
 
-    &--large {
-        @include spinner(calculateRem(86px), calculateRem(6px), $ibexa-color-primary);
+    @each $size-modifier, $sizes in $size-variants {
+        @each $color-modifier, $color in $color-variants {
+            &#{$size-modifier}.c-spinner#{$color-modifier} {
+                @include spinner(list.nth($sizes, 1), list.nth($sizes, 2), $color);
+            }
+        }
     }
 }

--- a/src/bundle/ui-dev/src/modules/common/spinner/spinner.js
+++ b/src/bundle/ui-dev/src/modules/common/spinner/spinner.js
@@ -9,10 +9,16 @@ export const SIZES = {
     LARGE: 'large',
 };
 
-const Spinner = ({ size }) => {
+export const COLOR_VARIATNS = {
+    PRIMARY: 'primary',
+    LIGHT: 'light',
+};
+
+const Spinner = ({ size, colorVariant }) => {
     const className = createCssClassNames({
         'c-spinner': true,
         [`c-spinner--${size}`]: true,
+        [`c-spinner--${colorVariant}`]: true,
     });
 
     return <div className={className} />;
@@ -20,10 +26,12 @@ const Spinner = ({ size }) => {
 
 Spinner.propTypes = {
     size: PropTypes.oneOf(Object.values(SIZES)),
+    colorVariant: PropTypes.oneOf(Object.values(COLOR_VARIATNS)),
 };
 
 Spinner.defaultProps = {
     size: SIZES.MEDIUM,
+    colorVariant: COLOR_VARIATNS.PRIMARY,
 };
 
 export default Spinner;

--- a/src/bundle/ui-dev/src/modules/common/spinner/spinner.js
+++ b/src/bundle/ui-dev/src/modules/common/spinner/spinner.js
@@ -9,7 +9,7 @@ export const SIZES = {
     LARGE: 'large',
 };
 
-export const COLOR_VARIATNS = {
+export const COLOR_VARIANTS = {
     PRIMARY: 'primary',
     LIGHT: 'light',
 };
@@ -26,12 +26,12 @@ const Spinner = ({ size, colorVariant }) => {
 
 Spinner.propTypes = {
     size: PropTypes.oneOf(Object.values(SIZES)),
-    colorVariant: PropTypes.oneOf(Object.values(COLOR_VARIATNS)),
+    colorVariant: PropTypes.oneOf(Object.values(COLOR_VARIANTS)),
 };
 
 Spinner.defaultProps = {
     size: SIZES.MEDIUM,
-    colorVariant: COLOR_VARIATNS.PRIMARY,
+    colorVariant: COLOR_VARIANTS.PRIMARY,
 };
 
 export default Spinner;

--- a/src/lib/REST/Output/ValueObjectVisitor/UniversalDiscovery/LocationListDataVisitor.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/UniversalDiscovery/LocationListDataVisitor.php
@@ -19,20 +19,18 @@ final class LocationListDataVisitor extends AbstractLocationDataVisitor
     public function visit(Visitor $visitor, Generator $generator, $data): void
     {
         $generator->startObjectElement('LocationList');
+        $generator->startList('locations');
 
         foreach ($data->getLocationList() as $locationList) {
-            $generator->startList('locations');
-
             $generator->startHashElement('locationWithPermissions');
 
             $this->buildLocationNode($locationList['location'], $generator, $visitor);
             $this->buildPermissionNode($locationList['permissions'], $generator);
 
             $generator->endHashElement('locationWithPermissions');
-
-            $generator->endList('locations');
         }
 
+        $generator->endList('locations');
         $generator->endObjectElement('LocationList');
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9274 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/image-picker/pull/97
- https://github.com/ibexa/assets-library-widget/pull/55

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For backend reviewers:
Endpoint `/api/ibexa/v2/module/universal-discovery/locations?locationIds=1,2,3` always return permissions only for the last location from the `locationIds` parameter. The problem was method `LocationListDataVisitor->visit` which iterates through the list of locations `$data->getLocationList()`, with each iteration it made a `startList`, which create new list with one element instead of adding location data to it.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
