### PR TITLE
Fixed editing content from UDW after dropping non-nullable `struct` parameter from parent form

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5479,31 +5479,19 @@ parameters:
 			path: src/lib/Form/Processor/ContentType/ContentTypeFormProcessor.php
 
 		-
-			message: '#^Access to an undefined property Ibexa\\ContentForms\\Data\\Content\\ContentCreateData\|Ibexa\\ContentForms\\Data\\Content\\ContentUpdateData\:\:\$contentDraft\.$#'
-			identifier: property.notFound
+			message: '#^Call to an undefined method Ibexa\\ContentForms\\Data\\Content\\ContentCreateData\|Ibexa\\ContentForms\\Data\\Content\\ContentUpdateData\:\:getContentDraft\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: src/lib/Form/Processor/PreviewFormProcessor.php
 
 		-
-			message: '#^Access to an undefined property Ibexa\\ContentForms\\Data\\Content\\ContentCreateData\|Ibexa\\ContentForms\\Data\\Content\\ContentUpdateData\:\:\$contentType\.$#'
-			identifier: property.notFound
+			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\ContentStruct\:\:getContentDraft\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/lib/Form/Processor/PreviewFormProcessor.php
 
 		-
-			message: '#^Access to an undefined property Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\ContentStruct\:\:\$contentDraft\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/lib/Form/Processor/PreviewFormProcessor.php
-
-		-
-			message: '#^Access to an undefined property Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\ContentStruct\:\:\$fieldsData\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/lib/Form/Processor/PreviewFormProcessor.php
-
-		-
-			message: '#^Call to an undefined method Ibexa\\ContentForms\\Data\\Content\\ContentCreateData\|Ibexa\\ContentForms\\Data\\Content\\ContentUpdateData\:\:getLocationStructs\(\)\.$#'
+			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\ContentStruct\:\:getFieldsData\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/lib/Form/Processor/PreviewFormProcessor.php
@@ -5573,12 +5561,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Form/Processor/User/UserOnTheFlyProcessor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Form\\Provider\\GroupedNonMetaFormFieldsProvider\:\:getGroupedFields\(\) has parameter \$fieldsDataForm with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Provider/GroupedNonMetaFormFieldsProvider.php
 
 		-
 			message: '#^Instanceof between Symfony\\Component\\HttpFoundation\\JsonResponse and Symfony\\Component\\HttpFoundation\\JsonResponse will always evaluate to true\.$#'

--- a/src/bundle/Controller/ContentOnTheFlyController.php
+++ b/src/bundle/Controller/ContentOnTheFlyController.php
@@ -195,6 +195,7 @@ class ContentOnTheFlyController extends Controller
             'contentCreateStruct' => $data,
             'drafts_enabled' => false,
             'intent' => 'create',
+            'struct' => $data,
         ]);
 
         $form->handleRequest($request);
@@ -240,7 +241,7 @@ class ContentOnTheFlyController extends Controller
         }
 
         $contentType = $this->contentTypeService->loadContentType(
-            $content->contentInfo->contentTypeId,
+            $content->getContentInfo()->contentTypeId,
             $this->userLanguagePreferenceProvider->getPreferredLanguages()
         );
 
@@ -266,10 +267,11 @@ class ContentOnTheFlyController extends Controller
             [
                 'location' => $location,
                 'languageCode' => $languageCode,
-                'mainLanguageCode' => $content->contentInfo->mainLanguageCode,
+                'mainLanguageCode' => $content->getContentInfo()->getMainLanguageCode(),
                 'content' => $content,
                 'contentUpdateStruct' => $contentUpdate,
                 'drafts_enabled' => true,
+                'struct' => $contentUpdate,
             ]
         );
 

--- a/src/lib/EventListener/UserProfileListener.php
+++ b/src/lib/EventListener/UserProfileListener.php
@@ -124,7 +124,7 @@ final class UserProfileListener implements EventSubscriberInterface
         $updateStruct = $this->userService->newUserUpdateStruct();
         $updateStruct->contentUpdateStruct = $this->contentService->newContentUpdateStruct();
 
-        foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+        foreach ($data->getFieldsData() as $fieldDefIdentifier => $fieldData) {
             $updateStruct->contentUpdateStruct->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
         }
 
@@ -138,7 +138,7 @@ final class UserProfileListener implements EventSubscriberInterface
             return false;
         }
 
-        foreach ($data->fieldsData as $fieldData) {
+        foreach ($data->getFieldsData() as $fieldData) {
             if ($fieldData->getFieldTypeIdentifier() === UserFieldType::class) {
                 return false;
             }

--- a/src/lib/FieldType/Mapper/AuthorFormMapper.php
+++ b/src/lib/FieldType/Mapper/AuthorFormMapper.php
@@ -49,7 +49,7 @@ class AuthorFormMapper implements FieldDefinitionFormMapperInterface, FieldValue
 
     public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
-        $fieldDefinition = $data->fieldDefinition;
+        $fieldDefinition = $data->getFieldDefinition();
         $fieldSettings = $fieldDefinition->getFieldSettings();
         $formConfig = $fieldForm->getConfig();
 
@@ -58,7 +58,7 @@ class AuthorFormMapper implements FieldDefinitionFormMapperInterface, FieldValue
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', AuthorFieldType::class, [
                         'default_author' => $fieldSettings['defaultAuthor'],
-                        'required' => $fieldDefinition->isRequired,
+                        'required' => $fieldDefinition->isRequired(),
                         'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)

--- a/src/lib/Form/Data/ContentTranslationData.php
+++ b/src/lib/Form/Data/ContentTranslationData.php
@@ -28,7 +28,7 @@ class ContentTranslationData extends ContentUpdateStruct implements NewnessCheck
 
     public function addFieldData(FieldData $fieldData): void
     {
-        $this->fieldsData[$fieldData->fieldDefinition->identifier] = $fieldData;
+        $this->fieldsData[$fieldData->getFieldDefinition()->getIdentifier()] = $fieldData;
     }
 
     public function isNew(): bool

--- a/src/lib/Form/Processor/TranslationFormProcessor.php
+++ b/src/lib/Form/Processor/TranslationFormProcessor.php
@@ -54,12 +54,12 @@ class TranslationFormProcessor implements EventSubscriberInterface
             return;
         }
 
-        $contentDraft = $this->contentService->createContentDraft($data->content->contentInfo);
+        $contentDraft = $this->contentService->createContentDraft($data->content->getContentInfo());
         $fields = array_filter($data->fieldsData, static function (FieldData $fieldData) use ($contentDraft, $data): bool {
-            $mainLanguageCode = $contentDraft->getVersionInfo()->getContentInfo()->mainLanguageCode;
+            $mainLanguageCode = $contentDraft->getVersionInfo()->getContentInfo()->getMainLanguageCode();
 
             return $mainLanguageCode === $data->initialLanguageCode
-                || ($mainLanguageCode !== $data->initialLanguageCode && $fieldData->fieldDefinition->isTranslatable);
+                || ($mainLanguageCode !== $data->initialLanguageCode && $fieldData->getFieldDefinition()->isTranslatable());
         });
         $contentUpdateData = new ContentUpdateData([
             'initialLanguageCode' => $data->initialLanguageCode,


### PR DESCRIPTION
| :ticket: Issue | - |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Followup after dropping deprecation described here: https://github.com/ibexa/content-forms/pull/70. Apart from this, I got rid of magic properties' accessing here and there in favour of proper getters.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
