### PR TITLE
IBX-9217: Added URL validation

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
@@ -23,9 +23,9 @@
             }
 
             if (!isEmpty) {
-                try {
-                    new URL(urlValue);
-                } catch (error) {
+                const isUrlValid = URL.canParse(urlValue);
+
+                if (!isUrlValid) {
                     result.isError = true;
                     result.errorMessage = ibexa.errors.invalidUrl;
                 }

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
@@ -7,15 +7,28 @@
 
     class EzUrlValidator extends ibexa.BaseFieldValidator {
         validateUrl(event) {
+            const result = {
+                isError: false,
+                errorMessage: null,
+            };
             const input = event.currentTarget;
+            const urlValue = input.value.trim();
             const isRequired = input.required;
-            const isEmpty = !input.value.trim();
-            const isError = isEmpty && isRequired;
+            const isEmpty = !urlValue;
             const label = input.closest(SELECTOR_FIELD_LINK).querySelector(SELECTOR_LABEL).innerHTML;
-            const result = { isError };
 
             if (isRequired && isEmpty) {
+                result.isError = true;
                 result.errorMessage = ibexa.errors.emptyField.replace('{fieldName}', label);
+            }
+
+            if (!isEmpty) {
+                try {
+                    new URL(urlValue);
+                } catch (error) {
+                    result.isError = true;
+                    result.errorMessage = ibexa.errors.invalidUrl;
+                }
             }
 
             return result;


### PR DESCRIPTION
| :ticket: Issue | IBX-9217 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
Ad. 9e00eb2 / 5ad899b

In the end modified scenarios for variants in https://github.com/ibexa/product-catalog/pull/1251 ~Added retrying (and mouse over) for switching field groups~ due to random error encountered on Chrome v124 on Headless:

https://github.com/ibexa/headless/actions/runs/13391931955/job/37401422810#step:18:215
https://res.cloudinary.com/ezplatformtravis/image/upload/v1739887300/screenshots/67b492c43b022776389969-vendor_ibexa_product-catalog_features_browser_productvariants_feature_165_whc2qm.png

In this PR tests fail because Chrome 110 is used (without support for `canParse`). 
Tests with Chrome 124 are run https://github.com/ibexa/commerce/pull/1186, https://github.com/ibexa/experience/pull/520, https://github.com/ibexa/headless/pull/190, https://github.com/ibexa/oss/pull/201.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
