### PR TITLE
IBX-8223: Refactored limitation value blocks to use 'ibexa_' prefix

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/policies/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/policies/limitation_values.html.twig
@@ -1,6 +1,6 @@
 {% extends '@ibexadesign/limitation/limitation_values.html.twig' %}
 
-{% block ez_limitation_node_value %}
+{% block ibexa_limitation_node_value %}
     {% for path in values %}
         {% for value in path %}
             <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>
@@ -10,7 +10,7 @@
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_subtree_value %}
+{% block ibexa_limitation_subtree_value %}
     {% for path in values %}
         {% for value in path %}
             <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>

--- a/src/bundle/Resources/views/themes/admin/content/tab/roles/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/roles/limitation_values.html.twig
@@ -1,6 +1,6 @@
 {% extends '@ibexadesign/limitation/limitation_values.html.twig' %}
 
-{% block ez_limitation_subtree_value %}
+{% block ibexa_limitation_subtree_value %}
     {% for path in values %}
         {% for value in path %}
             <a href="{{ path('ibexa.content.view', {'contentId': value.id, 'locationId': value.mainLocationId}) }}" >{{ value.name }}</a>

--- a/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/limitation_values.html.twig
@@ -1,93 +1,93 @@
 {# fallback block for limitations without defined value mapper #}
-{% block ez_limitation_value_fallback %}
+{% block ibexa_limitation_value_fallback %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_class_value %}
+{% block ibexa_limitation_class_value %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_language_value %}
+{% block ibexa_limitation_language_value %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_node_value %}
+{% block ibexa_limitation_node_value %}
     {% for path in values %}
         {% for value in path %}/{{ value.name }}{% endfor %}
         {% if not loop.last %}, {% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_owner_value %}
+{% block ibexa_limitation_owner_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_changeowner_value %}
+{% block ibexa_limitation_changeowner_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_parentowner_value %}
+{% block ibexa_limitation_parentowner_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_parentclass_value %}
+{% block ibexa_limitation_parentclass_value %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_section_value %}
+{% block ibexa_limitation_section_value %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_newsection_value %}
+{% block ibexa_limitation_newsection_value %}
     {% for value in values %}
         {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_siteaccess_value %}
+{% block ibexa_limitation_siteaccess_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_state_value %}
+{% block ibexa_limitation_state_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_newstate_value %}
+{% block ibexa_limitation_newstate_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_subtree_value %}
+{% block ibexa_limitation_subtree_value %}
     {% for path in values %}
         {% for value in path %}/{{ value.name }}{% endfor %}
         {% if not loop.last %}, {% endif %}
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_group_value %}
+{% block ibexa_limitation_group_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_parentdepth_value %}
+{% block ibexa_limitation_parentdepth_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_parentgroup_value %}
+{% block ibexa_limitation_parentgroup_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_status_value %}
+{% block ibexa_limitation_status_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_userpermissions_value %}
+{% block ibexa_limitation_userpermissions_value %}
     <br>
     {{ "role.policy.limitation.userpermissions.role_title"
     |trans({}, 'ibexa_content_forms_role')
@@ -110,10 +110,10 @@
     {% endfor %}
 {% endblock %}
 
-{% block ez_limitation_memberof_value %}
+{% block ibexa_limitation_memberof_value %}
     {{ values|join(', ') }}
 {% endblock %}
 
-{% block ez_limitation_role_value %}
+{% block ibexa_limitation_role_value %}
     {{ values|join(', ') }}
 {% endblock %}

--- a/src/lib/Limitation/Templating/LimitationBlockRenderer.php
+++ b/src/lib/Limitation/Templating/LimitationBlockRenderer.php
@@ -18,8 +18,8 @@ use Twig\Environment;
 
 class LimitationBlockRenderer implements LimitationBlockRendererInterface
 {
-    public const LIMITATION_VALUE_BLOCK_NAME = 'ez_limitation_%s_value';
-    public const LIMITATION_VALUE_BLOCK_NAME_FALLBACK = 'ez_limitation_value_fallback';
+    public const LIMITATION_VALUE_BLOCK_NAME = 'ibexa_limitation_%s_value';
+    public const LIMITATION_VALUE_BLOCK_NAME_FALLBACK = 'ibexa_limitation_value_fallback';
 
     private LimitationValueMapperRegistryInterface $valueMapperRegistry;
 

--- a/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_1.html.twig
+++ b/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_1.html.twig
@@ -1,5 +1,5 @@
-{% block ez_limitation_foo_value %}foo: {{ values|join(',') }}{% endblock %}
+{% block ibexa_limitation_foo_value %}foo: {{ values|join(',') }}{% endblock %}
 
-{% block ez_limitation_bar_value %}bar: {{ values|join(',') }}{% endblock %}
+{% block ibexa_limitation_bar_value %}bar: {{ values|join(',') }}{% endblock %}
 
-{% block ez_limitation_custom_param_value %}custom_param: {{ values|join(',') }} PARAM A:{{ param_a }} PARAM B:{{ param_b }}{% endblock %}
+{% block ibexa_limitation_custom_param_value %}custom_param: {{ values|join(',') }} PARAM A:{{ param_a }} PARAM B:{{ param_b }}{% endblock %}

--- a/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_2.html.twig
+++ b/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_2.html.twig
@@ -1,2 +1,2 @@
-{% block ez_limitation_baz_value %}baz: {{ values|join(',') }}{% endblock %}
+{% block ibexa_limitation_baz_value %}baz: {{ values|join(',') }}{% endblock %}
 

--- a/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_3.html.twig
+++ b/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_3.html.twig
@@ -1,1 +1,1 @@
-{% block ez_limitation_bar_value %}bar: {{ values|join('|') }}{% endblock %}
+{% block ibexa_limitation_bar_value %}bar: {{ values|join('|') }}{% endblock %}

--- a/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_overriden.html.twig
+++ b/tests/bundle/Templating/Twig/_fixtures/render_limitation_value/templates/limitation_value_overriden.html.twig
@@ -1,2 +1,2 @@
-{% block ez_limitation_foo_value %}FOO: {{ values|join('|') }}{% endblock %}
+{% block ibexa_limitation_foo_value %}FOO: {{ values|join('|') }}{% endblock %}
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8223 |
|----------------|-----------|


#### Related PRs: 
https://github.com/ibexa/activity-log/pull/126
https://github.com/ibexa/cart/pull/136
https://github.com/ibexa/corporate-account/pull/289
https://github.com/ibexa/order-management/pull/151
https://github.com/ibexa/payment/pull/172
https://github.com/ibexa/permissions/pull/28
https://github.com/ibexa/personalization/pull/369
https://github.com/ibexa/product-catalog/pull/1313
https://github.com/ibexa/segmentation/pull/129
https://github.com/ibexa/shipping/pull/112
https://github.com/ibexa/taxonomy/pull/334
https://github.com/ibexa/user/pull/100
https://github.com/ibexa/workflow/pull/136


#### Description:
Refactored limitation value blocks to use 'ibexa_' prefix

#### For QA:
Check if all type of limitations are rendered correctly
