### PR TITLE
IBX-9293: Base site access choice loader on language code

### DIFF
--- a/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/SiteAccessChoiceLoader.php
@@ -24,14 +24,18 @@ class SiteAccessChoiceLoader implements ChoiceLoaderInterface
 
     private SiteAccessNameGeneratorInterface $siteAccessNameGenerator;
 
+    private ?string $languageCode;
+
     public function __construct(
         SiteaccessResolverInterface $nonAdminSiteaccessResolver,
         SiteAccessNameGeneratorInterface $siteAccessNameGenerator,
-        ?Location $location = null
+        ?Location $location = null,
+        ?string $languageCode = null
     ) {
         $this->nonAdminSiteaccessResolver = $nonAdminSiteaccessResolver;
         $this->location = $location;
         $this->siteAccessNameGenerator = $siteAccessNameGenerator;
+        $this->languageCode = $languageCode;
     }
 
     /**
@@ -41,7 +45,11 @@ class SiteAccessChoiceLoader implements ChoiceLoaderInterface
     {
         $siteAccesses = $this->location === null
             ? $this->nonAdminSiteaccessResolver->getSiteAccessesList()
-            : $this->nonAdminSiteaccessResolver->getSiteAccessesListForLocation(($this->location));
+            : $this->nonAdminSiteaccessResolver->getSiteAccessesListForLocation(
+                $this->location,
+                null,
+                $this->languageCode
+            );
 
         $data = [];
         foreach ($siteAccesses as $siteAccess) {

--- a/src/lib/Form/Type/Preview/SiteAccessChoiceType.php
+++ b/src/lib/Form/Type/Preview/SiteAccessChoiceType.php
@@ -51,7 +51,8 @@ final class SiteAccessChoiceType extends AbstractType
                             new SiteAccessChoiceLoader(
                                 $this->siteAccessResolver,
                                 $this->siteAccessNameGenerator,
-                                $options['location']
+                                $options['location'],
+                                $options['languageCode'],
                             ),
                             $this->urlGenerator,
                             $options['content']->id,

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -477,7 +477,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         array $options
     ): ItemInterface {
         $versionNo = $content->getVersionInfo()->versionNo;
-        $languageCode = $content->contentInfo->mainLanguageCode;
+        $languageCode = $content->getDefaultLanguageCode();
 
         $siteAccesses = $this->siteaccessResolver->getSiteAccessesListForLocation(
             $location,


### PR DESCRIPTION
| :ticket: Issue | IBX-9293|
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/site-context/pull/64

#### Description:
Using the preview route's `languageCode` will narrow down site accesses to ones that use this language. 

Moreover, `defaultLanguageCode` seems better when generating preview URI: https://github.com/ibexa/admin-ui/pull/1421/commits/33a77c1d08b951a7295ce686c17697acdb2d226a

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
