### PR TITLE
Adapted to deprecated `null` value for content structs in `BaseContentType`

### DIFF
--- a/src/bundle/Controller/User/ProfileEditController.php
+++ b/src/bundle/Controller/User/ProfileEditController.php
@@ -72,7 +72,11 @@ final class ProfileEditController extends Controller
                 'languageCode' => $languageCode,
                 'mainLanguageCode' => $user->getContentInfo()->getMainLanguageCode(),
                 'struct' => $data,
-                'content' => $user,
+                //This is **the only permissible case for nullable content**. It stems from the fact that
+                //one's own user profile editing shouldn't undergo permissions checks. Otherwise, it
+                //would be impossible to composer role that would allow that out of the box for all users
+                //that are assigned to it.
+                'content' => null,
             ]
         );
 

--- a/src/bundle/Controller/UserOnTheFlyController.php
+++ b/src/bundle/Controller/UserOnTheFlyController.php
@@ -101,6 +101,7 @@ class UserOnTheFlyController extends Controller
         $form = $this->createForm(UserCreateType::class, $data, [
             'languageCode' => $language->languageCode,
             'mainLanguageCode' => $language->languageCode,
+            'struct' => $data,
         ]);
 
         $form->handleRequest($request);
@@ -195,7 +196,8 @@ class UserOnTheFlyController extends Controller
             [
                 'location' => $location,
                 'languageCode' => $languageCode,
-                'mainLanguageCode' => $user->contentInfo->mainLanguageCode,
+                'mainLanguageCode' => $user->getContentInfo()->getMainLanguageCode(),
+                'struct' => $contentUpdate,
             ]
         );
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/content-forms/pull/95

#### Description:
Adapted to deprecations introduced via https://github.com/ibexa/content-forms/pull/70.
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
