### PR TITLE
Replaced `ibexa_render_component_group` with `ibexa_twig_component_group` in form fields template.

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -540,7 +540,7 @@
             } only %}
         </div>
         <div class="ibexa-field-edit__distraction-free-mode-extras">
-            {{ ibexa_twig_component_group('distraction-free-mode-extras', {}) }}
+            {{ ibexa_twig_component_group('admin-ui-distraction-free-mode-extras', {}) }}
         </div>
         <div class="ibexa-field-edit__distraction-free-mode-control-container">
             <div class="ibexa-field-edit__distraction-free-mode-label">

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -540,7 +540,7 @@
             } only %}
         </div>
         <div class="ibexa-field-edit__distraction-free-mode-extras">
-            {{ ibexa_render_component_group('distraction-free-mode-extras', {}) }}
+            {{ ibexa_twig_component_group('distraction-free-mode-extras', {}) }}
         </div>
         <div class="ibexa-field-edit__distraction-free-mode-control-container">
             <div class="ibexa-field-edit__distraction-free-mode-label">


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----|

#### Description:
Replaces the deprecated Twig function `ibexa_render_component_group` with `ibexa_twig_component_group` as recommended since ibexa/admin-ui 4.6.19.

This removes deprecation warnings triggered in templates such as `form_fields.html.twig`.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
