### PR TITLE
[Twig] Removed usage of deprecated spaceless filter

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/policies/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/policies/limitation_values.html.twig
@@ -1,25 +1,21 @@
 {% extends '@ibexadesign/limitation/limitation_values.html.twig' %}
 
 {% block ez_limitation_node_value %}
-    {% apply spaceless %}
-        {% for path in values %}
-            {% for value in path %}
-                <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
-                {% if not loop.last %} / {% endif %}
-            {% endfor %}
-            {% if not loop.last %}, {% endif %}
+    {% for path in values %}
+        {% for value in path %}
+            <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
+            {% if not loop.last %} / {% endif %}
         {% endfor %}
-    {% endapply %}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
 {% endblock %}
 
 {% block ez_limitation_subtree_value %}
-    {% apply spaceless %}
-        {% for path in values %}
-            {% for value in path %}
-                <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
-                {% if not loop.last %} / {% endif %}
-            {% endfor %}
-            {% if not loop.last %}, {% endif %}
+    {% for path in values %}
+        {% for value in path %}
+            <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
+            {% if not loop.last %} / {% endif %}
         {% endfor %}
-    {% endapply %}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/content/tab/roles/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/roles/limitation_values.html.twig
@@ -1,13 +1,11 @@
 {% extends '@ibexadesign/limitation/limitation_values.html.twig' %}
 
 {% block ez_limitation_subtree_value %}
-    {% apply spaceless %}
-        {% for path in values %}
-            {% for value in path %}
-                <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
-                {% if not loop.last %} / {% endif %}
-            {% endfor %}
-            {% if not loop.last %}, {% endif %}
+    {% for path in values %}
+        {% for value in path %}
+            <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
+            {% if not loop.last %} / {% endif %}
         {% endfor %}
-    {% endapply %}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
@@ -1,161 +1,119 @@
 {# fallback block for limitations without defined value mapper #}
 {% block ez_limitation_value_fallback %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_class_value %}
-{% apply spaceless %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_language_value %}
-{% apply spaceless %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_node_value %}
-{% apply spaceless %}
     {% for path in values %}
         {% for value in path %}/{{ value.name }}{% endfor %}
         {% if not loop.last %}, {% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_owner_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_changeowner_value %}
-    {% apply spaceless %}
-        {{ values|join(', ') }}
-    {% endapply %}
+    {{ values|join(', ') }}
 {% endblock %}
 
 {% block ez_limitation_parentowner_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_parentclass_value %}
-{% apply spaceless %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_section_value %}
-{% apply spaceless %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_newsection_value %}
-{% apply spaceless %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_siteaccess_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_state_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_newstate_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_subtree_value %}
-{% apply spaceless %}
     {% for path in values %}
         {% for value in path %}/{{ value.name }}{% endfor %}
         {% if not loop.last %}, {% endif %}
     {% endfor %}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_group_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_parentdepth_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_parentgroup_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_status_value %}
-{% apply spaceless %}
     {{ values|join(', ') }}
-{% endapply %}
 {% endblock %}
 
 {% block ez_limitation_userpermissions_value %}
