### PR TITLE
IBX-9370: Aligned UDW-searchterm with main search

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useSearchByQueryFetch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/hooks/useSearchByQueryFetch.js
@@ -56,7 +56,7 @@ export const useSearchByQueryFetch = () => {
             const query = {};
 
             if (searchText) {
-                query.FullTextCriterion = `${searchText}*`;
+                query.FullTextCriterion = `${searchText}`;
             }
 
             if (fullTextCriterion) {


### PR DESCRIPTION
| :ticket: Issue | IBX-9370 |
|----------------|-----------|

Currently main search and UDW search behave differently:
- UDW search adds a trailing wildcard `*`  to the search term
- Main search does not add a trailing wildcard

This has some pitfalls:
- UDW search and main search will potentially provide different results.
- Wildcard character might be different across search engines or wildcards might not be supported at all.

PR is removing the wildcard.