### PR TITLE
Added extension point to resolve preview URL

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,12 +199,6 @@ parameters:
 			path: src/bundle/Controller/ContentController.php
 
 		-
-			message: '#^Parameter \#1 \$location of method Ibexa\\AdminUi\\Siteaccess\\SiteaccessResolverInterface\:\:getSiteAccessesListForLocation\(\) expects Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/bundle/Controller/ContentController.php
-
-		-
 			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -423,7 +423,7 @@ class ContentController extends Controller
             $preselectedSiteAccessName = reset($siteAccessesList);
         }
 
-        $versionInfo = $this->contentService->loadVersionInfo($content->contentInfo, $versionNo);
+        $versionInfo = $this->contentService->loadVersionInfo($content->getContentInfo(), $versionNo);
         $language = $this->languageService->loadLanguage($languageCode);
 
         $previewUrl = $this->previewUrlResolver->resolveUrl(

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -26,6 +26,7 @@ imports:
     - { resource: services/user_settings.yaml }
     - { resource: services/rest.yaml }
     - { resource: services/permissions.yaml }
+    - { resource: services/preview.yaml }
     - { resource: services/forms.yaml }
     - { resource: services/strategies.yaml }
     - { resource: services/query_types.yaml }

--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -424,4 +424,9 @@ services:
             $siteAccessResolver: '@Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver'
             $siteAccessNameGenerator: '@Ibexa\AdminUi\Siteaccess\SiteAccessNameGenerator'
 
+    Ibexa\AdminUi\Form\Type\Preview\VersionPreviewUrlChoiceType:
+        arguments:
+            $siteAccessResolver: '@Ibexa\AdminUi\Siteaccess\NonAdminSiteaccessResolver'
+            $siteAccessNameGenerator: '@Ibexa\AdminUi\Siteaccess\SiteAccessNameGenerator'
+
     Ibexa\AdminUi\Form\Type\LanguageSwitchType: ~

--- a/src/bundle/Resources/config/services/preview.yaml
+++ b/src/bundle/Resources/config/services/preview.yaml
@@ -8,5 +8,3 @@ services:
         alias: Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver
 
     Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver: ~
-
-

--- a/src/bundle/Resources/config/services/preview.yaml
+++ b/src/bundle/Resources/config/services/preview.yaml
@@ -1,0 +1,12 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Contracts\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolverInterface:
+        alias: Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver
+
+    Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver: ~
+
+

--- a/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
@@ -65,9 +65,7 @@
     {% block content %}
         <div class="ibexa-preview">
             <div class="ibexa-preview__iframe ibexa-preview__iframe--desktop">
-                <iframe src="{{ url('ibexa.version.preview', {
-                    'contentId': content.id, 'versionNo': version_no, 'language': language_code, 'siteAccessName': preselected_site_access
-                }) }}" frameborder="0"></iframe>
+                <iframe src="{{ preview_url }}" frameborder="0"></iframe>
             </div>
         </div>
     {% endblock %}

--- a/src/contracts/Event/ResolveVersionPreviewUrlEvent.php
+++ b/src/contracts/Event/ResolveVersionPreviewUrlEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\Event;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ResolveVersionPreviewUrlEvent extends Event
+{
+    private VersionInfo $versionInfo;
+
+    private Language $language;
+
+    private Location $location;
+
+    private SiteAccess $siteAccess;
+
+    private ?string $previewUrl = null;
+
+    public function __construct(
+        VersionInfo $versionInfo,
+        Language $language,
+        Location $location,
+        SiteAccess $siteAccess
+    ) {
+        $this->versionInfo = $versionInfo;
+        $this->language = $language;
+        $this->location = $location;
+        $this->siteAccess = $siteAccess;
+    }
+
+    public function getVersionInfo(): VersionInfo
+    {
+        return $this->versionInfo;
+    }
+
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+
+    public function getLocation(): Location
+    {
+        return $this->location;
+    }
+
+    public function getSiteAccess(): SiteAccess
+    {
+        return $this->siteAccess;
+    }
+
+    public function getPreviewUrl(): ?string
+    {
+        return $this->previewUrl;
+    }
+
+    public function setPreviewUrl(?string $previewUrl): void
+    {
+        $this->previewUrl = $previewUrl;
+    }
+}

