### PR TITLE
IBX-10221: Fixed 500 error when removing Site skeletons by improving location root checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "ibexa/user": "~4.6.0@dev",
         "ibexa/fieldtype-richtext": "~4.6.0@dev",
         "ibexa/rest": "~4.6.0@dev",
+        "ibexa/phpstan": "~4.6.x-dev",
         "ibexa/polyfill-php82": "^1.0",
         "ibexa/search": "~4.6.x-dev",
         "ibexa/twig-components": "~4.6.x-dev",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ includes:
     - phpstan-baseline.neon.php
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
+    - vendor/ibexa/phpstan/extension.neon
 
 parameters:
     level: 8

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -12,7 +12,7 @@ use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
 use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\AdminUi\Specification\ContentType\ContentTypeIsUser;
 use Ibexa\AdminUi\Specification\ContentType\ContentTypeIsUserGroup;
-use Ibexa\AdminUi\Specification\Location\IsContentStructureRoot;
+use Ibexa\AdminUi\Specification\Location\IsInContextualTreeRootIds;
 use Ibexa\AdminUi\Specification\Location\IsRoot;
 use Ibexa\AdminUi\Specification\Location\IsWithinCopySubtreeLimit;
 use Ibexa\AdminUi\UniversalDiscovery\ConfigResolver;
@@ -295,9 +295,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         }
 
         $isAtRootLevel = (new IsRoot())->isSatisfiedBy($location);
-        $isContentStructureRoot = (new IsContentStructureRoot($this->configResolver))->isSatisfiedBy($location);
+        $isInContextualRootIds = (new IsInContextualTreeRootIds($this->configResolver))->isSatisfiedBy($location);
 
