### PR TITLE
[CI] Fixed new phpstan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -583,12 +583,6 @@ parameters:
 			path: src/bundle/Controller/LinkManagerController.php
 
 		-
-			message: '#^Cannot access offset 0 on iterable\<int, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Relation\>\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/bundle/Controller/LocationController.php
-
-		-
 			message: '#^Cannot access property \$contentId on Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\|null\.$#'
 			identifier: property.nonObject
 			count: 3
@@ -13153,12 +13147,6 @@ parameters:
 			path: src/lib/UI/Dataset/VersionsDataset.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_map expects array, iterable\<int, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\VersionInfo\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/UI/Dataset/VersionsDataset.php
-
-		-
 			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -13425,6 +13413,12 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$versionInfo of class Ibexa\\AdminUi\\UI\\Value\\Content\\ContentDraft constructor expects Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\VersionInfo, Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\VersionInfo\|null given\.$#'
 			identifier: argument.type
+			count: 1
+			path: src/lib/UI/Value/ValueFactory.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/lib/UI/Value/ValueFactory.php
 

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -210,7 +210,14 @@ class LocationController extends Controller
                     $locationCreateStruct
                 );
 
-                $newLocation = $this->locationService->loadLocation($copiedContent->contentInfo->mainLocationId);
+                $mainLocationId = $copiedContent->getContentInfo()->getMainLocationId();
+                if ($mainLocationId === null) {
+                    throw new InvalidArgumentException(
+                        'mainLocationId',
+                        'Copied content does not have a main location'
+                    );
+                }
+                $newLocation = $this->locationService->loadLocation($mainLocationId);
 
                 $this->notificationHandler->success(
                     /** @Desc("'%name%' copied to '%location%'") */

--- a/src/lib/EventListener/ViewTemplatesListener.php
+++ b/src/lib/EventListener/ViewTemplatesListener.php
@@ -52,7 +52,7 @@ class ViewTemplatesListener implements EventSubscriberInterface
     }
 
     /**
-     * @return string[]
+     * @return array<class-string, string>
      */
     private function getTemplatesMap(): array
     {

--- a/tests/bundle/DependencyInjection/Configuration/Parser/SubtreeOperationsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/SubtreeOperationsTest.php
@@ -23,7 +23,7 @@ final class SubtreeOperationsTest extends TestCase
     private ContextualizerInterface $contextualizer;
 
     /**
-     * @return array<string, array{int}>
+     * @return iterable<string, array{int}>
      */
     public function getExpectedCopySubtreeLimit(): iterable
     {


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
https://github.com/ibexa/admin-ui/compare/4.6...fix-phpstan?expand=1#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaR13420

That one was added to the baseline as the issue comes from `\Ibexa\Contracts\Core\Repository\Values\Content\Relation::$sourceFieldDefinitionIdentifier`
where our glorious VO claimes that this can be only string in phpdoc, but we all know that it can be null as well when unitialized.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
