### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      - uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: highest
+
+      - name: Run rector
+        run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "ibexa/notifications": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/test-rest": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/rector.php
+++ b/rector.php
@@ -18,4 +18,5 @@ return RectorConfig::configure()
     ->withSets([
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,6 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_61,
+    ]);

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Process\Process;
 
 #[AsCommand(
     name: self::COMMAND_NAME,
-    description: 'Compiles all assets using WebPack Encore'
+    description: 'Compiles all assets using Webpack Encore'
 )]
 class CompileAssetsCommand extends Command
 {

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -19,10 +19,7 @@ use Symfony\Component\Process\Process;
 
 #[AsCommand(
     name: self::COMMAND_NAME,
-    description: 'Compiles all assets using WebPack Encore',
-    aliases: [
-        'ezplatform:encore:compile',
-    ]
+    description: 'Compiles all assets using WebPack Encore'
 )]
 class CompileAssetsCommand extends Command
 {

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -10,20 +10,24 @@ namespace Ibexa\Bundle\AdminUi\Command;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(
+    name: self::COMMAND_NAME,
+    description: 'Compiles all assets using WebPack Encore',
+    aliases: [
+        'ezplatform:encore:compile',
+    ]
+)]
 class CompileAssetsCommand extends Command
 {
     public const COMMAND_NAME = 'ibexa:encore:compile';
     public const COMMAND_DEFAULT_TIMEOUT = 300;
-
-    protected static $defaultName = self::COMMAND_NAME;
-
-    protected static $defaultDescription = 'Compiles all assets using WebPack Encore';
 
     private int $timeout;
 
@@ -36,9 +40,6 @@ class CompileAssetsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setAliases([
-                'ezplatform:encore:compile',
-            ])
             ->addOption(
                 'timeout',
                 't',

--- a/src/bundle/Controller/BookmarkController.php
+++ b/src/bundle/Controller/BookmarkController.php
@@ -87,8 +87,8 @@ class BookmarkController extends Controller
             '@ibexadesign/account/bookmarks/list.html.twig',
             [
                 'pager' => $pagerfanta,
-                'form_edit' => $editForm->createView(),
-                'form_remove' => $removeBookmarkForm->createView(),
+                'form_edit' => $editForm,
+                'form_remove' => $removeBookmarkForm,
             ]
         );
     }

--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -421,7 +421,7 @@ class ContentController extends Controller
             'content' => $content,
             'language_code' => $languageCode,
             'siteaccesses' => $siteAccessesList,
-            'site_access_form' => $siteAccessSelector->createView(),
+            'site_access_form' => $siteAccessSelector,
             'version_no' => $versionNo ?? $content->getVersionInfo()->versionNo,
             'preselected_site_access' => $preselectedSiteAccess,
             'referrer' => $referrer ?? 'content_draft_edit',

--- a/src/bundle/Controller/ContentDraftController.php
+++ b/src/bundle/Controller/ContentDraftController.php
@@ -75,7 +75,7 @@ class ContentDraftController extends Controller
 
         return $this->render('@ibexadesign/content/draft/draft_list.html.twig', [
             'pager' => $pagination,
-            'form_remove' => $removeContentDraftForm->createView(),
+            'form_remove' => $removeContentDraftForm,
         ]);
     }
 

--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -169,7 +169,7 @@ class ContentTypeController extends Controller
             'content_type_group' => $group,
             'pager' => $pagerfanta,
             'deletable' => $deletableTypes,
-            'form_content_types_delete' => $deleteContentTypesForm->createView(),
+            'form_content_types_delete' => $deleteContentTypesForm,
             'group' => $group,
             'route_name' => $routeName,
             'can_create' => $this->isGranted(new Attribute('class', 'create')),
