### PR TITLE
IBX-8638: Ensured last ancestor is valid before comparing paths in TrashItemData

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4231,12 +4231,6 @@ parameters:
 			path: src/lib/Form/Data/Section/SectionUpdateData.php
 
 		-
-			message: '#^Cannot access property \$path on Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/lib/Form/Data/TrashItemData.php
-
-		-
 			message: '#^Method Ibexa\\AdminUi\\Form\\Data\\URLWildcard\\URLWildcardDeleteData\:\:__construct\(\) has parameter \$urlWildcardsChoices with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/lib/Form/Data/TrashItemData.php
+++ b/src/lib/Form/Data/TrashItemData.php
@@ -81,7 +81,7 @@ class TrashItemData
     {
         $lastAncestor = end($this->ancestors);
 
-        return $this->location->path !== array_merge($lastAncestor->path, [(string)$this->location->id]);
+        return $lastAncestor !== false && $this->location->path !== array_merge($lastAncestor->path, [(string)$this->location->id]);
     }
 
     public function getCreator(): ?User

--- a/tests/lib/Form/Data/TrashItemDataTest.php
+++ b/tests/lib/Form/Data/TrashItemDataTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+use Ibexa\AdminUi\Form\Data\TrashItemData;
+use Ibexa\Core\Repository\Values\Content\Location;
+use Ibexa\Core\Repository\Values\Content\TrashItem;
+use PHPUnit\Framework\TestCase;
+
+class TrashItemDataTest extends TestCase
+{
+    public function testIsParentInTrashReturnsFalseWhenNoAncestors(): void
+    {
+        $trashItem = new TrashItem(['path' => ['1', '2', '3'], 'id' => 3]);
+        $data = new TrashItemData($trashItem, null, []);
+
+        self::assertFalse($data->isParentInTrash());
+    }
+
+    public function testIsParentInTrashReturnsFalseWhenPathsMatch(): void
+    {
+        $trashItem = new TrashItem(['path' => ['1', '2', '3'], 'id' => 3]);
+
+        $ancestor = new Location(['path' => ['1', '2']]);
+        $data = new TrashItemData($trashItem, null, [$ancestor]);
+
+        self::assertFalse($data->isParentInTrash());
+    }
+
+    public function testIsParentInTrashReturnsTrueWhenPathsDoNotMatch(): void
+    {
+        $trashItem = new TrashItem(['path' => ['1', '2', '3'], 'id' => 3]);
+        $ancestor = new Location(['path' => ['1']]);
+
+        $data = new TrashItemData($trashItem, null, [$ancestor]);
+
+        self::assertTrue($data->isParentInTrash());
+    }
+
+    public function testIsParentInTrashWithMultipleAncestors(): void
+    {
+        $trashItem = new TrashItem(['path' => ['1', '2', '3', '4'], 'id' => 4]);
+
+        $ancestor1 = new Location(['path' => ['1']]);
+        $ancestor2 = new Location(['path' => ['1', '2', '3']]);
+
+        $data = new TrashItemData($trashItem, null, [$ancestor1, $ancestor2]);
+
+        self::assertFalse($data->isParentInTrash());
+    }
+}

--- a/tests/lib/Form/Data/TrashItemDataTest.php
+++ b/tests/lib/Form/Data/TrashItemDataTest.php
@@ -4,6 +4,10 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Form\Data;
+
 use Ibexa\AdminUi\Form\Data\TrashItemData;
 use Ibexa\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Repository\Values\Content\TrashItem;

--- a/tests/lib/Form/Data/TrashItemDataTest.php
+++ b/tests/lib/Form/Data/TrashItemDataTest.php
@@ -13,7 +13,7 @@ use Ibexa\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Repository\Values\Content\TrashItem;
 use PHPUnit\Framework\TestCase;
 
-class TrashItemDataTest extends TestCase
+final class TrashItemDataTest extends TestCase
 {
     public function testIsParentInTrashReturnsFalseWhenNoAncestors(): void
     {


### PR DESCRIPTION

| :ticket: Issue | IBX-8638 |
|----------------|-----------|

#### Description:
Ensured last ancestor is valid before comparing paths in TrashItemData

#### For QA:
Check if after removing folder which is root in tree via API, we can open trash without problems