### PR TITLE
IBX-10100: Collaborator's icons should be displayed above field's label

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -551,12 +551,12 @@
                 show_close_btn: true
             } only %}
         </div>
+        <div class="ibexa-field-edit__distraction-free-mode-extras">
+            {{ ibexa_render_component_group('distraction-free-mode-extras', {}) }}
+        </div>
         <div class="ibexa-field-edit__distraction-free-mode-control-container">
             <div class="ibexa-field-edit__distraction-free-mode-label">
                 {{- form_label(form) -}}
-            </div>
-            <div class="ibexa-field-edit__distraction-free-mode-extras">
-                {{ ibexa_render_component_group('distraction-free-mode-extras', {}) }}
             </div>
             <div class="ibexa-field-edit__distraction-free-mode-btns">
                  <button {{ (fieldtype_is_not_translatable or disabled) ? 'disabled' }} type="button" class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small ibexa-field-edit__distraction-free-mode-control-btn ibexa-field-edit__distraction-free-mode-control-btn--enable">


### PR DESCRIPTION
| :ticket: Issue | IBX-10100 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/fieldtype-richtext-rte/pull/19


#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
