### PR TITLE
Phpstan fix - ContentTypeData::$isNew in isset() is not nullable nor uninitialized

### DIFF
--- a/src/lib/Form/Data/ContentTypeData.php
+++ b/src/lib/Form/Data/ContentTypeData.php
@@ -42,7 +42,7 @@ class ContentTypeData extends ContentTypeUpdateStruct implements NewnessCheckabl
     /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft */
     protected $contentTypeDraft;
 
-    private bool $isNew;
+    private ?bool $isNew = null;
 
     /**
      * @param array<mixed> $properties
@@ -56,11 +56,7 @@ class ContentTypeData extends ContentTypeUpdateStruct implements NewnessCheckabl
 
     public function isNew(): bool
     {
-        if (isset($this->isNew)) {
-            return $this->isNew;
-        }
-
-        return $this->isIdentifierNew();
+        return $this->isNew ?? $this->isIdentifierNew();
     }
 
     protected function getIdentifierValue(): string


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
