### PR TITLE
IBX-9636: Pagination arrows not displayed correctly

### DIFF
--- a/src/bundle/View/Template/IbexaPagerfantaTemplate.php
+++ b/src/bundle/View/Template/IbexaPagerfantaTemplate.php
@@ -23,6 +23,8 @@ class IbexaPagerfantaTemplate extends TwitterBootstrap4Template
         parent::__construct();
 
         $this->setOptions([
+            'css_prev_class' => 'prev',
+            'css_next_class' => 'next',
             'prev_message' => '',
             'next_message' => '',
             'active_suffix' => '',


### PR DESCRIPTION
| :ticket: Issue | IBX-9636 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
The problem is the lack of `.prev` and `.next` css classes that we use to style the buttons.
Ibexa DXP v5.0 uses `"pagerfant/pagerfant": "^3.6.2"` while in v4.6 `"pagerfant/pagerfant": "^2.7"` the getDefaultOptions method returning defaults paramteres has changed between versions.

Pagerfanta 3.x: 
`css_prev_class` and `css_next_class` return empty string
https://github.com/BabDev/Pagerfanta/blob/3.x/lib/Core/View/Template/TwitterBootstrapTemplate.php#L21-L22

Pagerfanta 2.x: 
`css_prev_class` return css class `prev`
 `css_next_class` return css class `next`
https://github.com/BabDev/Pagerfanta/blob/2.x/lib/Core/View/Template/TwitterBootstrapTemplate.php#L16-L17

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
