### PR TITLE
IBX-8471: Fixed 'Send to trash' confirmation modal after Symfony 7 upgrade

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6285,13 +6285,7 @@ parameters:
 		-
 			message: '#^Cannot call method get\(\) on Symfony\\Component\\Form\\FormInterface\|null\.$#'
 			identifier: method.nonObject
-			count: 3
-			path: src/lib/Form/Type/Location/LocationTrashType.php
-
-		-
-			message: '#^Cannot call method getData\(\) on Symfony\\Component\\Form\\FormInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
+			count: 2
 			path: src/lib/Form/Type/Location/LocationTrashType.php
 
 		-
@@ -6309,7 +6303,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$form of method Ibexa\\AdminUi\\Form\\Type\\Location\\LocationTrashType\:\:addConfirmCheckbox\(\) expects Symfony\\Component\\Form\\FormInterface, Symfony\\Component\\Form\\FormInterface\|null given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/lib/Form/Type/Location/LocationTrashType.php
 
 		-

--- a/src/bundle/Resources/views/themes/admin/content/modal/location_trash.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/modal/location_trash.html.twig
@@ -35,7 +35,7 @@
                 {% do option.setRendered() %}
             </div>
         {% endfor %}
-        {% if form.trash_options is not empty %}
+        {% if form.confirm is defined %}
             <p>
                 {{ form_widget(form.confirm) }}
             </p>

--- a/src/lib/Form/Type/Location/LocationTrashType.php
+++ b/src/lib/Form/Type/Location/LocationTrashType.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
 
 class LocationTrashType extends AbstractType
 {
@@ -59,13 +60,15 @@ class LocationTrashType extends AbstractType
 
         $builder->get('trash_options')->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event): void {
             $form = $event->getForm();
+            $parentForm = $form->getParent();
+            Assert::notNull($parentForm, 'LocationTrashType: missing parent context for trash_options');
             $this->trashTypeStrategy->addOptions(
                 $form,
-                $form->getParent()->getData()->getLocation()
+                $parentForm->getData()->getLocation()
             );
 
-            if (!empty($form->getParent()->get('trash_options')->all())) {
-                $this->addConfirmCheckbox($form->getParent());
+            if (!empty($form->all())) {
+                $this->addConfirmCheckbox($parentForm);
             }
         });
 

--- a/src/lib/Form/Type/Location/LocationTrashType.php
+++ b/src/lib/Form/Type/Location/LocationTrashType.php
@@ -57,7 +57,7 @@ class LocationTrashType extends AbstractType
                 ['label' => /** @Desc("Send to trash") */ 'location_trash_form.trash']
             );
 
-        $builder->get('trash_options')->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+        $builder->get('trash_options')->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event): void {
             $form = $event->getForm();
             $this->trashTypeStrategy->addOptions(
                 $form,


### PR DESCRIPTION
> [!CAUTION]
>  - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-8471 |
|----------------|-----------|


#### Related PRs: 
- #1489 


#### Description:

We have a regression in Symfony Forms handling of "Send to trash" confirmation dialog appearing in Content View.

1. Confirm checkbox was rendered outside of the modal dialog as options were added but were not present during rendering ([rendered on `form_end`](https://github.com/ibexa/admin-ui/blob/a2415ebf1e7b606bf48d84df8c95262e55b55fae/src/bundle/Resources/views/themes/admin/content/modal/location_trash.html.twig#L53)) - please read further to understand why.
2. `trash_options` didn't receive proper options

Actual behavior
![image](https://github.com/user-attachments/assets/9933fb67-76a0-4b2b-86b8-2cd3e85b6781)

Expected behavior:
![image](https://github.com/user-attachments/assets/96d2f00d-6703-403e-8411-87e7a60bf1a4)

Detected by [Behat regression run](https://github.com/ibexa/oss/actions/runs/15021258887/job/42210766591#step:18:64) :tada: 



Seems like, in Symfony 7, there's [the new `POST_SET_DATA` event which removes all fields](https://github.com/symfony/symfony/blob/v7.2.1/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php#L110-L112) and re-adds them from existing data object (that's what happened to our `trash_options`).
If we move our own listener to `POST_SET_DATA` as well, then our virtual labels will be added after that.

I've also changed the way the need for confirmation checkbox is handled both by `LocationTrashType` Form Type and Twig template:
1. Checking for emptiness of `$form->all()` as `$form->getParent()->get('trash_options')->all()` means the same in that context.
2. Checking in Twig template, if the confirmation form checkbox was added by `LocationTrashType` rather than relying on emptiness of `form.trash_options`. It makes the behavior more consistent because if the confirm option was added for any reason by `LocationTrashType`, then it needs to be displayed (otherwise gonna break the modal).

Kudos to @Steveb-p for helping me with debugging Symfony Forms.

_Side note: seems weird to me that we use collection type to add list of labels of checkbox type. There's only one actual checkbox for N added labels. Also, maybe those labels should be populated when building initial data rather than relying on what event is gonna do to them?_

#### For QA:

See https://github.com/ibexa/admin-ui/pull/1547#issuecomment-2880778292

Passing commerce build: https://github.com/ibexa/admin-ui/actions/runs/15031810337/job/42246527771?pr=1547

Page Builder issue is out of scope and will be handled separately.