### PR TITLE
IBX-8561: Fixed relation list when trying to display unauthorized content

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/relation_base.html.twig
@@ -96,18 +96,18 @@
         {% set body_rows = [] %}
 
         {% for relation in relations %}
-            {% set body_row_cols = [] %}
-            {% set col_raw_actions %}
-                {{ remove_item_btn }}
-
-                {% include '@ibexadesign/ui/component/embedded_item_actions/embedded_item_actions.html.twig' with {
-                    content_id: relation.contentId,
-                    location_id: relation.contentInfo.mainLocationId,
-                    version_no: relation.contentInfo.currentVersionNo,
-                } only %}
-            {% endset %}
-
             {% if relation.contentInfo is not null and relation.contentType is not null %}
+                {% set body_row_cols = [] %}
+                {% set col_raw_actions %}
+                    {{ remove_item_btn }}
+
+                    {% include '@ibexadesign/ui/component/embedded_item_actions/embedded_item_actions.html.twig' with {
+                        content_id: relation.contentId,
+                        location_id: relation.contentInfo.mainLocationId,
+                        version_no: relation.contentInfo.currentVersionNo,
+                    } only %}
+                {% endset %}
+
                 {% set col_raw_checkbox %}
                     <input
                         type="checkbox"
@@ -199,8 +199,8 @@
                     class: 'ibexa-relations__item',
                     attr: {
                         'data-content-id': relation.contentId,
-                        'data-location-id': relation.contentInfo.mainLocationId,
-                    },
+                        'data-location-id': relation.contentInfo is defined and relation.contentInfo is not null ? relation.contentInfo.mainLocationId,
+                    }|filter(v => v is not null),
                 }]) %}
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
| :ticket: Issue | IBX-8561 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
During some part of redesign/UX improvment there was added functionality with actions on embedded content. However, non of them took into consideration that we do not always have access to it. As a result, if conditions were not applied to all parts of the view.

#### For QA:
As the migration do not pass without some modifications - long story short, there is one content with relation to another one placed inside section to which editor user do not have access to.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
