### PR TITLE
IBX-9727: Aligned codebase with content-forms changes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3463,12 +3463,6 @@ parameters:
 			path: src/lib/FieldType/Mapper/UserAccountFormMapper.php
 
 		-
-			message: '#^Method Ibexa\\AdminUi\\Form\\ActionDispatcher\\ContentTypeDispatcher\:\:configureOptions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/ActionDispatcher/ContentTypeDispatcher.php
-
-		-
 			message: '#^Method Ibexa\\AdminUi\\Form\\Data\\Content\\CustomUrl\\CustomUrlRemoveData\:\:__construct\(\) has parameter \$urlAliases with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9349,12 +9343,6 @@ parameters:
 			path: src/lib/Validator/Constraints/ValidatorConfigurationValidator.php
 
 		-
-			message: '#^Parameter \#1 \$validationErrors of method Ibexa\\ContentForms\\Validator\\Constraints\\FieldTypeValidator\:\:processValidationErrors\(\) expects array\<Ibexa\\Contracts\\Core\\FieldType\\ValidationError\>, iterable\<Ibexa\\Contracts\\Core\\FieldType\\ValidationError\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/Validator/Constraints/ValidatorConfigurationValidator.php
-
-		-
 			message: '#^Call to an undefined method Symfony\\Component\\Form\\FormInterface\:\:getClickedButton\(\)\.$#'
 			identifier: method.notFound
 			count: 2
@@ -9659,12 +9647,6 @@ parameters:
 			identifier: phpDoc.parseError
 			count: 1
 			path: tests/lib/Config/AdminUiForms/ContentTypeFieldTypesResolverTest.php
-
-		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with Symfony\\Component\\HttpFoundation\\Response will always evaluate to false\.$#'
-			identifier: staticMethod.impossibleType
-			count: 2
-			path: tests/lib/Event/FormActionEventTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\AdminUi\\EventListener\\ContentProxyCreateDraftListenerTest\:\:getContentType\(\) has parameter \$fieldDefs with no value type specified in iterable type array\.$#'

--- a/src/lib/Form/ActionDispatcher/ContentTypeDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/ContentTypeDispatcher.php
@@ -13,12 +13,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentTypeDispatcher extends AbstractActionDispatcher
 {
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('languageCode');
     }
 
-    protected function getActionEventBaseName()
+    protected function getActionEventBaseName(): string
     {
         return FormEvents::CONTENT_TYPE_UPDATE;
     }

--- a/src/lib/Validator/Constraints/ValidatorConfigurationValidator.php
+++ b/src/lib/Validator/Constraints/ValidatorConfigurationValidator.php
@@ -22,19 +22,23 @@ class ValidatorConfigurationValidator extends FieldTypeValidator
      * @param \Ibexa\AdminUi\Form\Data\FieldDefinitionData $value The value that should be validated
      * @param \Symfony\Component\Validator\Constraint $constraint The constraint for the validation
      *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     *
      * @api
      */
-    public function validate($value, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$value instanceof FieldDefinitionData) {
             return;
         }
 
         $fieldType = $this->fieldTypeService->getFieldType($value->getFieldTypeIdentifier());
-        $this->processValidationErrors($fieldType->validateValidatorConfiguration($value->validatorConfiguration));
+        $this->processValidationErrors(
+            iterator_to_array($fieldType->validateValidatorConfiguration($value->validatorConfiguration))
+        );
     }
 
-    protected function generatePropertyPath($errorIndex, $errorTarget)
+    protected function generatePropertyPath($errorIndex, $errorTarget): string
     {
         return 'defaultValue';
     }


### PR DESCRIPTION
> [!CAUTION]
> - [x] Remove TMP commit before merging
> - [x] Merge content-forms first 

| :ticket: Issue | IBX-9727 |
|----------------|----------|


#### Related PRs: 
- https://github.com/ibexa/content-forms/pull/91


#### Description:

ibexa/content-forms#91 fixes several issues found by PHPStan after Symfony 7 upgrade. It also adds some return strict types. Aligning here AdminUI codebase with those changes.

Note: should `\Ibexa\AdminUi\Validator\Constraints\ValidatorConfigurationValidator::validate` accept strict `FieldDefinitionData` as `$value` type instead? That would change the behavior, so didn't touch it, but maybe it's a valid change? Also reported by PHPStan in the baseline.

Alternatively, I could roll back changes causing failure here. It wasn't quite visible when working on content-forms, found only by Behat at the end.

#### For QA:

Regression should be enough.