### PR TITLE
Added --watch option to ibexa:encore:compile

### DIFF
--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -48,7 +48,7 @@ class CompileAssetsCommand extends Command
                 't',
                 InputOption::VALUE_REQUIRED,
                 'Timeout in seconds (ignored in watch mode)',
-                $this->timeout
+                null
             )
             ->addOption(
                 'config-name',
@@ -69,10 +69,16 @@ class CompileAssetsCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
+        $watch = $input->getOption('watch');
         $timeout = $input->getOption('timeout');
 
-        if (!is_numeric($timeout)) {
-            throw new InvalidArgumentException('Timeout value has to be an integer.');
+        if (null !== $timeout) {
+            if ($watch) {
+                throw new InvalidArgumentException('Watch mode can\'t be used with a timeout.');
+            }
+            if (!is_numeric($timeout)) {
+                throw new InvalidArgumentException('Timeout value has to be an integer.');
+            }
         }
     }
 
@@ -84,7 +90,7 @@ class CompileAssetsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $watch = $input->getOption('watch');
-        $timeout = $watch ? null : (float)$input->getOption('timeout');
+        $timeout = $watch ? null : (int)($input->getOption('timeout')??$this->timeout);
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
         $frontendConfigsName = $input->getOption('frontend-configs-name');

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -47,7 +47,7 @@ class CompileAssetsCommand extends Command
                 'timeout',
                 't',
                 InputOption::VALUE_REQUIRED,
-                'Timeout in seconds (ignored in watch mode)',
+                "Timeout in seconds (default timeout is {$this->timeout}s when this option isn't used and not in watch mode)",
                 null
             )
             ->addOption(

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -90,7 +90,7 @@ class CompileAssetsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $watch = $input->getOption('watch');
-        $timeout = $watch ? null : (float)($input->getOption('timeout')??$this->timeout);
+        $timeout = $watch ? null : (float)($input->getOption('timeout') ?? $this->timeout);
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
         $frontendConfigsName = $input->getOption('frontend-configs-name');

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -90,7 +90,7 @@ class CompileAssetsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $watch = $input->getOption('watch');
-        $timeout = $watch ? null : (int)($input->getOption('timeout')??$this->timeout);
+        $timeout = $watch ? null : (float)($input->getOption('timeout')??$this->timeout);
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
         $frontendConfigsName = $input->getOption('frontend-configs-name');

--- a/src/bundle/Command/CompileAssetsCommand.php
+++ b/src/bundle/Command/CompileAssetsCommand.php
@@ -38,10 +38,16 @@ class CompileAssetsCommand extends Command
     {
         $this
             ->addOption(
+                'watch',
+                'w',
+                InputOption::VALUE_NONE,
+                'Watch mode rebuilds on file change'
+            )
+            ->addOption(
                 'timeout',
                 't',
                 InputOption::VALUE_REQUIRED,
-                'Timeout in seconds',
+                'Timeout in seconds (ignored in watch mode)',
                 $this->timeout
             )
             ->addOption(
@@ -77,7 +83,8 @@ class CompileAssetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $timeout = (float)$input->getOption('timeout');
+        $watch = $input->getOption('watch');
+        $timeout = $watch ? null : (float)$input->getOption('timeout');
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
         $frontendConfigsName = $input->getOption('frontend-configs-name');
@@ -88,6 +95,10 @@ class CompileAssetsCommand extends Command
         $encoreEnv = $env === 'prod' ? 'prod' : 'dev';
         $yarnBaseEncoreCommand = "yarn encore {$encoreEnv}";
         $yarnEncoreCommand = $yarnBaseEncoreCommand;
+
+        if ($watch) {
+            $yarnEncoreCommand = "{$yarnBaseEncoreCommand} --watch";
+        }
 
         if (!empty($configName)) {
             $yarnEncoreCommand = "{$yarnBaseEncoreCommand} --config-name {$configName}";


### PR DESCRIPTION
| :ticket: Issue | IBX-10558 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Allow to have `yarn encore dev --watch` feature without changing habitual command.

`php bin/console ibexa:encore:compile --watch` runs until killed, it watches the assets, and rebuilds them on change.

About errors:
* `php bin/console ibexa:encore:compile --watch --timeout 123` throws error `Watch mode can't be used with a timeout.` 
* `php bin/console ibexa:encore:compile --timeout` still throws error `The "--timeout" option requires a value.`
* `php bin/console ibexa:encore:compile --timeout abc` still throws error `Timeout value has to be an integer.`

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
