### PR TITLE
IBX-8945: Improved display of geolocation errors

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -599,7 +599,7 @@
 
             navigator.geolocation.getCurrentPosition(
                 (position) => updateMapState(position.coords.latitude, position.coords.longitude),
-                (error) => ibexa.helpers.notification.showErrorNotification(error),
+                (error) => ibexa.helpers.notification.showErrorNotification(error.message),
             );
         };
         let locationMarker;


### PR DESCRIPTION
| :ticket: Issue | IBX-8945 |
|----------------|-----------|


#### Description:
In `errorCallback` we get a `GeolocationPositionError` object, so we need to pass a value from the field message to `showErrorNotification`, which stores information about the error.



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