--- a/src/contracts/Exception/UnresolvedPreviewUrlException.php
+++ b/src/contracts/Exception/UnresolvedPreviewUrlException.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\Exception;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use RuntimeException;
+
+final class UnresolvedPreviewUrlException extends RuntimeException implements RepositoryException
+{
+}

--- a/src/contracts/PreviewUrlResolver/VersionPreviewUrlResolverInterface.php
+++ b/src/contracts/PreviewUrlResolver/VersionPreviewUrlResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\PreviewUrlResolver;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+
+interface VersionPreviewUrlResolverInterface
+{
+    public function resolveUrl(
+        VersionInfo $versionInfo,
+        Location $location,
+        Language $language,
+        SiteAccess $siteAccess
+    ): string;
+}

--- a/src/lib/EventListener/SystemVersionPreviewUrlSubscriber.php
+++ b/src/lib/EventListener/SystemVersionPreviewUrlSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\EventListener;
+
+use Ibexa\Contracts\AdminUi\Event\ResolveVersionPreviewUrlEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SystemVersionPreviewUrlSubscriber implements EventSubscriberInterface
+{
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ResolveVersionPreviewUrlEvent::class => ['onResolveVersionPreviewUrl', -100],
+        ];
+    }
+
+    public function onResolveVersionPreviewUrl(ResolveVersionPreviewUrlEvent $event): void
+    {
+        if ($event->getPreviewUrl() !== null) {
+            // Do not override already set preview URL
+            return;
+        }
+
+        $previewUrl = $this->urlGenerator->generate(
+            'ibexa.version.preview',
+            [
+                'contentId' => $event->getVersionInfo()->getContentInfo()->getId(),
+                'versionNo' => $event->getVersionInfo()->getVersionNo(),
+                'language' => $event->getLanguage()->getLanguageCode(),
+                'siteAccessName' => $event->getSiteAccess()->name,
+            ],
+        );
+
+        $event->setPreviewUrl($previewUrl);
+    }
+}

