### PR TITLE
IBX-8111: Validated file mime type for multi file upload without specified location mapping

### DIFF
--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -32,6 +32,7 @@ const readFile = function (file, resolve, reject) {
     this.readAsDataURL(file);
 };
 const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mimeTypes.find((type) => type === file.type));
+const fileWithinMimetypes = (mimeTypes, file) => mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
 const checkFileTypeAllowed = (file, locationMapping) => (!locationMapping ? true : isMimeTypeAllowed(locationMapping.mappings, file));
@@ -264,6 +265,19 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
 
     if (!checkFileTypeAllowed(file, locationMapping)) {
         errorMsgs.push(Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'));
+    }
+
+    if (!locationMapping) {
+        let allowed = false;
+        config.defaultMappings.forEach((mapping) => {
+            if (fileWithinMimetypes(mapping.mimeTypes, file)) {
+                allowed = true;
+            }
+        })
+
+        if (!allowed) {
+            errorMsgs.push(Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'));
+        }
     }
 
     if (file.size > maxFileSize) {

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -35,10 +35,11 @@ const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mim
 const checkIsFileWithinMimeTypes = (mimeTypes, file) => !!mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
-const checkFileTypeAllowed = (file, locationMapping, config) =>
-    !locationMapping
-        ? config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file))
+const checkFileTypeAllowed = (file, locationMapping, config) => {
+    return !locationMapping
+        ? config.defaultMappings.some((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file))
         : isMimeTypeAllowed(locationMapping.mappings, file);
+};
 
 const detectContentTypeMapping = (file, parentInfo, config) => {
     const locationMapping = config.locationMappings.find((item) => item.contentTypeIdentifier === parentInfo.contentTypeIdentifier);

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -32,7 +32,7 @@ const readFile = function (file, resolve, reject) {
     this.readAsDataURL(file);
 };
 const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mimeTypes.find((type) => type === file.type));
-const fileWithinMimeTypes = (mimeTypes, file) => mimeTypes.find((type) => type === file.type);
+const checkIsFileWithinMimeTypes = (mimeTypes, file) => !!mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
 const checkFileTypeAllowed = (file, locationMapping) => (!locationMapping ? true : isMimeTypeAllowed(locationMapping.mappings, file));
@@ -268,15 +268,9 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
     }
 
     if (!locationMapping) {
-        let allowed = false;
+        const isAllowed = config.defaultMappings.every(mapping => checkIsFileWithinMimeTypes(mapping.mimeTypes, file));
 
-        config.defaultMappings.forEach((mapping) => {
-            if (fileWithinMimeTypes(mapping.mimeTypes, file)) {
-                allowed = true;
-            }
-        });
-
-        if (!allowed) {
+        if (!isAllowed) {
             errorMsgs.push(
                 Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'),
             );

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -273,10 +273,12 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
             if (fileWithinMimetypes(mapping.mimeTypes, file)) {
                 allowed = true;
             }
-        })
+        });
 
         if (!allowed) {
-            errorMsgs.push(Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'));
+            errorMsgs.push(
+                Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'),
+            );
         }
     }
 

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -268,7 +268,7 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
     }
 
     if (!locationMapping) {
-        const isAllowed = config.defaultMappings.every(mapping => checkIsFileWithinMimeTypes(mapping.mimeTypes, file));
+        const isAllowed = config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file));
 
         if (!isAllowed) {
             errorMsgs.push(

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -35,7 +35,10 @@ const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mim
 const checkIsFileWithinMimeTypes = (mimeTypes, file) => !!mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
-const checkFileTypeAllowed = (file, locationMapping) => (!locationMapping ? true : isMimeTypeAllowed(locationMapping.mappings, file));
+const checkFileTypeAllowed = (file, locationMapping, config) => (!locationMapping
+    ? config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file))
+    : isMimeTypeAllowed(locationMapping.mappings, file)
+);
 
 const detectContentTypeMapping = (file, parentInfo, config) => {
     const locationMapping = config.locationMappings.find((item) => item.contentTypeIdentifier === parentInfo.contentTypeIdentifier);
@@ -263,18 +266,8 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
         );
     }
 
-    if (!checkFileTypeAllowed(file, locationMapping)) {
+    if (!checkFileTypeAllowed(file, locationMapping, config)) {
         errorMsgs.push(Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'));
-    }
-
-    if (!locationMapping) {
-        const isAllowed = config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file));
-
-        if (!isAllowed) {
-            errorMsgs.push(
-                Translator.trans(/*@Desc("File type is not allowed")*/ 'disallowed_type.message', {}, 'ibexa_multi_file_upload'),
-            );
-        }
     }
 
     if (file.size > maxFileSize) {

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -32,7 +32,7 @@ const readFile = function (file, resolve, reject) {
     this.readAsDataURL(file);
 };
 const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mimeTypes.find((type) => type === file.type));
-const fileWithinMimetypes = (mimeTypes, file) => mimeTypes.find((type) => type === file.type);
+const fileWithinMimeTypes = (mimeTypes, file) => mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
 const checkFileTypeAllowed = (file, locationMapping) => (!locationMapping ? true : isMimeTypeAllowed(locationMapping.mappings, file));
@@ -269,8 +269,9 @@ export const checkCanUpload = (file, parentInfo, config, errorCallback) => {
 
     if (!locationMapping) {
         let allowed = false;
+
         config.defaultMappings.forEach((mapping) => {
-            if (fileWithinMimetypes(mapping.mimeTypes, file)) {
+            if (fileWithinMimeTypes(mapping.mimeTypes, file)) {
                 allowed = true;
             }
         });

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -35,10 +35,10 @@ const findFileTypeMapping = (mappings, file) => mappings.find((item) => item.mim
 const checkIsFileWithinMimeTypes = (mimeTypes, file) => !!mimeTypes.find((type) => type === file.type);
 const isMimeTypeAllowed = (mappings, file) => !!findFileTypeMapping(mappings, file);
 
-const checkFileTypeAllowed = (file, locationMapping, config) => (!locationMapping
-    ? config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file))
-    : isMimeTypeAllowed(locationMapping.mappings, file)
-);
+const checkFileTypeAllowed = (file, locationMapping, config) =>
+    !locationMapping
+        ? config.defaultMappings.every((mapping) => checkIsFileWithinMimeTypes(mapping.mimeTypes, file))
+        : isMimeTypeAllowed(locationMapping.mappings, file);
 
 const detectContentTypeMapping = (file, parentInfo, config) => {
     const locationMapping = config.locationMappings.find((item) => item.contentTypeIdentifier === parentInfo.contentTypeIdentifier);


### PR DESCRIPTION
| :ticket: Issue | IBX-8111 |
|----------------|-----------|

#### Description:
If the location doesn't have a mapping assigned to it (by default it doesn't) maybe we should reuse the default mapping and validate a file's type only by the default mime types mapping. I'm not sure about this one to be honest. How should we validate file if location mapping is not there? Backend already does its validation properly, but what should we depend on when it comes to frontend?

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