-    {% apply spaceless %}
-        <br>
-        {{ "role.policy.limitation.userpermissions.role_title"
-        |trans({}, 'ibexa_content_forms_role')
-        |desc("Roles:") }}
-        {% if values['roles'] is empty %}
-            {{- 'policy.limitation.none'|trans|desc('None') -}}
-        {% endif %}
-        {% for role in values['roles'] %}
-            {{ role.identifier }}{% if not loop.last %},{% else %}{% endif %}
-        {% endfor %}
-        <br>
-        {{ "role.policy.limitation.userpermissions.user_groups_title"
-        |trans({}, 'ibexa_content_forms_role')
-        |desc("User Groups:") }}
-        {% if values['user_groups'] is empty %}
-            {{- 'policy.limitation.none'|trans|desc('None') -}}
-        {% endif %}
-        {% for user_group in values['user_groups'] %}
-            {{ user_group.name }}{% if not loop.last %},{% else %}{% endif %}
-        {% endfor %}
-    {% endapply %}
+    <br>
+    {{ "role.policy.limitation.userpermissions.role_title"
+    |trans({}, 'ibexa_content_forms_role')
+    |desc("Roles:") }}
+    {% if values['roles'] is empty %}
+        {{- 'policy.limitation.none'|trans|desc('None') -}}
+    {% endif %}
+    {% for role in values['roles'] %}
+        {{ role.identifier }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
+    <br>
+    {{ "role.policy.limitation.userpermissions.user_groups_title"
+    |trans({}, 'ibexa_content_forms_role')
+    |desc("User Groups:") }}
+    {% if values['user_groups'] is empty %}
+        {{- 'policy.limitation.none'|trans|desc('None') -}}
+    {% endif %}
+    {% for user_group in values['user_groups'] %}
+        {{ user_group.name }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
 {% endblock %}
 
 {% block ez_limitation_memberof_value %}
-    {% apply spaceless %}
-        {{ values|join(', ') }}
-    {% endapply %}
+    {{ values|join(', ') }}
 {% endblock %}
 
 {% block ez_limitation_role_value %}
-    {% apply spaceless %}
-        {{ values|join(', ') }}
-    {% endapply %}
+    {{ values|join(', ') }}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/component/tag_view_select/tag_view_select.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/tag_view_select/tag_view_select.html.twig
@@ -27,25 +27,23 @@
             {{ title|default(default_title) }}
         </div>
     {% endif %}
-    {% apply spaceless %}
-        <div
-            class="ibexa-tag-view-select__selected-list {{items|length == 0 ? 'ibexa-tag-view-select__selected-list--empty'}}"
-            data-template="{{ include('@ibexadesign/ui/component/tag_view_select/tag_view_select_selected_item_tag.html.twig', {
-                id: '{{ id }}',
-                name: '{{ name }}',
+    <div
+        class="ibexa-tag-view-select__selected-list {{items|length == 0 ? 'ibexa-tag-view-select__selected-list--empty'}}"
+        data-template="{{ include('@ibexadesign/ui/component/tag_view_select/tag_view_select_selected_item_tag.html.twig', {
+            id: '{{ id }}',
+            name: '{{ name }}',
+            is_deletable: is_delete_visible,
+        })|e('html_attr') }}"
+    >
+        {% for item in items %}
+            {{ include('@ibexadesign/ui/component/tag_view_select/tag_view_select_selected_item_tag.html.twig', {
+                id: item.id,
+                name: item.name,
                 is_deletable: is_delete_visible,
-            })|e('html_attr') }}"
-        >
-            {% for item in items %}
-                {{ include('@ibexadesign/ui/component/tag_view_select/tag_view_select_selected_item_tag.html.twig', {
-                    id: item.id,
-                    name: item.name,
-                    is_deletable: is_delete_visible,
-                    is_disabled
-                }) }}
-            {% endfor %}
-        </div>
-    {% endapply %}
+                is_disabled
+            }) }}
+        {% endfor %}
+    </div>
     {{ form_widget(form, {
         attr: { hidden: true }
     }) }}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -3,35 +3,29 @@
 {% trans_default_domain 'ibexa_fieldtypes_preview' %}
 
 {% block ezauthor_field %}
-    {% apply spaceless %}
-        {% if field.value.authors|length() > 0 %}
+    {% if field.value.authors|length() > 0 %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezauthor')|trim}) %}
-            <ul {{ block( 'field_attributes' ) }}>
-                {% for author in field.value.authors %}
-                    <li>
-                        {{ author.name }}
-                        {% if author.email is not empty %}
-                            &lt;<a href="mailto:{{ author.email|escape( 'url' ) }}">{{ author.email }}</a>&gt;
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-    {% endapply %}
+        <ul {{ block( 'field_attributes' ) }}>
+            {% for author in field.value.authors %}
+                <li>
+                    {{ author.name }}
+                    {% if author.email is not empty %}
+                        &lt;<a href="mailto:{{ author.email|escape( 'url' ) }}">{{ author.email }}</a>&gt;
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endblock %}
 
 {% block ezstring_field %}
-{% apply spaceless %}
     {% set field_value = field.value.text %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block eztext_field %}
-{% apply spaceless %}
     {% set field_value = field.value|nl2br %}
     {{ block( 'simple_block_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezrichtext_field %}
@@ -40,7 +34,6 @@
 {% endblock %}
 
 {% block ezcountry_field %}
-{% apply spaceless %}
     {% if fieldSettings.isMultiple and field.value.countries|length > 0 %}
         <ul {{ block( 'field_attributes' ) }}>
             {% for country in field.value.countries %}
@@ -54,18 +47,14 @@
         {% endfor %}
         </p>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezboolean_field %}
-{% apply spaceless %}
     {% set field_value = field.value.bool ? 'ezboolean.yes'|trans|desc('Yes') : 'ezboolean.no'|trans|desc('No') %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezdatetime_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.value|ibexa_full_datetime %}
         {{ block( 'simple_block_field' ) }}
@@ -77,20 +66,16 @@
             } only %}
         {% endif %}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezdate_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.date|ibexa_full_date('UTC') %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block eztime_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.time|ibexa_full_time('UTC') %}
         {{ block( 'simple_block_field' ) }}
