### PR TITLE
Allowed to use DateTimeInterface in DateTimePicker form type

### DIFF
--- a/src/lib/Form/DataTransformer/DateTimePickerTransformer.php
+++ b/src/lib/Form/DataTransformer/DateTimePickerTransformer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Form\DataTransformer;
 
 use DateTime;
+use DateTimeInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
@@ -29,9 +30,9 @@ class DateTimePickerTransformer implements DataTransformerInterface
             return null;
         }
 
-        if (!$value instanceof DateTime) {
+        if (!$value instanceof DateTimeInterface) {
             throw new TransformationFailedException(
-                sprintf('Found %s instead of %s', gettype($value), DateTime::class)
+                sprintf('Found %s instead of %s', gettype($value), DateTimeInterface::class)
             );
         }
 

--- a/src/lib/Form/DataTransformer/DateTimePickerTransformer.php
+++ b/src/lib/Form/DataTransformer/DateTimePickerTransformer.php
@@ -32,7 +32,7 @@ class DateTimePickerTransformer implements DataTransformerInterface
 
         if (!$value instanceof DateTimeInterface) {
             throw new TransformationFailedException(
-                sprintf('Found %s instead of %s', gettype($value), DateTimeInterface::class)
+                sprintf('Found %s instead of %s', get_debug_type($value), DateTimeInterface::class)
             );
         }
 

--- a/tests/lib/Form/DataTransformer/DateTimePickerTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/DateTimePickerTransformerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Form\DataTransformer;
+
+use DateTime;
+use DateTimeImmutable;
+use Ibexa\AdminUi\Form\DataTransformer\DateTimePickerTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+final class DateTimePickerTransformerTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderForTransform
+     */
+    public function testTransform(): void
+    {
+        $transformer = new DateTimePickerTransformer();
+        $dateTime = new DateTime('2021-01-01 00:00:00');
+        $this->assertSame($dateTime->getTimestamp(), $transformer->transform($dateTime));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, ?int}>
+     */
+    public function dataProviderForTransform(): iterable
+    {
+        yield 'null' => [null, null];
+        yield 'DateTime' => [new DateTime('2021-01-01 00:00:00'), 1609459200];
+        yield 'DateTimeImmutable' => [new DateTimeImmutable('2021-01-01 00:00:00'), 1609459200];
+    }
+
+    public function testTransformWithInvalidValue(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Found string instead of DateTimeInterface');
+
+        $transformer = new DateTimePickerTransformer();
+        $transformer->transform('invalid');
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransform
+     */
+    public function testReverseTransform(): void
+    {
+        $transformer = new DateTimePickerTransformer();
+        $dateTime = new DateTime('2021-01-01 00:00:00');
+        $this->assertEquals($dateTime, $transformer->reverseTransform($dateTime->getTimestamp()));
+    }
+
+    /**
+     * @return iterable<string, array{?int, ?DateTime}>
+     */
+    public function dataProviderForReverseTransform(): iterable
+    {
+        yield 'null' => [null, null];
+        yield 'DateTime' => [1609459200, new DateTime('2021-01-01 00:00:00')];
+    }
+
+    public function testReverseTransformWithInvalidValue(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Found string instead of a numeric value');
+
+        $transformer = new DateTimePickerTransformer();
+        $transformer->reverseTransform('invalid');
+    }
+}

--- a/tests/lib/Form/DataTransformer/DateTimePickerTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/DateTimePickerTransformerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 final class DateTimePickerTransformerTest extends TestCase
 {
     /**
-     * @dataProvider dataProviderForTransform
+     * @dataProvider dataProviderForTestTransform
      */
     public function testTransform(): void
     {
@@ -29,7 +29,7 @@ final class DateTimePickerTransformerTest extends TestCase
     /**
      * @return iterable<string, array{mixed, ?int}>
      */
-    public function dataProviderForTransform(): iterable
+    public function dataProviderForTestTransform(): iterable
     {
         yield 'null' => [null, null];
         yield 'DateTime' => [new DateTime('2021-01-01 00:00:00'), 1609459200];
@@ -46,7 +46,7 @@ final class DateTimePickerTransformerTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForReverseTransform
+     * @dataProvider dataProviderForTestReverseTransform
      */
     public function testReverseTransform(): void
     {
@@ -58,7 +58,7 @@ final class DateTimePickerTransformerTest extends TestCase
     /**
      * @return iterable<string, array{?int, ?DateTime}>
      */
-    public function dataProviderForReverseTransform(): iterable
+    public function dataProviderForTestReverseTransform(): iterable
     {
         yield 'null' => [null, null];
         yield 'DateTime' => [1609459200, new DateTime('2021-01-01 00:00:00')];


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Allowed to use \DateTimeInterface (effectively `DateTimeImmutable` and `DateTime`) with `\Ibexa\AdminUi\Form\Type\DateTimePickerType` 


#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
