### PR TITLE
Fixed docblock in MultipleSelectionBasedMapper

### DIFF
--- a/src/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
+++ b/src/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
@@ -40,7 +40,7 @@ abstract class MultipleSelectionBasedMapper implements LimitationFormMapperInter
     /**
      * Returns value choices to display, as expected by the "choices" option from Choice field.
      *
-     * @return array<int, string>
+     * @return array<array-key, int|string>
      */
     abstract protected function getSelectionChoices(): array;
 


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
As we have in the order-management package return type hint as `array<string, string>` here and in the personalization `array<int, int|string>`, the proposition is `array<array-key, int|string>`

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
