### PR TITLE
IBX-10125: Handled image upload failed request

### DIFF
--- a/src/bundle/Controller/AssetController.php
+++ b/src/bundle/Controller/AssetController.php
@@ -150,6 +150,7 @@ class AssetController extends Controller
         return new JsonResponse(
             [
                 'status' => 'failed',
+                'error' => $errorMessage,
                 'errorMessage' => $errorMessage,
             ],
             Response::HTTP_BAD_REQUEST

--- a/src/bundle/Controller/AssetController.php
+++ b/src/bundle/Controller/AssetController.php
@@ -147,10 +147,13 @@ class AssetController extends Controller
      */
     private function createGenericErrorResponse(string $errorMessage): JsonResponse
     {
-        return new JsonResponse([
-            'status' => 'failed',
-            'error' => $errorMessage,
-        ]);
+        return new JsonResponse(
+            [
+                'status' => 'failed',
+                'errorMessage' => $errorMessage,
+            ],
+            Response::HTTP_BAD_REQUEST
+        );
     }
 
     /**

--- a/src/bundle/Resources/public/js/scripts/helpers/request.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/request.helper.js
@@ -4,7 +4,7 @@ const defaultGetErrorMessage = (error = {}) => error.errorMessage;
 
 const getErrorMessageObject = (response) => {
     const responseErrorMessage = response.json().then((jsonResponse) => {
-        return jsonResponse.ErrorMessage;
+        return jsonResponse.ErrorMessage ?? jsonResponse;
     });
 
     return responseErrorMessage;


### PR DESCRIPTION
| :ticket: Issue | IBX-10125 |
|----------------|-----------|

#### Description:
Two things:
- JsonResponse should not succeed with status 200 if it fails.
- JS improperly handles such a failed request. The`jsonResponse.ErrorMessage` call was giving empty results. Shouldn't we rather fallback to full response?

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
