### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,4 +21,7 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_64,
+        SymfonySetList::SYMFONY_70,
+        SymfonySetList::SYMFONY_71,
+        SymfonySetList::SYMFONY_72,
     ]);

--- a/src/bundle/DependencyInjection/IbexaAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/IbexaAdminUiExtension.php
@@ -11,9 +11,9 @@ use Ibexa\Contracts\Core\Container\Encore\ConfigurationDumper as IbexaEncoreConf
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Yaml\Yaml;
 
 class IbexaAdminUiExtension extends Extension implements PrependExtensionInterface

--- a/src/bundle/Resources/config/services/form_ui_action_mappers.yaml
+++ b/src/bundle/Resources/config/services/form_ui_action_mappers.yaml
@@ -16,5 +16,5 @@ services:
 
     Ibexa\AdminUi\UI\Action\FormUiActionMappingDispatcher:
         arguments:
-            $mappers: !tagged ibexa.admin_ui.form_ui.mapper.action
+            $mappers: !tagged_iterator ibexa.admin_ui.form_ui.mapper.action
             $defaultMapper: '@Ibexa\AdminUi\UI\Action\FormUiActionMapper'

--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -384,7 +384,7 @@ services:
             - { name: ibexa.admin_ui.form.trash_location_option, priority: 20 }
 
     Ibexa\AdminUi\Form\TrashLocationOptionProvider\OptionsFactory:
-        arguments: [!tagged ibexa.admin_ui.form.trash_location_option]
+        arguments: [!tagged_iterator ibexa.admin_ui.form.trash_location_option]
 
     Ibexa\AdminUi\Form\Extension\HelpMultilineMessageExtension:
         tags:

--- a/src/bundle/Resources/config/services/siteaccess.yaml
+++ b/src/bundle/Resources/config/services/siteaccess.yaml
@@ -12,7 +12,7 @@ services:
 
     Ibexa\AdminUi\Siteaccess\SiteaccessResolver:
         arguments:
-            $siteaccessPreviewVoters: !tagged ibexa.admin_ui.site_access.preview.voter
+            $siteaccessPreviewVoters: !tagged_iterator ibexa.admin_ui.site_access.preview.voter
             $siteAccessService: '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
 
     Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver:

--- a/src/bundle/Resources/views/themes/admin/ui/search/spellcheck.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/spellcheck.html.twig
@@ -4,7 +4,7 @@
     <div class="ibexa-search-form__spellcheck-suggestion">
         {%- set suggestion_link -%}
             <a href="{{ path('ibexa.search', app.request.query|merge({'search[query]': spellcheck.query})) }}">
-                {{- spellcheck.query|spaceless -}}
+                {{- spellcheck.query|trim -}}
             </a>
         {%- endset -%}
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/dependency-injection] Changed !tagged to !tagged_iterators YAML tag
* [symfony/http-kernel] Replaced Symfony\Component\DependencyInjection\Extension instead of Symfony\Component\HttpKernel\DependencyInjection\Extension
```


#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