@@ -102,54 +87,42 @@
             } only %}
         {% endif %}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezemail_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.email %}
         <a href="mailto:{{ field.value.email|escape( 'url' ) }}" {{ block( 'field_attributes' ) }}>{{ field.value.email }}</a>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezinteger_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezfloat_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.value|format_number %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezurl_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         <a href="{{ field.value.link }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.text ? field.value.text : field.value.link }}</a>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezisbn_field %}
-{% apply spaceless %}
     {% set field_value = field.value.isbn %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezkeyword_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezkeyword')|trim}) %}
         <ul {{ block( 'field_attributes' ) }}>
@@ -162,11 +135,9 @@
         {% endfor %}
         </ul>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezselection_field %}
-{% apply spaceless %}
     {% set options = fieldSettings.options %}
 
     {% if fieldSettings.multilingualOptions[field.languageCode] is defined %}
@@ -195,7 +166,6 @@
             {{ block( 'simple_block_field' ) }}
         </div>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# @todo:
@@ -203,7 +173,6 @@
  # - legacy used to dump is_locked attribute
  #}
 {% block ezuser_field %}
-{% apply spaceless %}
 {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezuser')|trim}) %}
 <div class="ibexa-scrollable-table-wrapper mb-0">
     <table {{ block( 'field_attributes' ) }}>
@@ -242,11 +211,9 @@
         </p>
     {% endif %}
 </div>
-{% endapply %}
 {% endblock %}
 
 {% block ezbinaryfile_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set route_reference = ibexa_route( 'ibexa.content.download', {
             'content': content,
@@ -268,12 +235,10 @@
             </a>
         </div>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezmedia_field %}
 {% if not ibexa_field_is_empty( content, field ) %}
-{% apply spaceless %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezmedia')|trim}) %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
@@ -337,12 +302,10 @@
     {% endif %}
     {% endautoescape %}
     </div>
-{% endapply %}
 {% endif %}
 {% endblock %}
 
 {% block ezobjectrelationlist_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezobjectrelationlist')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
@@ -369,12 +332,10 @@
         {% endembed %}
     </div>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 
 {% block ezgmaplocation_field %}
-{% apply spaceless %}
 {% if field.value is not null %}
     {% set latitude = field.value.latitude %}
     {% set longitude = field.value.longitude %}
@@ -407,13 +368,10 @@
             </table>
         </div>
     </div>
-
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezimage_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) %}
 {% set imageAlias = ibexa_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
 {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
@@ -466,11 +424,9 @@
     </div>
 </div>
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezimageasset_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezimageasset')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
@@ -486,11 +442,9 @@
 {% else %}
     <em>{{ 'ezimageasset.not_available'|trans|desc('Image asset is not available (related content has been deleted or you have insufficient permissions)') }}</em>
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezobjectrelation_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ibexa-field-preview ibexa-field-preview--ezobjectrelationlist')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
@@ -515,47 +469,37 @@
         {% endembed %}
     </div>
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# pageService is exposed under parameters.pageService thanks to Page\ParameterProvider #}
 {% block ezpage_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) %}
     {% set layout = field.value.page.layout %}
     {% set template = parameters.pageService.getLayoutTemplate( layout ) %}
     {% include template with { 'zones': field.value.page.zones, 'zone_layout': layout, 'pageService': parameters.pageService } %}
 {% endif %}
-{% endapply %}
 {% endblock %}
-
 
 {# The simple_block_field block is a shorthand html block-based fields (like eztext or ezrichtext) #}
 {# You can define a field_value variable before rendering this one if you need special operation for rendering content (i.e. nl2br) #}
 {% block simple_block_field %}
-{% apply spaceless %}
     {% if field_value is not defined %}
         {% set field_value = field.value %}
     {% endif %}
     <div {{ block( 'field_attributes' ) }}>
-        {% endapply %}{{ field_value|raw }}{% apply spaceless %}
+        {{ field_value|raw }}
     </div>
-{% endapply %}
 {% endblock %}
 
 {% block simple_inline_field %}
-{% apply spaceless %}
     {% if field_value is not defined %}
         {% set field_value = field.value %}
     {% endif %}
     <span {{ block( 'field_attributes' ) }}>{{ field_value }}</span>
-{% endapply %}
 {% endblock %}
 
 {# Block for field attributes rendering. Useful to add a custom class, id or whatever HTML attribute to the field markup #}
 {% block field_attributes %}
-{% apply spaceless %}
     {% set attr = attr|default( {} ) %}
     {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
-{% endapply %}
 {% endblock %}


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

> The spaceless filter is deprecated as of Twig 3.12 and will be removed in Twig 4.0.

See https://twig.symfony.com/doc/3.x/deprecated.html 

#### For QA:
Limitations and field types rendering.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