-        if (!$contentIsUser && !$isAtRootLevel && !$isContentStructureRoot && $canTrashLocation) {
+        if (!$contentIsUser && !$isAtRootLevel && !$isInContextualRootIds && $canTrashLocation) {
             $menu->addChild(
                 $this->createMenuItem(
                     self::ITEM__SEND_TO_TRASH,
@@ -309,7 +309,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             );
         }
 
-        if ($isAtRootLevel || $isContentStructureRoot) {
+        if ($isAtRootLevel || $isInContextualRootIds) {
             $menu[self::ITEM__MOVE]->setAttribute('disabled', 'disabled');
         }
 

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -12,6 +12,7 @@ use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
 use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
 use Ibexa\AdminUi\Specification\ContentType\ContentTypeIsUser;
 use Ibexa\AdminUi\Specification\ContentType\ContentTypeIsUserGroup;
+use Ibexa\AdminUi\Specification\Location\IsContentStructureRoot;
 use Ibexa\AdminUi\Specification\Location\IsRoot;
 use Ibexa\AdminUi\Specification\Location\IsWithinCopySubtreeLimit;
 use Ibexa\AdminUi\UniversalDiscovery\ConfigResolver;
@@ -293,11 +294,10 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             );
         }
 
-        $rootContentDepth = $this->configResolver->getParameter('location_ids.content_structure');
         $isAtRootLevel = (new IsRoot())->isSatisfiedBy($location);
-        $isRootContent = $location->depth === $rootContentDepth;
+        $isContentStructureRoot = (new IsContentStructureRoot($this->configResolver))->isSatisfiedBy($location);
 
-        if (!$contentIsUser && !$isAtRootLevel && !$isRootContent && $canTrashLocation) {
+        if (!$contentIsUser && !$isAtRootLevel && !$isContentStructureRoot && $canTrashLocation) {
             $menu->addChild(
                 $this->createMenuItem(
                     self::ITEM__SEND_TO_TRASH,
@@ -309,7 +309,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             );
         }
 
-        if ($isAtRootLevel || $isRootContent) {
+        if ($isAtRootLevel || $isContentStructureRoot) {
             $menu[self::ITEM__MOVE]->setAttribute('disabled', 'disabled');
         }
 

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -293,7 +293,11 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             );
         }
 
-        if (!$contentIsUser && 1 !== $location->depth && $canTrashLocation) {
+        $rootContentDepth = $this->configResolver->getParameter('location_ids.content_structure');
+        $isAtRootLevel = (new IsRoot())->isSatisfiedBy($location);
+        $isRootContent = $location->depth === $rootContentDepth;
+
+        if (!$contentIsUser && !$isAtRootLevel && !$isRootContent && $canTrashLocation) {
             $menu->addChild(
                 $this->createMenuItem(
                     self::ITEM__SEND_TO_TRASH,
@@ -305,7 +309,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             );
         }
 
-        if (1 === $location->depth) {
+        if ($isAtRootLevel || $isRootContent) {
             $menu[self::ITEM__MOVE]->setAttribute('disabled', 'disabled');
         }
 

--- a/src/lib/Specification/Location/IsContentStructureRoot.php
+++ b/src/lib/Specification/Location/IsContentStructureRoot.php
@@ -11,13 +11,13 @@ namespace Ibexa\AdminUi\Specification\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\Core\Specification\AbstractSpecification;
 
-class IsContentStructureRoot extends AbstractSpecification
+final class IsContentStructureRoot extends AbstractSpecification
 {
-    private int $contentStructureRootDepth;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {
-        $this->contentStructureRootDepth = (int)$configResolver->getParameter('location_ids.content_structure');
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -25,6 +25,6 @@ class IsContentStructureRoot extends AbstractSpecification
      */
     public function isSatisfiedBy($item): bool
     {
-        return $item->depth === $this->contentStructureRootDepth;
+        return $item->depth === (int)$this->configResolver->getParameter('location_ids.content_structure');
     }
 }

--- a/src/lib/Specification/Location/IsContentStructureRoot.php
+++ b/src/lib/Specification/Location/IsContentStructureRoot.php
@@ -25,6 +25,6 @@ final class IsContentStructureRoot extends AbstractSpecification
      */
     public function isSatisfiedBy($item): bool
     {
-        return $item->depth === (int)$this->configResolver->getParameter('location_ids.content_structure');
+        return $item->getDepth() === (int)$this->configResolver->getParameter('location_ids.content_structure');
     }
 }

--- a/src/lib/Specification/Location/IsContentStructureRoot.php
+++ b/src/lib/Specification/Location/IsContentStructureRoot.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Specification\Location;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Specification\AbstractSpecification;
+
+class IsContentStructureRoot extends AbstractSpecification
+{
+    private int $contentStructureRootDepth;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->contentStructureRootDepth = (int)$configResolver->getParameter('location_ids.content_structure');
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $item
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        return $item->depth === $this->contentStructureRootDepth;
+    }
+}

--- a/src/lib/Specification/Location/IsInContextualTreeRootIds.php
+++ b/src/lib/Specification/Location/IsInContextualTreeRootIds.php
@@ -11,7 +11,7 @@ namespace Ibexa\AdminUi\Specification\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\Core\Specification\AbstractSpecification;
 
-final class IsContentStructureRoot extends AbstractSpecification
+final class IsInContextualTreeRootIds extends AbstractSpecification
 {
     private ConfigResolverInterface $configResolver;
 
@@ -25,6 +25,10 @@ final class IsContentStructureRoot extends AbstractSpecification
      */
     public function isSatisfiedBy($item): bool
     {
-        return $item->getId() === (int)$this->configResolver->getParameter('location_ids.content_structure');
+        $contextualRootIds = $this->configResolver->getParameter(
+            'content_tree_module.contextual_tree_root_location_ids'
+        );
+
+        return in_array($item->getId(), $contextualRootIds, true);
     }
 }

--- a/src/lib/Specification/Location/IsRoot.php
+++ b/src/lib/Specification/Location/IsRoot.php
@@ -14,12 +14,10 @@ class IsRoot extends AbstractSpecification
 {
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $item
-     *
-     * @return bool
      */
     public function isSatisfiedBy($item): bool
     {
-        return 1 === $item->depth;
+        return 1 === $item->getDepth();
     }
 }
 

--- a/tests/lib/Specification/Location/IsContentStructureRootTest.php
+++ b/tests/lib/Specification/Location/IsContentStructureRootTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Specification\Location;
+
+use Ibexa\AdminUi\Specification\Location\IsContentStructureRoot;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+class IsContentStructureRootTest extends TestCase
+{
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsContentStructureRoot::isSatisfiedBy
+     */
+    public function testReturnsTrueWhenLocationDepthMatchesRoot(): void
+    {
+        $depth = 1;
+
+        $specification = new IsContentStructureRoot(
+            $this->createConfigResolverReturning($depth)
+        );
+
+        $this->assertTrue(
+            $specification->isSatisfiedBy($this->createLocationWithDepth($depth))
+        );
+    }
+
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsContentStructureRoot::isSatisfiedBy
+     */
+    public function testReturnsFalseWhenLocationDepthDoesNotMatchRoot(): void
+    {
+        $specification = new IsContentStructureRoot(
+            $this->createConfigResolverReturning(1)
+        );
+
+        $this->assertFalse(
+            $specification->isSatisfiedBy($this->createLocationWithDepth(3))
+        );
+    }
+
+    private function createLocationWithDepth(int $depth): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location->method('getDepth')->willReturn($depth);
+
+        return $location;
+    }
+
+    private function createConfigResolverReturning(int $depth): ConfigResolverInterface
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+        $configResolver
+            ->method('getParameter')
+            ->with('location_ids.content_structure')
+            ->willReturn($depth);
+
+        return $configResolver;
+    }
+}

--- a/tests/lib/Specification/Location/IsContentStructureRootTest.php
+++ b/tests/lib/Specification/Location/IsContentStructureRootTest.php
@@ -20,14 +20,14 @@ final class IsContentStructureRootTest extends TestCase
      */
     public function testReturnsTrueWhenLocationDepthMatchesRoot(): void
     {
-        $depth = 1;
+        $id = 1;
 
         $specification = new IsContentStructureRoot(
-            $this->createConfigResolverReturning($depth)
+            $this->createConfigResolverReturning($id)
         );
 
         self::assertTrue(
-            $specification->isSatisfiedBy($this->createLocationWithDepth($depth))
+            $specification->isSatisfiedBy($this->createLocationWithId($id))
         );
     }
 
@@ -41,25 +41,25 @@ final class IsContentStructureRootTest extends TestCase
         );
 
         self::assertFalse(
-            $specification->isSatisfiedBy($this->createLocationWithDepth(3))
+            $specification->isSatisfiedBy($this->createLocationWithId(3))
         );
     }
 
