### PR TITLE
IBX-9727: Add missing type hints to options contracts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3067,24 +3067,6 @@ parameters:
 			path: src/lib/Config/AdminUiForms/ContentTypeFieldTypesResolver.php
 
 		-
-			message: '#^Method Ibexa\\AdminUi\\Event\\Options\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Event/Options.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Event\\Options\:\:all\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Event/Options.php
-
-		-
-			message: '#^Property Ibexa\\AdminUi\\Event\\Options\:\:\$options type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Event/Options.php
-
-		-
 			message: '#^Cannot call method log\(\) on Psr\\Log\\LoggerInterface\|null\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/src/lib/Event/Options.php
+++ b/src/lib/Event/Options.php
@@ -13,8 +13,12 @@ use Ibexa\Contracts\Core\Repository\Exceptions\OutOfBoundsException;
 
 final class Options implements MutableOptionsBag
 {
+    /** @var array<string, mixed> */
     private array $options;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(array $options = [])
     {
         $this->options = $options;
@@ -25,13 +29,9 @@ final class Options implements MutableOptionsBag
         return $this->options;
     }
 
-    public function get(
-        string $key,
-        $default = null
-    ) {
-        return $this->has($key)
-            ? $this->options[$key]
-            : $default;
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->options[$key] ?? $default;
     }
 
     public function has(string $key): bool
@@ -39,7 +39,7 @@ final class Options implements MutableOptionsBag
         return isset($this->options[$key]);
     }
 
-    public function set(string $key, $value): void
+    public function set(string $key, mixed $value): void
     {
         $this->options[$key] = $value;
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
See https://github.com/ibexa/core/pull/563 

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
