### PR TITLE
IBX-9293: List site accesses for location based on version info's languages

### DIFF
--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -34,7 +34,7 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
     {
         $siteAccess = $context->getSiteaccess();
         $location = $context->getLocation();
-        $languageCode = $context->getLanguageCode();
+        $languageCodes = $context->getLanguageCodes();
 
         if (empty(array_intersect($this->getRootLocationIds($siteAccess), $location->getPath()))) {
             return false;
@@ -50,7 +50,7 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
             $siteAccess
         );
 
-        return in_array($languageCode, $siteAccessLanguages, true);
+        return !empty(array_intersect($languageCodes, $siteAccessLanguages));
     }
 
     protected function validateRepositoryMatch(string $siteaccess): bool

--- a/src/lib/Siteaccess/SiteaccessPreviewVoterContext.php
+++ b/src/lib/Siteaccess/SiteaccessPreviewVoterContext.php
@@ -22,19 +22,22 @@ final class SiteaccessPreviewVoterContext
     /** @var string */
     private $siteaccess;
 
-    /** @var string */
-    private $languageCode;
+    /** @var array<string> */
+    private $languageCodes;
 
+    /**
+     * @param array<int, string> $languageCodes
+     */
     public function __construct(
         Location $location,
         VersionInfo $versionInfo,
         string $siteaccess,
-        string $languageCode
+        array $languageCodes
     ) {
         $this->location = $location;
         $this->versionInfo = $versionInfo;
         $this->siteaccess = $siteaccess;
-        $this->languageCode = $languageCode;
+        $this->languageCodes = $languageCodes;
     }
 
     /**
@@ -54,11 +57,11 @@ final class SiteaccessPreviewVoterContext
     }
 
     /**
-     * @return string
+     * @return array<int, string>
      */
-    public function getLanguageCode(): string
+    public function getLanguageCodes(): array
     {
-        return $this->languageCode;
+        return $this->languageCodes;
     }
 
     /**

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -81,12 +81,12 @@ class SiteaccessResolver implements SiteaccessResolverInterface
     ): array {
         $contentInfo = $location->getContentInfo();
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $versionNo);
-        $languageCode = $languageCode ?? $contentInfo->getMainLanguageCode();
+        $languageCodes = $languageCode !== null ? [$languageCode] : $versionInfo->getLanguageCodes();
 
         $eligibleSiteAccesses = [];
         /** @var \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess */
         foreach ($this->siteAccessService->getAll() as $siteAccess) {
-            $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteAccess->name, $languageCode);
+            $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteAccess->name, $languageCodes);
             foreach ($this->siteAccessPreviewVoters as $siteAccessPreviewVoter) {
                 if ($siteAccessPreviewVoter->vote($context)) {
                     $eligibleSiteAccesses[] = $siteAccess;

--- a/tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
+++ b/tests/lib/Siteaccess/AdminSiteaccessPreviewVoterTest.php
@@ -50,7 +50,7 @@ class AdminSiteaccessPreviewVoterTest extends TestCase
         ]);
         $siteaccess = 'site';
 
-        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, $languageCode);
+        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, [$languageCode]);
 
         $this->mockConfigMethods($context);
 
@@ -177,7 +177,7 @@ class AdminSiteaccessPreviewVoterTest extends TestCase
         ]);
         $siteaccess = 'site';
 
-        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, $languageCode);
+        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, [$languageCode]);
 
         return [
             [


### PR DESCRIPTION
| :ticket: Issue | IBX-9293|
|----------------|-----------|

#### Description:
Technically speaking, the `getSiteAccessesListForLocation` method shouldn't rely on location's `mainLanguageCode`. It should rely on languages that a current location's content have or rather its `VersionInfo`'s languages. This obviously makes sense only if a developer does not provide the `languageCode` argument.

This change would require changes in the following packages:
- `site-skeleton`
- `product-catalog`
- `dashboard`

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
