### PR TITLE
IBX-9838: FIX Edit option in three-dot menu remains clickable despite insufficient user permissions

### DIFF
--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -226,7 +226,7 @@ class ContentTreeController extends RestController
                 'restrictedLanguageCodes' => $createLimitationsValues[Limitation::LANGUAGE],
             ],
             'edit' => [
-                'hasAccess' => $lookupUpdateLimitationsResult->hasAccess(),
+                'hasAccess' => $this->canUserEditContent($location),
                 // skipped content type limitation values as in this case it can be inferred from "hasAccess" above
                 'restrictedLanguageCodes' => $updateLimitationsValues[Limitation::LANGUAGE],
             ],
@@ -324,6 +324,21 @@ class ContentTreeController extends RestController
         );
 
         return !empty($siteAccesses);
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    private function canUserEditContent(Location $location): bool
+    {
+        $content = $location->getContent();
+
+        return $this->permissionResolver->canUser(
+            'content',
+            'edit',
+            $content
+        );
     }
 }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9838 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
As stated in the public ticket, when the user has a limitation, for example, only for a specific content type, lets say `Article`, if we go to the Content tree, click on any other content  type and open the context menu, the edit button would be clickable and it would throw a permission error.
I'm fixing here the edit check to rely on `this->permissionResolver->canUser` instead of `hasAccess` method.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
