### PR TITLE
IBX-9333: introduced isUpdate to reload sub-items page after actions

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -134,6 +134,7 @@ export default class SubItemsModule extends Component {
             morePanelVisible: false,
             morePanelVisibleItemsIndexes: [],
             queryParams: {},
+            isUpdate: false,
         };
     }
 
@@ -171,7 +172,7 @@ export default class SubItemsModule extends Component {
     }
 
     componentDidUpdate() {
-        const { activePageIndex, activePageItems, totalCount } = this.state;
+        const { activePageIndex, activePageItems, totalCount, isUpdate } = this.state;
         const { limit: itemsPerPage } = this.props;
         const pagesCount = Math.ceil(totalCount / itemsPerPage);
         const pageDoesNotExist = activePageIndex > pagesCount - 1 && activePageIndex !== 0;
@@ -186,7 +187,7 @@ export default class SubItemsModule extends Component {
 
         const shouldLoadPage = !activePageItems;
 
-        if (shouldLoadPage && this.requestParamsHaveChanged(activePageIndex)) {
+        if (shouldLoadPage && (this.requestParamsHaveChanged(activePageIndex) || isUpdate)) {
             this.loadPage(activePageIndex);
         }
 
@@ -261,6 +262,7 @@ export default class SubItemsModule extends Component {
                 sortOrder,
                 cursor,
             },
+            isUpdate: false,
         });
 
         loadLocation(restInfo, queryConfig, (response) => {
@@ -330,6 +332,10 @@ export default class SubItemsModule extends Component {
      * @memberof SubItemsModule
      */
     afterPriorityUpdated(response) {
+        this.setState({
+            isUpdate: true,
+        });
+
         if (this.state.sortClause === 'LocationPriority') {
             this.discardActivePageItems();
             this.refreshContentTree();
@@ -475,6 +481,9 @@ export default class SubItemsModule extends Component {
     afterBulkMove(location, movedItems, notMovedItems) {
         const { totalCount } = this.state;
 
+        this.setState({
+            isUpdate: true,
+        });
         this.refreshContentTree();
         this.updateTotalCountState(totalCount - movedItems.length);
         this.deselectAllItems();
@@ -534,6 +543,9 @@ export default class SubItemsModule extends Component {
     }
 
     afterBulkHide(successItems, failedItems) {
+        this.setState({
+            isUpdate: true,
+        });
         this.deselectAllItems();
         this.discardActivePageItems();
         this.toggleBulkOperationStatusState(false);
@@ -579,6 +591,9 @@ export default class SubItemsModule extends Component {
     }
 
     afterBulkUnhide(successItems, failedItems) {
+        this.setState({
+            isUpdate: true,
+        });
         this.deselectAllItems();
         this.discardActivePageItems();
         this.toggleBulkOperationStatusState(false);
@@ -624,6 +639,9 @@ export default class SubItemsModule extends Component {
     }
 
     afterBulkAddLocation(location, successItems, failedItems) {
+        this.setState({
+            isUpdate: true,
+        });
         this.deselectAllItems();
         this.discardActivePageItems();
         this.toggleBulkOperationStatusState(false);
@@ -774,6 +792,9 @@ export default class SubItemsModule extends Component {
         const { totalCount } = this.state;
         const isUser = ({ content }) => window.ibexa.adminUiConfig.userContentTypes.includes(content._info.contentType.identifier);
 
+        this.setState({
+            isUpdate: true,
+        });
         this.refreshContentTree();
         this.updateTotalCountState(totalCount - deletedItems.length);
         this.deselectAllItems();


### PR DESCRIPTION
| :ticket: Issue | IBX-9333 |
|----------------|-----------|


#### Description:
After introducing `requestParamsHaveChanged`, actions did not cause the page to be reloaded and the loading to be hidden, which is why an additional state was introduced



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
