### PR TITLE
IBX-9489: [OSS] UncaughtTypeError after entering 'Content structure'

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/tree-item-toggle-selection/tree.item.toggle.selection.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/tree-item-toggle-selection/tree.item.toggle.selection.js
@@ -24,16 +24,16 @@ const TreeItemToggleSelection = ({ locationId, isContainer, contentTypeIdentifie
         parseTooltip(document.querySelector('.c-list'));
     }, []);
 
+    if (!isUDW) {
+        return null;
+    }
+
     const { isInitLocationsDeselectionBlocked, initSelectedLocationsIds } = useContext(SelectionConfigContext);
     const [selectedLocations, dispatchSelectedLocationsAction] = useContext(SelectedLocationsContext);
     const [multiple, multipleItemsLimit] = useContext(MultipleConfigContext);
     const containersOnly = useContext(ContainersOnlyContext);
     const allowedContentTypes = useContext(AllowedContentTypesContext);
     const restInfo = useContext(RestInfoContext);
-
-    if (!isUDW) {
-        return null;
-    }
 
     const isSelected = selectedLocations.some((selectedLocation) => selectedLocation.location.id === locationId);
     const isNotSelectable =


### PR DESCRIPTION
| :ticket: Issue | [IBX-9489](https://issues.ibexa.co/browse/IBX-9489) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR reverts changing order of operations introduced in https://github.com/ibexa/admin-ui/pull/1409/files#diff-bf77db8b51e34024d4e5a4296543fbdca4b437d11f43b61d4de71482b7b5c794R33
That's not perfect solution, as it breaks rules of hooks (early return before hooks), but this check has to be done here, as all these contexts doesn't exist outside UDW. In a perfect world, this `isUDW` check should be done in parent before rendering this component, but parent is class component, so it can't use context from hooks...
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
