### PR TITLE
IBX-10417: Removed redundant information in header create/edit

### DIFF
--- a/src/bundle/Resources/translations/ibexa_content_edit.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_edit.en.xliff
@@ -31,11 +31,6 @@
         <target state="new">Editing</target>
         <note>key: editing</note>
       </trans-unit>
-      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
-        <source>Location: %location% Translation: %language%</source>
-        <target state="new">Location: %location% Translation: %language%</target>
-        <note>key: editing_details</note>
-      </trans-unit>
       <trans-unit id="582b09a837963ba464ba24493c8cc7c360b99708" resname="editing_details_subtitle">
         <source>under: %location%</source>
         <target state="new">under: %location%</target>

--- a/src/bundle/Resources/translations/ibexa_user_create.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_user_create.en.xliff
@@ -11,10 +11,10 @@
         <target state="new">Creating</target>
         <note>key: Create</note>
       </trans-unit>
-      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
-        <source>Location: %location%</source>
-        <target state="new">Location: %location%</target>
-        <note>key: editing_details</note>
+      <trans-unit id="582b09a837963ba464ba24493c8cc7c360b99708" resname="editing_details_subtitle">
+        <source>under: %location%</source>
+        <target state="new">under: %location%</target>
+        <note>key: editing_details_subtitle</note>
       </trans-unit>
       <trans-unit id="32d50c07b2eacd6fa72742ff1c1f5963c26a251d" resname="new_content_item">
         <source>New %contentType%</source>

--- a/src/bundle/Resources/translations/ibexa_user_edit.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_user_edit.en.xliff
@@ -11,10 +11,10 @@
         <target state="new">Editing</target>
         <note>key: editing</note>
       </trans-unit>
-      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
-        <source>Location: %location%</source>
-        <target state="new">Location: %location%</target>
-        <note>key: editing_details</note>
+      <trans-unit id="582b09a837963ba464ba24493c8cc7c360b99708" resname="editing_details_subtitle">
+        <source>under: %location%</source>
+        <target state="new">under: %location%</target>
+        <note>key: editing_details_subtitle</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -31,6 +31,7 @@
     {% include '@ibexadesign/ui/edit_header.html.twig' with {
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
+        subtitle: 'editing_details_subtitle'|trans({ '%location%': parent_location.contentInfo.name })|desc('under: %location%'),
         icon_name: content_type.identifier,
         show_autosave_status: true,
         description: content_type.description,

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -35,7 +35,7 @@
         content_type_name: content_type.name,
         show_autosave_status: true,
         description: content_type.description,
-        subtitle: 'editing_details'|trans({ '%location%': parent_location.contentInfo.name, '%language%': language.name })|desc('Location: %location% Translation: %language%'),
+        subtitle: 'editing_details_subtitle'|trans({ '%location%': parent_location.contentInfo.name })|desc('under: %location%'),
         context_actions: context_actions,
     } %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/user/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/create.html.twig
@@ -17,7 +17,7 @@
         icon_name: content_type.name,
         show_autosave_status: false,
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        subtitle: 'editing_details'|trans({ '%location%': parent_location.contentInfo.name })|desc('Location: %location%'),
+        subtitle: 'editing_details_subtitle'|trans({ '%location%': parent_location.contentInfo.name })|desc('under: %location%'),
         context_actions: knp_menu_render(user_content_edit_menu, {'template': '@ibexadesign/ui/menu/context_menu.html.twig'})
     } %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/user/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/edit.html.twig
@@ -18,7 +18,7 @@
         icon_name: content_type.name,
         show_autosave_status: false,
         title: "%s %s"|format(user.getFieldValue('first_name'), user.getFieldValue('last_name')),
-        subtitle: parent_location ? 'editing_details'|trans({ '%location%': parent_location.contentInfo.name })|desc('Location: %location%') : null,
+        subtitle: parent_location ? 'editing_details_subtitle'|trans({ '%location%': parent_location.contentInfo.name })|desc('under: %location%') : null,
         context_actions: knp_menu_render(user_content_edit_menu, {'template': '@ibexadesign/ui/menu/context_menu.html.twig'})
     } %}
 {% endblock %}


### PR DESCRIPTION
| :ticket: Issue | IBX-10417 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In this PR I updated create/edit header for content on the fly and create user header and the user creation header.

Content on the fly 
<img width="1019" height="461" alt="Screenshot 2025-08-01 at 10 43 47" src="https://github.com/user-attachments/assets/61d0b679-d983-4f66-93b6-d0765549cf1a" />

User create
<img width="1095" height="421" alt="Screenshot 2025-08-01 at 10 43 18" src="https://github.com/user-attachments/assets/2a7c1b93-eb59-493f-aabc-31e338af115a" />


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
