### PR TITLE
IBX-10358: Close icon in AI Assistant is barely visible

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/common/_draggable.dialog.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/common/_draggable.dialog.scss
@@ -11,3 +11,7 @@
         user-select: none;
     }
 }
+
+.ibexa-tooltip--draggable-dialog {
+    z-index: 10050;
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-10358 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Increased z-index for tooltips in component c-draggable-dialog, which has z-index itself on 10000 
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
