### PR TITLE
IBX-9944: Add support for stateless CSRF protection in admin-ui

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,4 +1,0 @@
-{
-    "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-183",
-    "packages": []
-}

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,4 @@
+{
+    "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-183",
+    "packages": []
+}

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -106,7 +106,7 @@ services:
 
     Ibexa\Bundle\AdminUi\Templating\Twig\SecurityExtension:
         arguments:
-                $csrfTokenIntention: 'rest'
+                $csrfTokenIntention: '%ibexa.rest.csrf_token_intention%'
 
     Ibexa\AdminUi\UI\Config\Provider\UserContentTypes:
         tags:

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -106,7 +106,7 @@ services:
 
     Ibexa\Bundle\AdminUi\Templating\Twig\SecurityExtension:
         arguments:
-                $csrfTokenIntention: '%ibexa.rest.csrf_token_intention%'
+            $csrfTokenIntention: '%ibexa.rest.csrf_token_intention%'
 
     Ibexa\AdminUi\UI\Config\Provider\UserContentTypes:
         tags:

--- a/src/bundle/Resources/config/services/ui_config/common.yaml
+++ b/src/bundle/Resources/config/services/ui_config/common.yaml
@@ -104,6 +104,10 @@ services:
 
     Ibexa\Bundle\AdminUi\Templating\Twig\EmbeddedItemEditFormExtension: ~
 
+    Ibexa\Bundle\AdminUi\Templating\Twig\SecurityExtension:
+        arguments:
+                $csrfTokenIntention: 'rest'
+
     Ibexa\AdminUi\UI\Config\Provider\UserContentTypes:
         tags:
             - { name: ibexa.admin_ui.config.provider, key: 'userContentTypes' }

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -2,7 +2,7 @@
 <html lang="{{ app.request.locale }}">
     <head>
         <meta charset="UTF-8" />
-        <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
+        <meta name="CSRF-Token" content="{{ csrf_token(ibexa_get_rest_csrf_token_intention()) }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
         <meta name="UserId" content="{{ ibexa_admin_ui_config.user.user.id|default() }}" />
         <script>

--- a/src/bundle/Templating/Twig/SecurityExtension.php
+++ b/src/bundle/Templating/Twig/SecurityExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\AdminUi\Templating\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityExtension extends AbstractExtension
+{
+    public function __construct(
+        private string $csrfTokenIntention,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ibexa_get_rest_csrf_token_intention',
+                fn (): string => $this->csrfTokenIntention,
+            ),
+        ];
+    }
+}

--- a/src/bundle/Templating/Twig/SecurityExtension.php
+++ b/src/bundle/Templating/Twig/SecurityExtension.php
@@ -14,7 +14,7 @@ use Twig\TwigFunction;
 final class SecurityExtension extends AbstractExtension
 {
     public function __construct(
-        private string $csrfTokenIntention,
+        private readonly string $csrfTokenIntention,
     ) {
     }
 

--- a/tests/bundle/Templating/Twig/SecurityExtensionTest.php
+++ b/tests/bundle/Templating/Twig/SecurityExtensionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\AdminUi\Templating\Twig;
+
+use Ibexa\Bundle\AdminUi\Templating\Twig\SecurityExtension;
+use Twig\Test\IntegrationTestCase;
+
+final class SecurityExtensionTest extends IntegrationTestCase
+{
+    private const string CSRF_TOKEN_INTENTION = 'foo_intention';
+
+    protected function getExtensions(): array
+    {
+        return [
+            new SecurityExtension(self::CSRF_TOKEN_INTENTION),
+        ];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/security/';
+    }
+}

--- a/tests/bundle/Templating/Twig/_fixtures/security/ibexa_get_rest_csrf_token_intention.test
+++ b/tests/bundle/Templating/Twig/_fixtures/security/ibexa_get_rest_csrf_token_intention.test
@@ -1,0 +1,8 @@
+--TEST--
+"ibexa_get_rest_csrf_token_intention" function
+--TEMPLATE--
+{{ ibexa_get_rest_csrf_token_intention() }}
+--DATA--
+return [];
+--EXPECT--
+foo_intention


### PR DESCRIPTION
| :ticket: Issue | IBX-9944 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/recipes-dev/pull/183


#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
