### PR TITLE
IBX-10239: Fixed malfunctioning URL management pagination

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8089,24 +8089,6 @@ parameters:
 			path: src/lib/Tab/TabGroup.php
 
 		-
-			message: '#^Method Ibexa\\AdminUi\\Tab\\URLManagement\\LinkManagerTab\:\:evaluate\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Tab/URLManagement/LinkManagerTab.php
-
-		-
-			message: '#^Property Ibexa\\AdminUi\\Tab\\URLManagement\\LinkManagerTab\:\:\$notificationHandler is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/lib/Tab/URLManagement/LinkManagerTab.php
-
-		-
-			message: '#^Property Ibexa\\AdminUi\\Tab\\URLManagement\\LinkManagerTab\:\:\$submitHandler is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/lib/Tab/URLManagement/LinkManagerTab.php
-
-		-
 			message: '#^Cannot access property \$query on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
 			identifier: property.nonObject
 			count: 1

--- a/src/bundle/Controller/LinkManagerController.php
+++ b/src/bundle/Controller/LinkManagerController.php
@@ -25,40 +25,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class LinkManagerController extends Controller
 {
-    public const DEFAULT_MAX_PER_PAGE = 10;
+    public const int DEFAULT_MAX_PER_PAGE = 10;
 
-    private URLService $urlService;
-
-    private FormFactory $formFactory;
-
-    private SubmitHandler $submitHandler;
-
-    private TranslatableNotificationHandlerInterface $notificationHandler;
-
-    /**
-     * @param \Ibexa\Contracts\Core\Repository\URLService $urlService
-     * @param \Ibexa\AdminUi\Form\Factory\FormFactory $formFactory
-     * @param \Ibexa\AdminUi\Form\SubmitHandler $submitHandler
-     * @param \Ibexa\Contracts\AdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
-     */
     public function __construct(
-        URLService $urlService,
-        FormFactory $formFactory,
-        SubmitHandler $submitHandler,
-        TranslatableNotificationHandlerInterface $notificationHandler
+        private readonly URLService $urlService,
+        private readonly FormFactory $formFactory,
+        private readonly SubmitHandler $submitHandler,
+        private readonly TranslatableNotificationHandlerInterface $notificationHandler
     ) {
-        $this->urlService = $urlService;
-        $this->formFactory = $formFactory;
-        $this->submitHandler = $submitHandler;
-        $this->notificationHandler = $notificationHandler;
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int $urlId
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
@@ -107,11 +84,6 @@ final class LinkManagerController extends Controller
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int $urlId
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
@@ -123,9 +95,7 @@ final class LinkManagerController extends Controller
         $usages->setCurrentPage($request->query->getInt('page', 1));
         $usages->setMaxPerPage($request->query->getInt('limit', self::DEFAULT_MAX_PER_PAGE));
 
-        $editForm = $this->formFactory->contentEdit(
-            new ContentEditData()
-        );
+        $editForm = $this->formFactory->contentEdit(new ContentEditData());
 
         return $this->render('@ibexadesign/link_manager/view.html.twig', [
             'url' => $url,

--- a/src/bundle/Resources/views/themes/admin/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/list.html.twig
@@ -14,7 +14,6 @@
                 {{ form_label(form.status) }}
                 {{ form_widget(form.status) }}
             </div>
-            {{ form_widget(form.page, { attr: { value: '1' }}) }}
         {{ form_end(form) }}
     </section>
 
@@ -81,8 +80,7 @@
 
         {% if urls.haveToPaginate %}
             {% include '@ibexadesign/ui/pagination.html.twig' with {
-                'pager': urls,
-                'paginaton_params' : {'pageParameter': '[search_data][page]'}
+                'pager': urls
             } %}
         {% endif %}
     </section>

--- a/src/lib/Form/Data/URL/URLListData.php
+++ b/src/lib/Form/Data/URL/URLListData.php
@@ -10,17 +10,17 @@ namespace Ibexa\AdminUi\Form\Data\URL;
 
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
-class URLListData extends ValueObject
+final class URLListData extends ValueObject
 {
-    /** @var string|null */
-    public $searchQuery;
+    public ?string $searchQuery;
 
-    /** @var bool|null */
-    public $status;
+    public ?bool $status;
 
-    /** @var int */
-    public $page = 1;
-
-    /** @var int */
-    public $limit = 10;
+    public function __construct(
+        ?string $searchQuery = null,
+        ?bool $status = null,
+    ) {
+        $this->searchQuery = $searchQuery;
+        $this->status = $status;
+    }
 }

--- a/src/lib/Form/Data/URL/URLUpdateData.php
+++ b/src/lib/Form/Data/URL/URLUpdateData.php
@@ -10,8 +10,7 @@ namespace Ibexa\AdminUi\Form\Data\URL;
 
 use Ibexa\Contracts\Core\Repository\Values\URL\URLUpdateStruct;
 
-class URLUpdateData extends URLUpdateStruct
+final class URLUpdateData extends URLUpdateStruct
 {
-    /** @var int */
-    public $id;
+    public int $id;
 }

--- a/src/lib/Form/Type/URL/URLListType.php
+++ b/src/lib/Form/Type/URL/URLListType.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Form\Type\URL;
 
@@ -11,32 +12,17 @@ use Ibexa\AdminUi\Form\Data\URL\URLListData;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * URL list form.
- */
-class URLListType extends AbstractType
+final class URLListType extends AbstractType
 {
-    private TranslatorInterface $translator;
-
-    /**
-     * URLListType constructor.
-     *
-     * @param \Symfony\Contracts\Translation\TranslatorInterface $translator
-     */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('status', ChoiceType::class, [
@@ -65,14 +51,8 @@ class URLListType extends AbstractType
         $builder->add('searchQuery', SearchType::class, [
             'required' => false,
         ]);
-
-        $builder->add('limit', HiddenType::class);
-        $builder->add('page', HiddenType::class);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
@@ -81,17 +61,11 @@ class URLListType extends AbstractType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return $this->getBlockPrefix();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix(): string
     {
         return 'ezplatform_content_forms_url_list';

--- a/src/lib/Pagination/Pagerfanta/URLSearchAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/URLSearchAdapter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Pagination\Pagerfanta;
 
@@ -14,22 +15,12 @@ use Pagerfanta\Adapter\AdapterInterface;
 /**
  * @implements \Pagerfanta\Adapter\AdapterInterface<\Ibexa\Contracts\Core\Repository\Values\URL\URL>
  */
-class URLSearchAdapter implements AdapterInterface
+final readonly class URLSearchAdapter implements AdapterInterface
 {
-    private URLQuery $query;
-
-    private URLService $urlService;
-
-    /**
-     * UrlSearchAdapter constructor.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\URL\URLQuery $query
-     * @param \Ibexa\Contracts\Core\Repository\URLService $urlService
-     */
-    public function __construct(URLQuery $query, URLService $urlService)
-    {
-        $this->query = $query;
-        $this->urlService = $urlService;
+    public function __construct(
+        private URLQuery $query,
+        private URLService $urlService
+    ) {
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | IBX-10239 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In short: `page` and `limit` don't need to be parts of the form as hidden inputs. We can rely on query params like in other tabs containing paginated results.

I also took liberty to adjust related code to PHP8 a little.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
