### PR TITLE
Added `phpstan-` prefix to PHPStan-only hints

### DIFF
--- a/src/lib/Event/FilterContentTypesEvent.php
+++ b/src/lib/Event/FilterContentTypesEvent.php
@@ -15,11 +15,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class FilterContentTypesEvent extends Event
 {
-    /** @var array<string, array<TContentTypeData>> */
+    /** @phpstan-var array<string, array<TContentTypeData>> */
     private array $contentTypeGroups;
 
     /**
-     * @param array<string, array<TContentTypeData>> $contentTypeGroups
+     * @phpstan-param array<string, array<TContentTypeData>> $contentTypeGroups
      */
     public function __construct(
         array $contentTypeGroups
@@ -28,7 +28,7 @@ final class FilterContentTypesEvent extends Event
     }
 
     /**
-     * @return array<string, array<TContentTypeData>>
+     * @phpstan-return array<string, array<TContentTypeData>>
      */
     public function getContentTypeGroups(): array
     {


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
It seems that JMS translation extractor [1] crashes trying to resolve PHPStan types in some PHPDocs:

```
In StringTypeResolver.php line 360:
                                            
  [DomainException]                         
  Unhandled "TContentTypeData" identifier.  
```                                       

---
[1] `jms:translation:extract` Symfony command
