### PR TITLE
IBX-10617: Allowed nullable field type identifier within `ModifyFieldDefinitionsCollectionTypeExtension`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5065,12 +5065,6 @@ parameters:
 			path: tests/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriberTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\AdminUi\\Form\\Type\\Extension\\EventSubscriber\\ModifyFieldDefinitionFieldsSubscriberTest\:\:getFormData\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriberTest.php
-
-		-
 			message: '#^Parameter \#1 \$options of method Ibexa\\Tests\\AdminUi\\Form\\Type\\Extension\\EventSubscriber\\ModifyFieldDefinitionFieldsSubscriberTest\:\:mockFormBuilderGetOptions\(\) expects array\<string, bool\|float\|int\|string\>, array\<string, string\|true\|null\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriber.php
+++ b/src/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriber.php
@@ -27,9 +27,9 @@ final readonly class ModifyFieldDefinitionFieldsSubscriber implements EventSubsc
      * @param array<string> $fieldIdentifiers
      */
     public function __construct(
-        private string $fieldTypeIdentifier,
         private array $modifiedOptions,
         private array $fieldIdentifiers = [],
+        private ?string $fieldTypeIdentifier = null,
         private ?SpecificationInterface $contentTypeSpecification = null
     ) {
     }

--- a/src/lib/Form/Type/Extension/ModifyFieldDefinitionsCollectionTypeExtension.php
+++ b/src/lib/Form/Type/Extension/ModifyFieldDefinitionsCollectionTypeExtension.php
@@ -26,19 +26,19 @@ final class ModifyFieldDefinitionsCollectionTypeExtension extends AbstractTypeEx
      * @param array<string> $fieldIdentifiers
      */
     public function __construct(
-        private readonly string $fieldTypeIdentifier,
         private readonly array $modifiedOptions,
-        private array $fieldIdentifiers = [],
-        private ?SpecificationInterface $contentTypeSpecification = null
+        private readonly array $fieldIdentifiers = [],
+        private readonly ?string $fieldTypeIdentifier = null,
+        private readonly ?SpecificationInterface $contentTypeSpecification = null
     ) {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $subscriber = new ModifyFieldDefinitionFieldsSubscriber(
-            $this->fieldTypeIdentifier,
             $this->modifiedOptions,
             $this->fieldIdentifiers,
+            $this->fieldTypeIdentifier,
             $this->contentTypeSpecification
         );
 

--- a/tests/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriberTest.php
+++ b/tests/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriberTest.php
@@ -24,8 +24,8 @@ use Symfony\Component\Form\FormInterface;
  */
 final class ModifyFieldDefinitionFieldsSubscriberTest extends TestCase
 {
-    private const FIELD_TYPE_IDENTIFIER = 'foo';
-    private const MODIFIED_OPTIONS = [
+    private const string FIELD_TYPE_IDENTIFIER = 'foo';
+    private const array MODIFIED_OPTIONS = [
         'disable_identifier_field' => true,
         'disable_required_field' => true,
         'disable_translatable_field' => true,
@@ -44,8 +44,9 @@ final class ModifyFieldDefinitionFieldsSubscriberTest extends TestCase
         $this->form = $this->createMock(FormInterface::class);
         $this->formBuilder = $this->createMock(FormBuilderInterface::class);
         $this->modifyFieldDefinitionFieldsSubscriber = new ModifyFieldDefinitionFieldsSubscriber(
-            self::FIELD_TYPE_IDENTIFIER,
-            self::MODIFIED_OPTIONS
+            self::MODIFIED_OPTIONS,
+            [],
+            self::FIELD_TYPE_IDENTIFIER
         );
     }
 
@@ -78,6 +79,9 @@ final class ModifyFieldDefinitionFieldsSubscriberTest extends TestCase
         $this->modifyFieldDefinitionFieldsSubscriber->onPostSetData($event);
     }
 
+    /**
+     * @return array<string, \Ibexa\AdminUi\Form\Data\FieldDefinitionData>
+     */
     private function getFormData(string $identifier): array
     {
         $contentTypeDraftMock = $this->createMock(ContentTypeDraft::class);


### PR DESCRIPTION
| :ticket: Issue | IBX-10617 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