-    private function createLocationWithDepth(int $depth): Location
+    private function createLocationWithId(int $id): Location
     {
         $location = $this->createMock(Location::class);
-        $location->method('getDepth')->willReturn($depth);
+        $location->method('getId')->willReturn($id);
 
         return $location;
     }
 
-    private function createConfigResolverReturning(int $depth): ConfigResolverInterface
+    private function createConfigResolverReturning(int $id): ConfigResolverInterface
     {
         $configResolver = $this->createMock(ConfigResolverInterface::class);
         $configResolver
             ->method('getParameter')
             ->with('location_ids.content_structure')
-            ->willReturn($depth);
+            ->willReturn($id);
 
         return $configResolver;
     }

--- a/tests/lib/Specification/Location/IsContentStructureRootTest.php
+++ b/tests/lib/Specification/Location/IsContentStructureRootTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use PHPUnit\Framework\TestCase;
 
-class IsContentStructureRootTest extends TestCase
+final class IsContentStructureRootTest extends TestCase
 {
     /**
      * @covers \Ibexa\AdminUi\Specification\Location\IsContentStructureRoot::isSatisfiedBy
@@ -26,7 +26,7 @@ class IsContentStructureRootTest extends TestCase
             $this->createConfigResolverReturning($depth)
         );
 
-        $this->assertTrue(
+        self::assertTrue(
             $specification->isSatisfiedBy($this->createLocationWithDepth($depth))
         );
     }
@@ -40,7 +40,7 @@ class IsContentStructureRootTest extends TestCase
             $this->createConfigResolverReturning(1)
         );
 
-        $this->assertFalse(
+        self::assertFalse(
             $specification->isSatisfiedBy($this->createLocationWithDepth(3))
         );
     }

--- a/tests/lib/Specification/Location/IsInContextualTreeRootIdsTest.php
+++ b/tests/lib/Specification/Location/IsInContextualTreeRootIdsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Specification\Location;
+
+use Ibexa\AdminUi\Specification\Location\IsInContextualTreeRootIds;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class IsInContextualTreeRootIdsTest extends TestCase
+{
+    private const CONTEXTUAL_ROOT_IDS = [2, 5, 43, 55, 56, 67];
+
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsInContextualTreeRootIds::isSatisfiedBy
+     */
+    public function testReturnsTrueWhenLocationIdIsInContextualRootList(): void
+    {
+        $specification = new IsInContextualTreeRootIds(
+            $this->createConfigResolverReturning()
+        );
+
+        self::assertTrue(
+            $specification->isSatisfiedBy($this->createLocationWithId(43))
+        );
+    }
+
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsInContextualTreeRootIds::isSatisfiedBy
+     */
+    public function testReturnsFalseWhenLocationIdIsNotInContextualRootList(): void
+    {
+        $specification = new IsInContextualTreeRootIds(
+            $this->createConfigResolverReturning()
+        );
+
+        self::assertFalse(
+            $specification->isSatisfiedBy($this->createLocationWithId(999))
+        );
+    }
+
+    private function createLocationWithId(int $id): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location->method('getId')->willReturn($id);
+
+        return $location;
+    }
+
+    private function createConfigResolverReturning(): ConfigResolverInterface
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+        $configResolver
+            ->method('getParameter')
+            ->with('content_tree_module.contextual_tree_root_location_ids')
+            ->willReturn(self::CONTEXTUAL_ROOT_IDS);
+
+        return $configResolver;
+    }
+}

