### PR TITLE
Added missing return types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1339,12 +1339,6 @@ parameters:
 			path: src/bundle/DependencyInjection/IbexaAdminUiExtension.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\AdminUi\\Templating\\Twig\\ComponentExtension\:\:renderComponent\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Templating/Twig/ComponentExtension.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\AdminUi\\Templating\\Twig\\ComponentExtension\:\:renderComponent\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -8257,42 +8251,6 @@ parameters:
 			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
 
 		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:afterTraverse\(\) should return array\<PhpParser\\Node\>\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:beforeTraverse\(\) should return array\<PhpParser\\Node\>\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:leaveNode\(\) should return array\<PhpParser\\Node\>\|int\|PhpParser\\Node\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitPhpFile\(\) has parameter \$ast with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitTwigFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
 			message: '#^Parameter \#1 \$desc of method JMS\\TranslationBundle\\Model\\Message\:\:setDesc\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -9211,12 +9169,6 @@ parameters:
 			path: src/lib/Validator/Constraints/FieldSettings.php
 
 		-
-			message: '#^Property Ibexa\\AdminUi\\Validator\\Constraints\\LocationHasChildren\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/Validator/Constraints/LocationHasChildren.php
-
-		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$message\.$#'
 			identifier: property.notFound
 			count: 2
@@ -9227,12 +9179,6 @@ parameters:
 			identifier: identical.alwaysFalse
 			count: 1
 			path: src/lib/Validator/Constraints/LocationHasChildrenValidator.php
-
-		-
-			message: '#^Property Ibexa\\AdminUi\\Validator\\Constraints\\LocationHaveUniqueAssetRelation\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/Validator/Constraints/LocationHaveUniqueAssetRelation.php
 
 		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$message\.$#'
@@ -9247,12 +9193,6 @@ parameters:
 			path: src/lib/Validator/Constraints/LocationHaveUniqueAssetRelationValidator.php
 
 		-
-			message: '#^Property Ibexa\\AdminUi\\Validator\\Constraints\\LocationIsContainer\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/Validator/Constraints/LocationIsContainer.php
-
-		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$message\.$#'
 			identifier: property.notFound
 			count: 2
@@ -9265,12 +9205,6 @@ parameters:
 			path: src/lib/Validator/Constraints/LocationIsContainerValidator.php
 
 		-
-			message: '#^Property Ibexa\\AdminUi\\Validator\\Constraints\\LocationIsNotRoot\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/Validator/Constraints/LocationIsNotRoot.php
-
-		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$message\.$#'
 			identifier: property.notFound
 			count: 2
@@ -9281,12 +9215,6 @@ parameters:
 			identifier: identical.alwaysFalse
 			count: 1
 			path: src/lib/Validator/Constraints/LocationIsNotRootValidator.php
-
-		-
-			message: '#^Property Ibexa\\AdminUi\\Validator\\Constraints\\LocationIsWithinCopySubtreeLimit\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/Validator/Constraints/LocationIsWithinCopySubtreeLimit.php
 
 		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$message\.$#'

--- a/src/bundle/Templating/Twig/ComponentExtension.php
+++ b/src/bundle/Templating/Twig/ComponentExtension.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\AdminUi\Templating\Twig;
 
-use Ibexa\AdminUi\Component\Registry as ComponentRegistry;
-use Ibexa\Contracts\AdminUi\Component\Renderer\RendererInterface;
+use Ibexa\Contracts\TwigComponents\Renderer\RendererInterface;
+use Ibexa\TwigComponents\Component\Registry as ComponentRegistry;
 use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -28,7 +28,7 @@ class ComponentExtension extends AbstractExtension
         $this->renderer = $renderer;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(
@@ -55,7 +55,7 @@ class ComponentExtension extends AbstractExtension
         return implode('', $this->renderer->renderGroup($group, $parameters));
     }
 