@@ -587,7 +587,7 @@ class ContentTypeController extends Controller
             }
 
             return $this->render('@ibexadesign/content_type/part/field_definition_form.html.twig', [
-                'form' => $fieldDefinitionsGroupForm[$fieldDefinitionIdentifier]->createView(),
+                'form' => $fieldDefinitionsGroupForm[$fieldDefinitionIdentifier],
                 'content_type_group' => $group,
                 'content_type' => $contentTypeDraft,
                 'language_code' => $baseLanguage ? $baseLanguage->languageCode : $language->languageCode,
@@ -733,7 +733,7 @@ class ContentTypeController extends Controller
             'field_definitions_by_group' => $fieldDefinitionsByGroup,
             'can_update' => $canUpdate,
             'languages' => $languages,
-            'form_content_type_edit' => $contentTypeEdit->createView(),
+            'form_content_type_edit' => $contentTypeEdit,
         ]);
     }
 

--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -94,7 +94,7 @@ class ContentTypeGroupController extends Controller
 
         return $this->render('@ibexadesign/content_type/content_type_group/list.html.twig', [
             'pager' => $pagerfanta,
-            'form_content_type_groups_delete' => $deleteContentTypeGroupsForm->createView(),
+            'form_content_type_groups_delete' => $deleteContentTypeGroupsForm,
             'deletable' => $deletableContentTypeGroup,
             'content_types_count' => $count,
             'can_create' => $this->isGranted(new Attribute('class', 'create')),
@@ -150,7 +150,7 @@ class ContentTypeGroupController extends Controller
         }
 
         return $this->render('@ibexadesign/content_type/content_type_group/create.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -204,7 +204,7 @@ class ContentTypeGroupController extends Controller
 
         return $this->render('@ibexadesign/content_type/content_type_group/edit.html.twig', [
             'content_type_group' => $group,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/DashboardController.php
+++ b/src/bundle/Controller/DashboardController.php
@@ -46,7 +46,7 @@ class DashboardController extends Controller
         );
 
         return $this->render('@ibexadesign/ui/dashboard/dashboard.html.twig', [
-            'form_edit' => $editForm->createView(),
+            'form_edit' => $editForm,
             'can_create_content' => $this->permissionResolver->hasAccess('content', 'create'),
         ]);
     }

--- a/src/bundle/Controller/LanguageController.php
+++ b/src/bundle/Controller/LanguageController.php
@@ -93,7 +93,7 @@ class LanguageController extends Controller
 
         return $this->render('@ibexadesign/language/list.html.twig', [
             'pager' => $pagerfanta,
-            'form_languages_delete' => $deleteLanguagesForm->createView(),
+            'form_languages_delete' => $deleteLanguagesForm,
             'can_administrate' => $this->isGranted(new Attribute('content', 'translations')),
         ]);
     }
@@ -113,7 +113,7 @@ class LanguageController extends Controller
 
         return $this->render('@ibexadesign/language/index.html.twig', [
             'language' => $language,
-            'deleteForm' => $deleteForm->createView(),
+            'deleteForm' => $deleteForm,
             'can_administrate' => $this->isGranted(new Attribute('content', 'translations')),
         ]);
     }
@@ -235,7 +235,7 @@ class LanguageController extends Controller
         }
 
         return $this->render('@ibexadesign/language/create.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
             'actionUrl' => $this->generateUrl('ibexa.language.create'),
         ]);
     }
@@ -282,7 +282,7 @@ class LanguageController extends Controller
         }
 
         return $this->render('@ibexadesign/language/edit.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
             'actionUrl' => $this->generateUrl('ibexa.language.edit', ['languageId' => $language->id]),
             'language' => $language,
         ]);

--- a/src/bundle/Controller/LinkManagerController.php
+++ b/src/bundle/Controller/LinkManagerController.php
@@ -105,7 +105,7 @@ final class LinkManagerController extends Controller
         }
 
         return $this->render('@ibexadesign/link_manager/edit.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
             'url' => $url,
         ]);
     }
@@ -135,7 +135,7 @@ final class LinkManagerController extends Controller
             'url' => $url,
             'can_edit' => $this->isGranted(new Attribute('url', 'update')),
             'usages' => $usages,
-            'form_edit' => $editForm->createView(),
+            'form_edit' => $editForm,
         ]);
     }
 }

