### PR TITLE
Ibx 8316 temp

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/modal.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/modal.helper.js
@@ -11,7 +11,7 @@ const controlZIndex = (container) => {
     document.body.dispatchEvent(new CustomEvent('ibexa-control-z-index:events-attached'));
 };
 
-const betterControlZIndex = (containers, listenerContainer, resetedZIndex = 'initial') => {
+const betterControlZIndex = (items, listenerContainer) => {
     const listenersAbortController = new AbortController();
     const containersInitialZIndexes = new Map();
     const removeControlZIndexListeners = () => {
@@ -19,24 +19,18 @@ const betterControlZIndex = (containers, listenerContainer, resetedZIndex = 'ini
         listenerContainer.dispatchEvent(new CustomEvent('ibexa-control-z-index:events-detached'));
     }
 
-    containers.forEach((container) => {
+    items.forEach(({ container }) => {
         containersInitialZIndexes.set(container, container.style.zIndex);
     });
 
-    containers.forEach((container) => {
-        listenerContainer.addEventListener('show.bs.modal', () => {
-            container.style.zIndex = resetedZIndex;
+    listenerContainer.addEventListener('show.bs.modal', () => {
+        items.forEach(({ container, zIndex = 'initial' }) => {
+            container.style.zIndex = zIndex;
         });
-    });
-
-    // listenerContainer.addEventListener('show.bs.modal', () => {
-    //     containers.forEach((container) => {
-    //         container.style.zIndex = resetedZIndex;
-    //     });
-    // }, { signal: listenersAbortController.signal });
+    }, { signal: listenersAbortController.signal });
 
     listenerContainer.addEventListener('hidden.bs.modal', () => {
-        containers.forEach((container) => {
+        items.forEach(({ container }) => {
             container.style.zIndex = containersInitialZIndexes.get(container);
         });
     }, { signal: listenersAbortController.signal });

--- a/src/bundle/Resources/public/js/scripts/helpers/modal.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/modal.helper.js
@@ -1,14 +1,42 @@
-const controlZIndex = (container) => {
+const controlZIndex = (container, listenerContainer, resetedZIndex = 'initial') => {
     const initialZIndex = container.style.zIndex;
-
-    container.addEventListener('show.bs.modal', () => {
-        container.style.zIndex = 'initial';
-    });
-    container.addEventListener('hide.bs.modal', () => {
+    const finalListenerContainer = listenerContainer ?? container;
+    const handleShowModal = () => {
+        container.style.zIndex = resetedZIndex;
+    };
+    const handleCloseModal = () => {
         container.style.zIndex = initialZIndex;
-    });
+    };
+    const removeControlZIndexListeners = () => {
+        finalListenerContainer.removeEventListener('show.bs.modal', handleShowModal, false);
+        finalListenerContainer.removeEventListener('hidden.bs.modal', handleCloseModal, false);
+
+        document.body.dispatchEvent(new CustomEvent('ibexa-control-z-index:events-detached'));
+    };
+
+    finalListenerContainer.addEventListener('show.bs.modal', handleShowModal, false);
+    finalListenerContainer.addEventListener('hidden.bs.modal', handleCloseModal, false);
 
     document.body.dispatchEvent(new CustomEvent('ibexa-control-z-index:events-attached'));
+
+    return {
+        removeControlZIndexListeners,
+    };
 };
 
-export { controlZIndex };
+const controlZIndexBulk = (items) => {
+    const storedControlZIndex = items.map((item) => {
+        return controlZIndex(...item);
+    });
+    const removeControlZIndexListeners = () => {
+        storedControlZIndex.forEach((item) => {
+            item.removeControlZIndexListeners();
+        });
+    };
+
+    return {
+        removeControlZIndexListeners,
+    };
+};
+
+export { controlZIndex, controlZIndexBulk };


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Potentially different approach than https://github.com/ibexa/admin-ui/pull/1465
Previous one was calling events for each element separately, this one does it in one modal event. Current approach I think is more bug-proof, as having multiple event listeners could cause in future that there will be delay between adjusting nodes, depending on how quick events are executed.

It's drawback is that it in some way duplicates `controlZIndex` in terms of adding events and dispatching it. But as this one allows array, setting specific zIndex and having different modal event listener adjusting old helper made it so much less clean (1465 looks really bad imo, compared to this one)

Usage, sth like that:
```
        storedControlZIndex = betterControlZIndex(
            [
                {
                    container: fieldsConfigPanel,
                    zIndex: 1,
                },
                {
                    container: fieldsConfigPanelTogglerBtn,
                },
            ],
            doc,
        );
```
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