--- a/tests/lib/Specification/Location/IsRootTest.php
+++ b/tests/lib/Specification/Location/IsRootTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Specification\Location;
+
+use Ibexa\AdminUi\Specification\Location\IsRoot;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+
+class IsRootTest extends TestCase
+{
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsRoot::isSatisfiedBy
+     */
+    public function testReturnsTrueWhenLocationDepthIsOne(): void
+    {
+        $specification = new IsRoot();
+
+        $location = $this->createLocationWithDepth(1);
+
+        $this->assertTrue($specification->isSatisfiedBy($location));
+    }
+
+    /**
+     * @covers \Ibexa\AdminUi\Specification\Location\IsRoot::isSatisfiedBy
+     */
+    public function testReturnsFalseWhenLocationDepthIsNotOne(): void
+    {
+        $specification = new IsRoot();
+
+        $location = $this->createLocationWithDepth(2);
+
+        $this->assertFalse($specification->isSatisfiedBy($location));
+    }
+
+    private function createLocationWithDepth(int $depth): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location->method('getDepth')->willReturn($depth);
+
+        return $location;
+    }
+}

--- a/tests/lib/Specification/Location/IsRootTest.php
+++ b/tests/lib/Specification/Location/IsRootTest.php
@@ -12,7 +12,7 @@ use Ibexa\AdminUi\Specification\Location\IsRoot;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
 
-class IsRootTest extends TestCase
+final class IsRootTest extends TestCase
 {
     /**
      * @covers \Ibexa\AdminUi\Specification\Location\IsRoot::isSatisfiedBy
@@ -23,7 +23,7 @@ class IsRootTest extends TestCase
 
         $location = $this->createLocationWithDepth(1);
 
-        $this->assertTrue($specification->isSatisfiedBy($location));
+        self::assertTrue($specification->isSatisfiedBy($location));
     }
 
     /**
@@ -35,7 +35,7 @@ class IsRootTest extends TestCase
 
         $location = $this->createLocationWithDepth(2);
 
-        $this->assertFalse($specification->isSatisfiedBy($location));
+        self::assertFalse($specification->isSatisfiedBy($location));
     }
 
     private function createLocationWithDepth(int $depth): Location

--- a/tests/lib/Validator/Constraint/LocationIsNotRootValidatorTest.php
+++ b/tests/lib/Validator/Constraint/LocationIsNotRootValidatorTest.php
@@ -31,11 +31,8 @@ class LocationIsNotRootValidatorTest extends TestCase
 
     public function testValid()
     {
-        $location = $this
-            ->getMockBuilder(Location::class)
-            ->setMethodsExcept(['__get'])
-            ->setConstructorArgs([['depth' => 5]])
-            ->getMock();
+        $location = $this->createMock(Location::class);
+        $location->method('getDepth')->willReturn(5);
 
         $this->executionContext
             ->expects($this->never())
@@ -46,11 +43,8 @@ class LocationIsNotRootValidatorTest extends TestCase
 
     public function testInvalid()
     {
-        $location = $this
-            ->getMockBuilder(Location::class)
-            ->setMethodsExcept(['__get'])
-            ->setConstructorArgs([['depth' => 1]])
-            ->getMock();
+        $location = $this->createMock(Location::class);
+        $location->method('getDepth')->willReturn(1);
 
         $this->executionContext
             ->expects($this->once())


### PR DESCRIPTION
| :ticket: Issue | IBX-10221 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fix 500 error when attempting to trash root-level or contextual root locations
- Fixed a 500 error that occurred when attempting to send a Site skeleton to trash, caused by incorrect handling of contextual root locations.
- Introduced the IsInContextualTreeRootIds specification, which checks whether a location belongs to the configured contextual root locations via the
- The "Send to Trash" menu item is now hidden when the selected location is either the root or a contextual root location.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