--- a/src/bundle/Controller/ObjectStateController.php
+++ b/src/bundle/Controller/ObjectStateController.php
@@ -96,7 +96,7 @@ class ObjectStateController extends Controller
             'object_state_group' => $objectStateGroup,
             'object_states' => $objectStates,
             'unused_object_states' => $unusedObjectStates,
-            'form_states_delete' => $deleteObjectStatesForm->createView(),
+            'form_states_delete' => $deleteObjectStatesForm,
         ]);
     }
 
@@ -177,7 +177,7 @@ class ObjectStateController extends Controller
 
         return $this->render('@ibexadesign/object_state/add.html.twig', [
             'object_state_group' => $objectStateGroup,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -314,7 +314,7 @@ class ObjectStateController extends Controller
         return $this->render('@ibexadesign/object_state/edit.html.twig', [
             'object_state_group' => $objectState->getObjectStateGroup(),
             'object_state' => $objectState,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -79,7 +79,7 @@ class ObjectStateGroupController extends Controller
             'can_administrate' => $this->isGranted(new Attribute('state', 'administrate')),
             'object_state_groups' => $objectStateGroups,
             'empty_object_state_groups' => $emptyObjectStateGroups,
-            'form_state_groups_delete' => $deleteObjectStateGroupsForm->createView(),
+            'form_state_groups_delete' => $deleteObjectStateGroupsForm,
         ]);
     }
 
@@ -156,7 +156,7 @@ class ObjectStateGroupController extends Controller
         }
 
         return $this->render('@ibexadesign/object_state/object_state_group/add.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -284,7 +284,7 @@ class ObjectStateGroupController extends Controller
 
         return $this->render('@ibexadesign/object_state/object_state_group/edit.html.twig', [
             'object_state_group' => $group,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/PolicyController.php
+++ b/src/bundle/Controller/PolicyController.php
@@ -113,7 +113,7 @@ class PolicyController extends Controller
         );
 
         return $this->render('@ibexadesign/user/policy/list.html.twig', [
-            'form_policies_delete' => $deletePoliciesForm->createView(),
+            'form_policies_delete' => $deletePoliciesForm,
             'is_editable' => $isEditable,
             'role' => $role,
             'pager' => $pagerfanta,
@@ -192,7 +192,7 @@ class PolicyController extends Controller
 
         return $this->render('@ibexadesign/user/policy/add.html.twig', [
             'role' => $role,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -278,7 +278,7 @@ class PolicyController extends Controller
         return $this->render('@ibexadesign/user/policy/edit.html.twig', [
             'role' => $role,
             'policy' => $policy,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -327,7 +327,7 @@ class PolicyController extends Controller
 
         return $this->render('@ibexadesign/user/policy/create_with_limitation.html.twig', [
             'role' => $role,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/RoleAssignmentController.php
+++ b/src/bundle/Controller/RoleAssignmentController.php
@@ -89,7 +89,7 @@ class RoleAssignmentController extends Controller
 
         return $this->render('@ibexadesign/user/role_assignment/list.html.twig', [
             'role' => $role,
-            'form_role_assignments_delete' => $deleteRoleAssignmentsForm->createView(),
+            'form_role_assignments_delete' => $deleteRoleAssignmentsForm,
             'pager' => $pagerfanta,
             'route_name' => $routeName,
             'can_assign' => $this->isGranted(new Attribute('role', 'assign')),
@@ -139,7 +139,7 @@ class RoleAssignmentController extends Controller
 
         return $this->render('@ibexadesign/user/role_assignment/create.html.twig', [
             'role' => $role,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/RoleController.php
+++ b/src/bundle/Controller/RoleController.php
@@ -104,7 +104,7 @@ class RoleController extends Controller
         $rolesDeleteForm = $this->formFactory->deleteRoles($rolesDeleteData);
 
         return $this->render('@ibexadesign/user/role/list.html.twig', [
-            'form_roles_delete' => $rolesDeleteForm->createView(),
+            'form_roles_delete' => $rolesDeleteForm,
             'pager' => $pagerfanta,
             'can_create' => $this->isGranted(new Attribute('role', 'create')),
             'can_delete' => $this->isGranted(new Attribute('role', 'delete')),
@@ -121,7 +121,7 @@ class RoleController extends Controller
 
         return $this->render('@ibexadesign/user/role/index.html.twig', [
             'role' => $role,
-            'delete_form' => $deleteForm->createView(),
+            'delete_form' => $deleteForm,
             'route_name' => $request->get('_route'),
             'policy_page' => $policyPage,
             'assignment_page' => $assignmentPage,
@@ -172,7 +172,7 @@ class RoleController extends Controller
         }
 
         return $this->render('@ibexadesign/user/role/add.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -207,7 +207,7 @@ class RoleController extends Controller
 
         return $this->render('@ibexadesign/user/role/copy.html.twig', [
             'role' => $role,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -264,7 +264,7 @@ class RoleController extends Controller
 
         return $this->render('@ibexadesign/user/role/edit.html.twig', [
             'role' => $role,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -171,8 +171,8 @@ class SectionController extends Controller
             'content_count' => $contentCountBySectionId,
             'deletable' => $deletableSections,
             'assignable' => $assignableSections,
-            'form_sections_delete' => $deleteSectionsForm->createView(),
-            'form_section_content_assign' => $assignContentForms->createView(),
+            'form_sections_delete' => $deleteSectionsForm,
+            'form_section_content_assign' => $assignContentForms,
         ]);
     }
 
@@ -432,7 +432,7 @@ class SectionController extends Controller
         }
 
         return $this->render('@ibexadesign/section/create.html.twig', [
-            'form_section_create' => $form->createView(),
+            'form_section_create' => $form,
         ]);
     }
 
@@ -480,7 +480,7 @@ class SectionController extends Controller
 
         return $this->render('@ibexadesign/section/update.html.twig', [
             'section' => $section,
-            'form_section_update' => $form->createView(),
+            'form_section_update' => $form,
         ]);
     }
 

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -165,10 +165,10 @@ class TrashController extends Controller
             'can_view_section' => $this->isGranted(new Attribute('section', 'view')),
             'trash_items' => $trashItemsList,
             'pager' => $pagerfanta,
-            'form_trash_item_restore' => $trashItemRestoreForm->createView(),
-            'form_trash_item_delete' => $trashItemDeleteForm->createView(),
-            'form_trash_empty' => $trashEmptyForm->createView(),
-            'form_search' => $searchForm->createView(),
+            'form_trash_item_restore' => $trashItemRestoreForm,
+            'form_trash_item_delete' => $trashItemDeleteForm,
+            'form_trash_empty' => $trashEmptyForm,
+            'form_search' => $searchForm,
             'user_content_type_identifier' => $this->configResolver->getParameter('user_content_type_identifier'),
         ]);
     }

--- a/src/bundle/Controller/URLWildcardController.php
+++ b/src/bundle/Controller/URLWildcardController.php
@@ -158,7 +158,7 @@ final class URLWildcardController extends Controller
         );
 
         return $this->render('@ibexadesign/url_wildcard/update.html.twig', [
-            'form' => $form->createView(),
+            'form' => $form,
             'actionUrl' => $actionUrl,
             'urlWildcard' => $urlWildcard,
         ]);

--- a/src/bundle/Controller/User/FocusModeController.php
+++ b/src/bundle/Controller/User/FocusModeController.php
@@ -84,7 +84,7 @@ final class FocusModeController extends Controller
         return $this->render(
             '@ibexadesign/ui/focus_mode_form.html.twig',
             [
-                'form' => $form->createView(),
+                'form' => $form,
             ]
         );
     }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,7 +1,6 @@
 imports:
     - { resource: services/service_aliases.yaml }
     - { resource: services/config.yaml }
-    - { resource: services/controller_argument_resolvers.yaml }
     - { resource: services/controllers.yaml }
     - { resource: services/tabs.yaml }
     - { resource: services/menu.yaml }
@@ -39,6 +38,7 @@ imports:
     - { resource: services/icons.yaml }
     - { resource: services/role_form_mappers.yaml }
     - { resource: services/security.yaml }
+    - { resource: services/value_resolvers.yaml }
 
 parameters:
     ibexa.admin_ui.load_users_with_permission_info.limit: 10
@@ -53,12 +53,6 @@ services:
     Ibexa\Contracts\AdminUi\Controller\Controller:
         tags:
             -   name: controller.service_arguments
-
-    Ibexa\Bundle\AdminUi\ValueResolver\:
-        resource: "../../ValueResolver/*"
-        tags:
-            -   name: controller.argument_value_resolver
-                priority: 150
 
     Ibexa\AdminUi\UI\Dataset\DatasetFactory:
         lazy: true

--- a/src/bundle/Resources/config/services/value_resolvers.yaml
+++ b/src/bundle/Resources/config/services/value_resolvers.yaml
@@ -4,11 +4,17 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Bundle\AdminUi\ControllerArgumentResolver\UniversalDiscoveryRequestQueryArgumentResolver:
+    Ibexa\Bundle\AdminUi\ValueResolver\:
+        resource: "../../ValueResolver/*"
+        tags:
+            -   name: controller.argument_value_resolver
+                priority: 150
+
+    Ibexa\Bundle\AdminUi\ValueResolver\UniversalDiscoveryRequestQueryValueResolver:
         tags:
             - { name: controller.argument_value_resolver, priority: 50 }
 
-    Ibexa\Bundle\AdminUi\ControllerArgumentResolver\ContentTreeChildrenQueryArgumentResolver:
+    Ibexa\Bundle\AdminUi\ValueResolver\ContentTreeChildrenQueryValueResolver:
         arguments:
             $criterionProcessor: '@Ibexa\AdminUi\REST\Input\Parser\CriterionProcessor'
         tags:

--- a/src/bundle/Templating/Twig/ComponentExtension.php
+++ b/src/bundle/Templating/Twig/ComponentExtension.php
@@ -32,12 +32,12 @@ class ComponentExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_render_component_group',
-                [$this, 'renderComponentGroup'],
+                $this->renderComponentGroup(...),
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
                 'ibexa_render_component',
-                [$this, 'renderComponent'],
+                $this->renderComponent(...),
                 ['is_safe' => ['html']]
             ),
         ];

--- a/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeGroupIconExtension.php
@@ -29,7 +29,7 @@ final class ContentTypeGroupIconExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_content_type_group_icon',
-                [$this->contentTypeGroupIconResolver, 'getContentTypeGroupIcon'],
+                $this->contentTypeGroupIconResolver->getContentTypeGroupIcon(...),
                 [
                     'is_safe' => ['html'],
                 ]

--- a/src/bundle/Templating/Twig/ContentTypeIconExtension.php
+++ b/src/bundle/Templating/Twig/ContentTypeIconExtension.php
@@ -26,7 +26,7 @@ class ContentTypeIconExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_content_type_icon',
-                [$this->contentTypeIconResolver, 'getContentTypeIcon'],
+                $this->contentTypeIconResolver->getContentTypeIcon(...),
                 [
                     'is_safe' => ['html'],
                 ]

--- a/src/bundle/Templating/Twig/EmbeddedItemEditFormExtension.php
+++ b/src/bundle/Templating/Twig/EmbeddedItemEditFormExtension.php
@@ -34,7 +34,7 @@ final class EmbeddedItemEditFormExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_render_embedded_item_edit_form',
-                [$this, 'renderEmbeddedItemEditForm']
+                $this->renderEmbeddedItemEditForm(...)
             ),
         ];
     }

--- a/src/bundle/Templating/Twig/FieldGroupRenderingExtension.php
+++ b/src/bundle/Templating/Twig/FieldGroupRenderingExtension.php
@@ -33,7 +33,7 @@ final class FieldGroupRenderingExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'ibexa_field_group_name',
-                [$this, 'getFieldGroupName']
+                $this->getFieldGroupName(...)
             ),
         ];
     }

--- a/src/bundle/Templating/Twig/FormatIntervalExtension.php
+++ b/src/bundle/Templating/Twig/FormatIntervalExtension.php
@@ -37,7 +37,7 @@ class FormatIntervalExtension extends AbstractExtension implements TranslationCo
     public function getFilters()
     {
         return [
-            new TwigFilter('format_interval', [$this, 'formatInterval']),
+            new TwigFilter('format_interval', $this->formatInterval(...)),
         ];
     }
 

--- a/src/bundle/Templating/Twig/IconPathExtension.php
+++ b/src/bundle/Templating/Twig/IconPathExtension.php
@@ -27,7 +27,7 @@ final class IconPathExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ez_icon_path',
-                [$this, 'getIconPath'],
+                $this->getIconPath(...),
                 [
                     'is_safe' => ['html'],
                     'deprecated' => true,
@@ -36,7 +36,7 @@ final class IconPathExtension extends AbstractExtension
             ),
             new TwigFunction(
                 'ibexa_icon_path',
-                [$this, 'getIconPath'],
+                $this->getIconPath(...),
                 [
                     'is_safe' => ['html'],
                 ]

--- a/src/bundle/Templating/Twig/PathStringExtension.php
+++ b/src/bundle/Templating/Twig/PathStringExtension.php
@@ -30,7 +30,7 @@ class PathStringExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_path_to_locations',
-                [$this, 'getLocationList']
+                $this->getLocationList(...)
             ),
         ];
     }

--- a/src/bundle/Templating/Twig/TimeDiffExtension.php
+++ b/src/bundle/Templating/Twig/TimeDiffExtension.php
@@ -29,7 +29,7 @@ class TimeDiffExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'ibexa_datetime_diff',
-                [$this, 'diff'],
+                $this->diff(...),
                 ['is_safe' => ['html']]
             ),
         ];

