### PR TITLE
IBX-9577: Fixed fetching query data for Trash search

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -761,21 +761,6 @@ parameters:
 			path: src/bundle/Controller/TranslationController.php
 
 		-
-			message: "#^Offset 'page' on string\\|null on left side of \\?\\? does not exist\\.$#"
-			count: 1
-			path: src/bundle/Controller/TrashController.php
-
-		-
-			message: "#^Parameter \\#1 \\$key of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\:\\:get\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Controller/TrashController.php
-
-		-
-			message: "#^Variable \\$requestedPage in empty\\(\\) always exists and is always falsy\\.$#"
-			count: 1
-			path: src/bundle/Controller/TrashController.php
-
-		-
 			message: "#^Argument of an invalid type array\\<bool\\>\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/bundle/Controller/URLWildcardController.php

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -118,7 +118,7 @@ class TrashController extends Controller
 
         $searchForm->handleRequest($request);
 
-        $requestedPage = $request->query->get($searchFormName)['page'] ?? null;
+        $requestedPage = $request->query->all($searchFormName)['page'] ?? null;
         $page = empty($requestedPage) ? 1 : (int)$requestedPage;
         $trashItemsList = [];
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9577 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1415


#### Description:

This is a follow up to Symfony 6 upgrade (#1415). In Symfony 6 we can no longer use `$request->query->get` on non-scalar request query parameters. Resolving here the issue at hand, however I expect some follow-ups.



#### For QA:

Steps from JIRA.
