### PR TITLE
IBX-10375 - Fix problematic validator names

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -32,7 +32,7 @@
     const fields = doc.querySelectorAll('.ibexa-field-edit');
     const getValidationResults = (validator) => {
         const isValid = validator.isValid();
-        const validatorName = validator.constructor.name;
+        const validatorName = validator.getValidatorName();
         const result = { isValid, validatorName };
 
         return result;

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-field.js
@@ -13,6 +13,10 @@
             return this.fieldContainer ? this.fieldContainer : fallback;
         }
 
+        getValidatorName() {
+            return 'BaseFieldValidator';
+        }
+
         /**
          * Attaches event to elements found with a selector provided by field config
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/multi-input-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/multi-input-field.js
@@ -6,6 +6,10 @@
             this.containerSelectors = containerSelectors;
         }
 
+        getValidatorName() {
+            return 'MultiInputFieldValidator';
+        }
+
         toggleInvalidState(isError, config, input) {
             super.toggleInvalidState(isError, config, input);
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezboolean.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezboolean.js
@@ -3,6 +3,10 @@
     const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzBooleanValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzBooleanValidator';
+        }
+
         /**
          * Validates the input field value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezcountry.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezcountry.js
@@ -5,6 +5,10 @@
     const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzCountryValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzCountryValidator';
+        }
+
         /**
          * Validates the country field value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -6,6 +6,10 @@
     const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzDateValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzDateValidator';
+        }
+
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -7,6 +7,10 @@
     const { convertDateToTimezone } = ibexa.helpers.timezone;
 
     class EzDateTimeValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzDateTimeValidator';
+        }
+
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezemail.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezemail.js
@@ -3,6 +3,9 @@
     const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzEmailValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzEmailValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezfloat.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezfloat.js
@@ -3,6 +3,9 @@
     const SELECTOR_ERROR_NODE = `${SELECTOR_FIELD} .ibexa-form-error`;
 
     class EzFloatValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzFloatValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -20,6 +20,9 @@
     const maps = [];
 
     class EzGMapLocationValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzGMapLocationValidator';
+        }
         /**
          * Validates latitude/longitude input value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezinteger.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezinteger.js
@@ -3,6 +3,9 @@
     const SELECTOR_ERROR_NODE = `${SELECTOR_FIELD} .ibexa-form-error`;
 
     class EzIntegerValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzIntegerValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezkeyword.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezkeyword.js
@@ -5,6 +5,9 @@
     const SELECTOR_ERROR_NODE = '.ibexa-form-error';
 
     class EzKeywordValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzKeywordValidator';
+        }
         /**
          * Validates the keywords input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
@@ -11,6 +11,9 @@
     const EVENT_CUSTOM = 'validateInput';
 
     class EzObjectRelationListValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzObjectRelationListValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezselection.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezselection.js
@@ -5,6 +5,9 @@
     const EVENT_VALUE_CHANGED = 'change';
 
     class EzSelectionValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzSelectionValidator';
+        }
         /**
          * Validates the textarea field value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezstring.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezstring.js
@@ -3,6 +3,9 @@
     const SELECTOR_SOURCE_INPUT = '.ibexa-data-source__input';
 
     class EzStringValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzStringValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/eztext.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztext.js
@@ -2,6 +2,9 @@
     const SELECTOR_FIELD = '.ibexa-field-edit--eztext';
 
     class EzTextValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzTextValidator';
+        }
         /**
          * Validates the textarea field value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
@@ -6,6 +6,9 @@
     const EVENT_VALUE_CHANGED = 'change';
 
     class EzTimeValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzTimeValidator';
+        }
         /**
          * Validates the input
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
@@ -6,6 +6,10 @@
     const SELECTOR_ERROR_NODE = '.ibexa-data-source__field--link .ibexa-form-error';
 
     class EzUrlValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzUrlValidator';
+        }
+        
         validateUrl(event) {
             const result = {
                 isError: false,

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezuser.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezuser.js
@@ -10,6 +10,9 @@
     const SELECTOR_ERROR_WRAPPER = '.ibexa-form-error';
 
     class EzUserValidator extends ibexa.BaseFieldValidator {
+        getValidatorName() {
+            return 'EzUserValidator';
+        }
         /**
          * Validates the input field value
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/validator/richtext-validator.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/validator/richtext-validator.js
@@ -11,6 +11,10 @@ class RichTextValidator extends ibexa.BaseFieldValidator {
         this.labelSelector = labelSelector;
     }
 
+    getValidatorName() {
+        return 'RichTextValidator';
+    }
+
     /**
      * Validates the input
      *


### PR DESCRIPTION
> Supersedes https://github.com/ibexa/admin-ui/pull/1655 targeting v4.6 instead of v5
| :ticket: Issue | IBX-10375 |
|----------------|-----------|

# What
This PR intruduces a new method to eZ validators called "getValidatorName" which returns a reliable stable refernce to the name of the given validator. This PR also updates to references where the validator names are pulled.

# Why
In _production_ mode only references to the `validator.constructor.name` are mangled into random letters.

<img width="828" height="281" alt="image" src="https://github.com/user-attachments/assets/d95b6e8f-e6b7-4d83-aab7-e39b15e21172" />

In eZ 3.3 decisions about what errors to show in the page builder are predicated on the field-set these validator names rely on.

# How
By moving to a hard coded string the minified JS does not effect the names of validators as given.
