### PR TITLE
IBX-9723: Relative URLs in ezurl field no longer works

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
@@ -23,7 +23,7 @@
             }
 
             if (!isEmpty) {
-                const isUrlValid = URL.canParse(urlValue);
+                const isUrlValid = ibexa.errors.urlRegexp.test(urlValue);
 
                 if (!isUrlValid) {
                     result.isError = true;

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -62,7 +62,7 @@
             window.ibexa.addConfig('richText', {{ ibexa_richtext_config|json_encode|raw }});
             window.ibexa.addConfig('errors', {
                 emailRegexp: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-                urlRegexp: /^(https?:\/\/|ftp:\/\/|www\.|\/)[^\s]+$/,
+                urlRegexp: /^((https?:\/\/|ftps?:\/\/|sftp:\/\/|www\.|\/|ezlocation:\/\/)[^\s]+$)|(^([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(\/[^\s]*)?$)/,
                 emptyField: '{{ 'js.error.empty.field'|trans({}, 'validators')|desc('{fieldName} Field cannot be empty') }}',
                 invalidEmail: '{{ 'js.error.invalid_email'|trans({}, 'validators')|desc('A valid email address is required') }}',
                 invalidUrl: '{{ 'js.error.invalid_url'|trans({}, 'validators')|desc('A valid URL is required') }}',

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -62,6 +62,7 @@
             window.ibexa.addConfig('richText', {{ ibexa_richtext_config|json_encode|raw }});
             window.ibexa.addConfig('errors', {
                 emailRegexp: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                urlRegexp: /^(https?:\/\/|ftp:\/\/|www\.|\/)[^\s]+$/,
                 emptyField: '{{ 'js.error.empty.field'|trans({}, 'validators')|desc('{fieldName} Field cannot be empty') }}',
                 invalidEmail: '{{ 'js.error.invalid_email'|trans({}, 'validators')|desc('A valid email address is required') }}',
                 invalidUrl: '{{ 'js.error.invalid_url'|trans({}, 'validators')|desc('A valid URL is required') }}',


### PR DESCRIPTION
| :ticket: Issue | IBX-9723 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
I changed the url validation to a regular expression checking if the string starts with: 
- `http://`
- `https://`
- ` ftp:// `
- ` ftps:// `
- ` sftp:// `
-  `www.`
- `/ `
- `ezlocation://`
- `domain`
- `sub.domain`

And after this has at least one character. The previously solution with `canParse` returns true for e.g. `http:a`

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
