### PR TITLE
Fixed setting location data in ContentMainLocationUpdateMapper

### DIFF
--- a/src/lib/Form/DataMapper/ContentMainLocationUpdateMapper.php
+++ b/src/lib/Form/DataMapper/ContentMainLocationUpdateMapper.php
@@ -10,6 +10,7 @@ namespace Ibexa\AdminUi\Form\DataMapper;
 use Ibexa\AdminUi\Exception\InvalidArgumentException;
 use Ibexa\AdminUi\Form\Data\Content\Location\ContentMainLocationUpdateData;
 use Ibexa\Contracts\AdminUi\Form\DataMapper\DataMapperInterface;
+use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentMetadataUpdateStruct;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
@@ -18,14 +19,21 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  */
 class ContentMainLocationUpdateMapper implements DataMapperInterface
 {
+    private LocationService $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
     /**
      * Maps given ContentMetadataUpdateStruct object to a ContentMainLocationUpdateData object.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentMetadataUpdateStruct|\Ibexa\Contracts\Core\Repository\Values\ValueObject $value
      *
-     * @return \Ibexa\AdminUi\Form\Data\Content\Location\ContentMainLocationUpdateData
-     *
-     * @throws \Ibexa\AdminUi\Exception\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
     public function map(ValueObject $value): ContentMainLocationUpdateData
     {
@@ -35,7 +43,9 @@ class ContentMainLocationUpdateMapper implements DataMapperInterface
 
         $data = new ContentMainLocationUpdateData();
 
-        $data->setLocation($value->mainLocationId);
+        if (null !== $value->mainLocationId) {
+            $data->setLocation($this->locationService->loadLocation($value->mainLocationId));
+        }
 
         return $data;
     }

--- a/tests/lib/Form/DataMapper/ContentMainLocationUpdateMapperTest.php
+++ b/tests/lib/Form/DataMapper/ContentMainLocationUpdateMapperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Form\DataMapper;
+
+use Ibexa\AdminUi\Exception\InvalidArgumentException;
+use Ibexa\AdminUi\Form\DataMapper\ContentMainLocationUpdateMapper;
+use Ibexa\Contracts\Core\Repository\LocationService;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentMetadataUpdateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\ValueObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\AdminUi\Form\DataMapper\ContentMainLocationUpdateMapper
+ */
+final class ContentMainLocationUpdateMapperTest extends TestCase
+{
+    /** @var \Ibexa\Contracts\Core\Repository\LocationService&\PHPUnit\Framework\MockObject\MockObject */
+    private LocationService $locationService;
+
+    private ContentMainLocationUpdateMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->mapper = new ContentMainLocationUpdateMapper($this->locationService);
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    public function testMapWithMainLocationId(): void
+    {
+        $mainLocationId = 42;
+        $location = $this->createMock(Location::class);
+
+        $struct = new ContentMetadataUpdateStruct(['mainLocationId' => $mainLocationId]);
+
+        $this->locationService
+            ->expects(self::once())
+            ->method('loadLocation')
+            ->with($mainLocationId)
+            ->willReturn($location);
+
+        $data = $this->mapper->map($struct);
+
+        self::assertSame($location, $data->getLocation());
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    public function testMapWithNullMainLocationId(): void
+    {
+        $struct = new ContentMetadataUpdateStruct(['mainLocationId' => null]);
+
+        $this->locationService
+            ->expects(self::never())
+            ->method('loadLocation');
+
+        $data = $this->mapper->map($struct);
+
+        self::assertNull($data->getLocation());
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    public function testMapThrowsOnInvalidValueObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mapper->map($this->createMock(ValueObject::class));
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Related PRs: 
- https://github.com/ibexa/core/pull/569


#### Description:
Discovered while testing ibexa/core#569 on main. It looks like the bug exists in 4.6.

`\Ibexa\AdminUi\Form\DataMapper\ContentMainLocationUpdateMapper::map` calls `\Ibexa\AdminUi\Form\Data\Content\Location\ContentMainLocationUpdateData::setLocation` with `mainLocationId` while the method expects an instance of a Location. My guess is that the method is not used anywhere, therefore not visible.

#### For QA:
Regressions:

- :green_circle:   https://github.com/ibexa/commerce/pull/1366