-    public function renderComponent(string $group, string $id, array $parameters = [])
+    public function renderComponent(string $group, string $id, array $parameters = []): string
     {
         return $this->renderer->renderSingle($group, $id, $parameters);
     }

--- a/src/bundle/Templating/Twig/FormatIntervalExtension.php
+++ b/src/bundle/Templating/Twig/FormatIntervalExtension.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 
 class FormatIntervalExtension extends AbstractExtension implements TranslationContainerInterface
 {
-    private const INTERVAL_PARTS = [
+    private const array INTERVAL_PARTS = [
         'y' => 'years',
         'm' => 'months',
         'd' => 'days',
@@ -33,7 +33,7 @@ class FormatIntervalExtension extends AbstractExtension implements TranslationCo
         $this->translator = $translator;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('format_interval', $this->formatInterval(...)),

--- a/src/bundle/Templating/Twig/TimeDiffExtension.php
+++ b/src/bundle/Templating/Twig/TimeDiffExtension.php
@@ -23,7 +23,7 @@ class TimeDiffExtension extends AbstractExtension
         $this->dateTimeFormatter = $dateTimeFormatter;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter(

--- a/src/lib/Validator/Constraints/LocationHasChildren.php
+++ b/src/lib/Validator/Constraints/LocationHasChildren.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class LocationHasChildren extends Constraint implements TranslationContainerInterface
 {
-    public $message = 'ezplatform.trash.location_has_no_children';
+    public string $message = 'ezplatform.trash.location_has_no_children';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.trash.location_has_no_children', 'validators')

--- a/src/lib/Validator/Constraints/LocationHaveUniqueAssetRelation.php
+++ b/src/lib/Validator/Constraints/LocationHaveUniqueAssetRelation.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class LocationHaveUniqueAssetRelation extends Constraint implements TranslationContainerInterface
 {
-    public $message = 'ezplatform.trash.have_used_assets';
+    public string $message = 'ezplatform.trash.have_used_assets';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.trash.have_used_assets', 'validators')

--- a/src/lib/Validator/Constraints/LocationIsContainer.php
+++ b/src/lib/Validator/Constraints/LocationIsContainer.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class LocationIsContainer extends Constraint implements TranslationContainerInterface
 {
-    public $message = 'ezplatform.copy_subtree.is_not_container';
+    public string $message = 'ezplatform.copy_subtree.is_not_container';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.copy_subtree.is_not_container', 'validators')

--- a/src/lib/Validator/Constraints/LocationIsNotRoot.php
+++ b/src/lib/Validator/Constraints/LocationIsNotRoot.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class LocationIsNotRoot extends Constraint implements TranslationContainerInterface
 {
-    public $message = 'ezplatform.copy_subtree.is_root';
+    public string $message = 'ezplatform.copy_subtree.is_root';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.copy_subtree.is_root', 'validators')

--- a/src/lib/Validator/Constraints/LocationIsNotSubLocation.php
+++ b/src/lib/Validator/Constraints/LocationIsNotSubLocation.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraints\AbstractComparison;
 
-/**
- * @Annotation
- */
 class LocationIsNotSubLocation extends AbstractComparison implements TranslationContainerInterface
 {
     public string $message = 'ezplatform.copy_subtree.is_sub_location';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.copy_subtree.is_sub_location', 'validators')

--- a/src/lib/Validator/Constraints/LocationIsWithinCopySubtreeLimit.php
+++ b/src/lib/Validator/Constraints/LocationIsWithinCopySubtreeLimit.php
@@ -12,14 +12,11 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class LocationIsWithinCopySubtreeLimit extends Constraint implements TranslationContainerInterface
 {
-    public $message = 'ezplatform.copy_subtree.limit_exceeded';
+    public string $message = 'ezplatform.copy_subtree.limit_exceeded';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ezplatform.copy_subtree.limit_exceeded', 'validators')


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
This PR adds explicit return types.
These changes eliminate PHPStan errors (e.g., missingType.return, missingType.iterableValue) and improve static analysis coverage.

No functional changes were made.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