--- a/src/bundle/Templating/Twig/UniversalDiscoveryExtension.php
+++ b/src/bundle/Templating/Twig/UniversalDiscoveryExtension.php
@@ -34,7 +34,7 @@ class UniversalDiscoveryExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_udw_config',
-                [$this, 'renderUniversalDiscoveryWidgetConfig'],
+                $this->renderUniversalDiscoveryWidgetConfig(...),
                 ['is_safe' => ['json']]
             ),
         ];

--- a/src/bundle/ValueResolver/UniversalDiscoveryRequestQueryValueResolver.php
+++ b/src/bundle/ValueResolver/UniversalDiscoveryRequestQueryValueResolver.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Bundle\AdminUi\ControllerArgumentResolver;
+namespace Ibexa\Bundle\AdminUi\ValueResolver;
 
 use Ibexa\AdminUi\Exception\ValidationFailedException;
 use Ibexa\AdminUi\REST\Value\UniversalDiscovery\RequestQuery;
@@ -15,11 +15,11 @@ use Ibexa\Contracts\AdminUi\UniversalDiscovery\Provider;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-final class UniversalDiscoveryRequestQueryArgumentResolver implements ArgumentValueResolverInterface
+final class UniversalDiscoveryRequestQueryValueResolver implements ValueResolverInterface
 {
     private Provider $provider;
 
@@ -33,7 +33,7 @@ final class UniversalDiscoveryRequestQueryArgumentResolver implements ArgumentVa
         $this->validator = $validator;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    private function supports(ArgumentMetadata $argument): bool
     {
         return RequestQuery::class === $argument->getType()
             && 'requestQuery' === $argument->getName();
@@ -44,6 +44,10 @@ final class UniversalDiscoveryRequestQueryArgumentResolver implements ArgumentVa
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
+        if (!$this->supports($argument)) {
+            return [];
+        }
+
         $this->validate($request);
 
         $query = $request->query;


### PR DESCRIPTION
| :ticket: Issue | IBX-9584 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute  
* [CLI] Dropped ezplatform:encore:compile command alias
* [PHP] Updated method reference syntax
* [HTTP] Migrated from ArgumentValueResolvedInterface to ValueResolverInterfaceInterface
* [HTTP] Symplified form rendering by not calling `->createView()` on `render` function

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+. Example failing job: https://github.com/ibexa/admin-ui/actions/runs/13224490057/job/36913615653 

#### For QA:

Sanities.

#### Documentation:

N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
