### PR TITLE
IBX-9511: Fixed incorrect object type in PolicyValueResolver

### DIFF
--- a/src/bundle/ValueResolver/PolicyValueResolver.php
+++ b/src/bundle/ValueResolver/PolicyValueResolver.php
@@ -43,15 +43,18 @@ final class PolicyValueResolver extends AbstractValueResolver
         return is_numeric($value);
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
     protected function load(array $key): object
     {
         $roleId = (int)$key[self::ATTRIBUTE_ROLE_ID];
         $policyId = (int)$key[self::ATTRIBUTE_POLICY_ID];
 
-        $roleDraft = $this->roleService->loadRole($roleId);
-        foreach ($roleDraft->getPolicies() as $policy) {
-            /** @var \Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft $policy */
-            if ($policy->originalId === $policyId) {
+        $role = $this->roleService->loadRole($roleId);
+        foreach ($role->getPolicies() as $policy) {
+            if ($policy->id === $policyId) {
                 return $policy;
             }
         }

--- a/tests/bundle/ValueResolver/PolicyValueResolverTest.php
+++ b/tests/bundle/ValueResolver/PolicyValueResolverTest.php
@@ -10,7 +10,9 @@ namespace Ibexa\Tests\Bundle\AdminUi\ValueResolver;
 
 use Ibexa\Bundle\AdminUi\ValueResolver\PolicyValueResolver;
 use Ibexa\Contracts\Core\Repository\RoleService;
+use Ibexa\Contracts\Core\Repository\Values\User\Policy;
 use Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft;
+use Ibexa\Contracts\Core\Repository\Values\User\Role;
 use Ibexa\Contracts\Core\Repository\Values\User\RoleDraft;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -32,16 +34,16 @@ final class PolicyValueResolverTest extends TestCase
 
     public function testResolve(): void
     {
-        $policyDraft = $this->createMock(PolicyDraft::class);
-        $policyDraft
+        $policy = $this->createMock(Policy::class);
+        $policy
             ->method('__get')
-            ->with('originalId')
+            ->with('id')
             ->willReturn(123);
 
-        $roleDraft = $this->createMock(RoleDraft::class);
-        $roleDraft
+        $role = $this->createMock(Role::class);
+        $role
             ->method('getPolicies')
-            ->willReturn([$policyDraft]);
+            ->willReturn([$policy]);
 
         $attributes = [
             'roleId' => '456',
@@ -51,10 +53,10 @@ final class PolicyValueResolverTest extends TestCase
         $this->roleService->expects(self::once())
             ->method('loadRole')
             ->with(456)
-            ->willReturn($roleDraft);
+            ->willReturn($role);
 
         $argumentMetadata = $this->createMock(ArgumentMetadata::class);
-        $argumentMetadata->method('getType')->willReturn(PolicyDraft::class);
+        $argumentMetadata->method('getType')->willReturn(Policy::class);
         $argumentMetadata->method('getName')->willReturn('policy');
 
         $request = new Request([], [], $attributes);
@@ -62,7 +64,7 @@ final class PolicyValueResolverTest extends TestCase
         $result = iterator_to_array($this->resolver->resolve($request, $argumentMetadata));
 
         self::assertCount(1, $result);
-        self::assertSame($policyDraft, $result[0]);
+        self::assertSame($policy, $result[0]);
     }
 
     public function testResolvePolicyNotFound(): void


### PR DESCRIPTION
| :ticket: Issue | IBX-9511 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1415

#### Description:

This PR fixes incorrect expectation and usage of object returned by `RoleService::loadRole` API.
I can't find any occurence where that API would return `RoleDraft` instead of `Role`. For that we have a separate API.

So, that means we need more extensive manual QA, because maybe I'm missing something.

Note: Behat fails due to unmerged DXP PRs.

#### For QA:

PolicyValueResolver is used for Admin -> Roles:
* update policy
* delete policy

however it would be nice to have here more manual tests around that module, as there's probably a reson the code was written as it was.


