### PR TITLE
Fix getContentTypeIconUrl JSDoc @function tag

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/content.type.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/content.type.helper.js
@@ -38,7 +38,7 @@ const getContentTypeDataMapByHref = () => {
 /**
  * Returns an URL to a content type icon
  *
- * @function getContentTypeIcon
+ * @function getContentTypeIconUrl
  * @param {String} contentTypeIdentifier
  * @returns {String|null} url to icon
  */


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 

- ibexa/documentation-developer#2634

#### Description:

The `@function getContentTypeIcon` tag didn't match the function constant name `getContentTypeIconUrl`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