--- a/src/lib/Form/Type/ChoiceList/Loader/SiteAccessPreviewChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/SiteAccessPreviewChoiceLoader.php
@@ -10,6 +10,9 @@ namespace Ibexa\AdminUi\Form\Type\ChoiceList\Loader;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @deprecated Deprecated since 4.6.24/5.0.2 and will be removed in 6.0. Use `\Ibexa\AdminUi\Form\Type\ChoiceList\Loader\VersionPreviewUrlChoiceLoader` instead.
+ */
 final class SiteAccessPreviewChoiceLoader extends BaseChoiceLoader
 {
     private SiteAccessChoiceLoader $siteAccessChoiceLoader;

--- a/src/lib/Form/Type/ChoiceList/Loader/VersionPreviewUrlChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/VersionPreviewUrlChoiceLoader.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Form\Type\ChoiceList\Loader;
+
+use Ibexa\Contracts\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolverInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+
+final class VersionPreviewUrlChoiceLoader extends BaseChoiceLoader
+{
+    private SiteAccessServiceInterface $siteAccessService;
+
+    private VersionPreviewUrlResolverInterface $previewUrlResolver;
+
+    private SiteAccessChoiceLoader $siteAccessChoiceLoader;
+
+    private VersionInfo $versionInfo;
+
+    private Location $location;
+
+    private Language $language;
+
+    public function __construct(
+        SiteAccessServiceInterface $siteAccessService,
+        VersionPreviewUrlResolverInterface $previewUrlResolver,
+        SiteAccessChoiceLoader $siteAccessChoiceLoader,
+        VersionInfo $versionInfo,
+        Location $location,
+        Language $language
+    ) {
+        $this->siteAccessService = $siteAccessService;
+        $this->previewUrlResolver = $previewUrlResolver;
+        $this->siteAccessChoiceLoader = $siteAccessChoiceLoader;
+        $this->versionInfo = $versionInfo;
+        $this->location = $location;
+        $this->language = $language;
+    }
+
+    /**
+     * @return array<string, string> An associative array where keys are site access names and values are preview URLs.
+     */
+    public function getChoiceList(): array
+    {
+        $baseChoiceList = $this->siteAccessChoiceLoader->getChoiceList();
+
+        $choiceList = [];
+        foreach ($baseChoiceList as $siteAccessName => $siteAccessKey) {
+            $choiceList[$siteAccessName] = $this->previewUrlResolver->resolveUrl(
+                $this->versionInfo,
+                $this->location,
+                $this->language,
+                $this->siteAccessService->get($siteAccessKey)
+            );
+        }
+
+        return $choiceList;
+    }
+}

--- a/src/lib/Form/Type/Preview/SiteAccessChoiceType.php
+++ b/src/lib/Form/Type/Preview/SiteAccessChoiceType.php
@@ -22,6 +22,9 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @deprecated Deprecated since 4.6.24/5.0.2 and will be removed in 6.0. Use `\Ibexa\AdminUi\Form\Type\Preview\VersionPreviewUrlChoiceType` instead.
+ */
 final class SiteAccessChoiceType extends AbstractType
 {
     private SiteaccessResolverInterface $siteAccessResolver;

--- a/src/lib/Form/Type/Preview/VersionPreviewUrlChoiceType.php
+++ b/src/lib/Form/Type/Preview/VersionPreviewUrlChoiceType.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Form\Type\Preview;
+
+use Ibexa\AdminUi\Form\Type\ChoiceList\Loader\SiteAccessChoiceLoader;
+use Ibexa\AdminUi\Form\Type\ChoiceList\Loader\VersionPreviewUrlChoiceLoader;
+use Ibexa\AdminUi\Siteaccess\SiteAccessNameGeneratorInterface;
+use Ibexa\AdminUi\Siteaccess\SiteaccessResolverInterface;
+use Ibexa\Contracts\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolverInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This form type provides a choice field for selecting a site access to preview a specific content version.
+ */
+final class VersionPreviewUrlChoiceType extends AbstractType
+{
+    private SiteAccessServiceInterface $siteAccessService;
+
+    private SiteaccessResolverInterface $siteAccessResolver;
+
+    private SiteAccessNameGeneratorInterface $siteAccessNameGenerator;
+
+    private VersionPreviewUrlResolverInterface $previewUrlResolver;
+
+    public function __construct(
+        SiteAccessServiceInterface $siteAccessService,
+        SiteaccessResolverInterface $siteAccessResolver,
+        SiteAccessNameGeneratorInterface $siteAccessNameGenerator,
+        VersionPreviewUrlResolverInterface $previewUrlResolver
+    ) {
+        $this->siteAccessService = $siteAccessService;
+        $this->siteAccessResolver = $siteAccessResolver;
+        $this->siteAccessNameGenerator = $siteAccessNameGenerator;
+        $this->previewUrlResolver = $previewUrlResolver;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->define('version_info')->allowedTypes(VersionInfo::class)->required();
+        $resolver->define('location')->allowedTypes(Location::class)->required();
+        $resolver->define('language')->allowedTypes(Language::class)->required();
+
+        $resolver->setDefaults([
+            'choice_loader' => function (Options $options): ChoiceLoaderInterface {
+                /** @var \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo */
+                $versionInfo = $options['version_info'];
+                /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
+                $location = $options['location'];
+                /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language $language */
+                $language = $options['language'];
+
+                return ChoiceList::loader(
+                    $this,
+                    new VersionPreviewUrlChoiceLoader(
+                        $this->siteAccessService,
+                        $this->previewUrlResolver,
+                        new SiteAccessChoiceLoader(
+                            $this->siteAccessResolver,
+                            $this->siteAccessNameGenerator,
+                            $location,
+                            $language->getLanguageCode(),
+                        ),
+                        $versionInfo,
+                        $location,
+                        $language
+                    ),
+                    [
+                        $versionInfo->getContentInfo()->getId(),
+                        $versionInfo->getVersionNo(),
+                        $location->getId(),
+                        $language->getLanguageCode(),
+                    ]
+                );
+            },
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/lib/Form/Type/Preview/VersionPreviewUrlChoiceType.php
+++ b/src/lib/Form/Type/Preview/VersionPreviewUrlChoiceType.php
@@ -26,6 +26,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This form type provides a choice field for selecting a site access to preview a specific content version.
+ *
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<string>
  */
 final class VersionPreviewUrlChoiceType extends AbstractType
 {

--- a/src/lib/PreviewUrlResolver/VersionPreviewUrlResolver.php
+++ b/src/lib/PreviewUrlResolver/VersionPreviewUrlResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\PreviewUrlResolver;
+
+use Ibexa\Contracts\AdminUi\Event\ResolveVersionPreviewUrlEvent;
+use Ibexa\Contracts\AdminUi\Exception\UnresolvedPreviewUrlException;
+use Ibexa\Contracts\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolverInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class VersionPreviewUrlResolver implements VersionPreviewUrlResolverInterface
+{
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function resolveUrl(
+        VersionInfo $versionInfo,
+        Location $location,
+        Language $language,
+        SiteAccess $siteAccess
+    ): string {
+        $event = $this->eventDispatcher->dispatch(
+            new ResolveVersionPreviewUrlEvent(
+                $versionInfo,
+                $language,
+                $location,
+                $siteAccess
+            )
+        );
+
+        $previewUrl = $event->getPreviewUrl();
+        if ($previewUrl === null) {
+            throw new UnresolvedPreviewUrlException(
+                sprintf(
+                    'Preview URL for content id = %d and version no = %d could not be resolved.',
+                    $versionInfo->getContentInfo()->getId(),
+                    $versionInfo->getVersionNo()
+                )
+            );
+        }
+
+        return $previewUrl;
+    }
+}

--- a/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
+++ b/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Tests\AdminUi\EventListener;

--- a/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
+++ b/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\EventListener;
+
+use Ibexa\AdminUi\EventListener\SystemVersionPreviewUrlSubscriber;
+use Ibexa\Contracts\AdminUi\Event\ResolveVersionPreviewUrlEvent;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SystemVersionPreviewUrlSubscriberTest extends TestCase
+{
+    private const EXAMPLE_PREVIEW_URL = '/example';
+    private const EXAMPLE_CONTENT_ID = 99;
+    private const EXAMPLE_VERSION_NO = 42;
+    private const EXAMPLE_LANGUAGE_CODE = 'eng-EN';
+    private const EXAMPLE_SITE_ACCESS = 'example_site_access';
+
+    public function testGetSubscribedEvents(): void
+    {
+        self::assertEquals(
+            [
+                ResolveVersionPreviewUrlEvent::class,
+            ],
+            array_keys(SystemVersionPreviewUrlSubscriber::getSubscribedEvents())
+        );
+    }
+
+    public function testOnSystemVersionPreviewIsSkippedIfUrlHasBeenResolved(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+        $event = new ResolveVersionPreviewUrlEvent(
+            $this->createMock(VersionInfo::class),
+            $this->createMock(Language::class),
+            $this->createMock(Location::class),
+            $this->createMock(SiteAccess::class)
+        );
+        $event->setPreviewUrl(self::EXAMPLE_PREVIEW_URL);
+
+        $subscriber = new SystemVersionPreviewUrlSubscriber($urlGenerator);
+        $subscriber->onResolveVersionPreviewUrl($event);
+
+        self::assertEquals(self::EXAMPLE_PREVIEW_URL, $event->getPreviewUrl());
+    }
+
+    public function testOnSystemVersionPreview(): void
+    {
+        $contentInfo = $this->createMock(ContentInfo::class);
+        $contentInfo->method('getId')->willReturn(self::EXAMPLE_CONTENT_ID);
+
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $versionInfo->method('getVersionNo')->willReturn(self::EXAMPLE_VERSION_NO);
+        $versionInfo->method('getContentInfo')->willReturn($contentInfo);
+
+        $language = $this->createMock(Language::class);
+        $language->method('getLanguageCode')->willReturn(self::EXAMPLE_LANGUAGE_CODE);
+
+        $siteAccess = $this->createMock(SiteAccess::class);
+        $siteAccess->name = self::EXAMPLE_SITE_ACCESS;
+
+        $event = new ResolveVersionPreviewUrlEvent(
+            $versionInfo,
+            $language,
+            $this->createMock(Location::class),
+            $siteAccess
+        );
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->method('generate')
+            ->with(
+                'ibexa.version.preview',
+                [
+                    'contentId' => self::EXAMPLE_CONTENT_ID,
+                    'versionNo' => self::EXAMPLE_VERSION_NO,
+                    'language' => self::EXAMPLE_LANGUAGE_CODE,
+                    'siteAccessName' => self::EXAMPLE_SITE_ACCESS,
+                ]
+            )
+            ->willReturn(self::EXAMPLE_PREVIEW_URL);
+
+        $subscriber = new SystemVersionPreviewUrlSubscriber($urlGenerator);
+        $subscriber->onResolveVersionPreviewUrl($event);
+
+        self::assertEquals(self::EXAMPLE_PREVIEW_URL, $event->getPreviewUrl());
+    }
+}

--- a/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
+++ b/tests/lib/EventListener/SystemVersionPreviewUrlSubscriberTest.php
@@ -18,6 +18,9 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @covers \Ibexa\AdminUi\EventListener\SystemVersionPreviewUrlSubscriber
+ */
 final class SystemVersionPreviewUrlSubscriberTest extends TestCase
 {
     private const EXAMPLE_PREVIEW_URL = '/example';

--- a/tests/lib/PreviewUrlResolver/VersionPreviewUrlResolverTest.php
+++ b/tests/lib/PreviewUrlResolver/VersionPreviewUrlResolverTest.php
@@ -19,11 +19,14 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @covers \Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver
+ */
 final class VersionPreviewUrlResolverTest extends TestCase
 {
     private const EXAMPLE_PREVIEW_URL = 'https://example.org/preview/url';
-    public const EXAMPLE_CONTNET_ID = 42;
-    public const EXAMPLE_VERSION_NO = 7;
+    private const EXAMPLE_CONTENT_ID = 42;
+    private const EXAMPLE_VERSION_NO = 7;
 
     public function testResolvesPreviewUrlSuccessfully(): void
     {
@@ -42,7 +45,7 @@ final class VersionPreviewUrlResolverTest extends TestCase
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher->method('dispatch')
             ->with($event)
-            ->willReturnCallback(static function (ResolveVersionPreviewUrlEvent $event) {
+            ->willReturnCallback(static function (ResolveVersionPreviewUrlEvent $event): ResolveVersionPreviewUrlEvent {
                 // Set preview URL as if an event listener did it
                 $event->setPreviewUrl(self::EXAMPLE_PREVIEW_URL);
 
@@ -63,7 +66,7 @@ final class VersionPreviewUrlResolverTest extends TestCase
         $siteAccess = $this->createMock(SiteAccess::class);
 
         $contentInfo = $this->createMock(ContentInfo::class);
-        $contentInfo->method('getId')->willReturn(self::EXAMPLE_CONTNET_ID);
+        $contentInfo->method('getId')->willReturn(self::EXAMPLE_CONTENT_ID);
 
         $versionInfo->method('getContentInfo')->willReturn($contentInfo);
         $versionInfo->method('getVersionNo')->willReturn(self::EXAMPLE_VERSION_NO);
@@ -81,7 +84,9 @@ final class VersionPreviewUrlResolverTest extends TestCase
         $resolver = new VersionPreviewUrlResolver($eventDispatcher);
 
         $this->expectException(UnresolvedPreviewUrlException::class);
-        $this->expectExceptionMessage('Preview URL for content id = 42 and version no = 7 could not be resolved.');
+        $this->expectExceptionMessage(
+            'Preview URL for content id = 42 and version no = 7 could not be resolved.'
+        );
 
         $resolver->resolveUrl($versionInfo, $location, $language, $siteAccess);
     }

--- a/tests/lib/PreviewUrlResolver/VersionPreviewUrlResolverTest.php
+++ b/tests/lib/PreviewUrlResolver/VersionPreviewUrlResolverTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\PreviewUrlResolver;
+
+use Ibexa\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolver;
+use Ibexa\Contracts\AdminUi\Event\ResolveVersionPreviewUrlEvent;
+use Ibexa\Contracts\AdminUi\Exception\UnresolvedPreviewUrlException;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class VersionPreviewUrlResolverTest extends TestCase
+{
+    private const EXAMPLE_PREVIEW_URL = 'https://example.org/preview/url';
+    public const EXAMPLE_CONTNET_ID = 42;
+    public const EXAMPLE_VERSION_NO = 7;
+
+    public function testResolvesPreviewUrlSuccessfully(): void
+    {
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $location = $this->createMock(Location::class);
+        $language = $this->createMock(Language::class);
+        $siteAccess = $this->createMock(SiteAccess::class);
+
+        $event = new ResolveVersionPreviewUrlEvent(
+            $versionInfo,
+            $language,
+            $location,
+            $siteAccess
+        );
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->with($event)
+            ->willReturnCallback(static function (ResolveVersionPreviewUrlEvent $event) {
+                // Set preview URL as if an event listener did it
+                $event->setPreviewUrl(self::EXAMPLE_PREVIEW_URL);
+
+                return $event;
+            });
+
+        $resolver = new VersionPreviewUrlResolver($eventDispatcher);
+        $result = $resolver->resolveUrl($versionInfo, $location, $language, $siteAccess);
+
+        $this->assertSame(self::EXAMPLE_PREVIEW_URL, $result);
+    }
+
+    public function testThrowsExceptionWhenPreviewUrlIsNotResolved(): void
+    {
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $location = $this->createMock(Location::class);
+        $language = $this->createMock(Language::class);
+        $siteAccess = $this->createMock(SiteAccess::class);
+
+        $contentInfo = $this->createMock(ContentInfo::class);
+        $contentInfo->method('getId')->willReturn(self::EXAMPLE_CONTNET_ID);
+
+        $versionInfo->method('getContentInfo')->willReturn($contentInfo);
+        $versionInfo->method('getVersionNo')->willReturn(self::EXAMPLE_VERSION_NO);
+
+        $event = new ResolveVersionPreviewUrlEvent(
+            $versionInfo,
+            $language,
+            $location,
+            $siteAccess
+        );
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')->willReturn($event);
+
+        $resolver = new VersionPreviewUrlResolver($eventDispatcher);
+
+        $this->expectException(UnresolvedPreviewUrlException::class);
+        $this->expectExceptionMessage('Preview URL for content id = 42 and version no = 7 could not be resolved.');
+
+        $resolver->resolveUrl($versionInfo, $location, $language, $siteAccess);
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Introduced `Ibexa\Contracts\AdminUi\PreviewUrlResolver\VersionPreviewUrlResolverInterface` which is responsible for determine preview URL of given content version (inc. content drafts).
 

```php
interface VersionPreviewUrlResolverInterface
{
    public function resolveUrl(
        VersionInfo $versionInfo,
        Location $location,
        Language $language,
        SiteAccess $siteAccess
    ): string;
}
```

Resolver also dispatches `\Ibexa\Contracts\AdminUi\Event\ResolveVersionPreviewUrlEvent` event allowing to custom preview URL generation from 3rd party extensions. Use cases:

* Added pre-auth token for generating public link
* Delegate preview rendering to 3rd party service e.g. Single Page Application 
 
 
#### For QA:
N/A

#### Documentation:
New service and extension point. 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
