### PR TITLE
Fixes for PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13417,12 +13417,6 @@ parameters:
 			path: src/lib/UI/Value/ValueFactory.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/lib/UI/Value/ValueFactory.php
-
-		-
 			message: '#^Method Ibexa\\AdminUi\\UniversalDiscovery\\ConfigResolver\:\:getConfig\(\) has parameter \$context with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriber.php
+++ b/src/lib/Form/Type/Extension/EventSubscriber/ModifyFieldDefinitionFieldsSubscriber.php
@@ -101,8 +101,8 @@ final class ModifyFieldDefinitionFieldsSubscriber implements EventSubscriberInte
     private function getContentTypeDraft(array $data): ?ContentTypeDraft
     {
         $firstField = reset($data);
-        if ($firstField instanceof FieldDefinitionData && isset($firstField->contentTypeData)) {
-            return $firstField->contentTypeData->contentTypeDraft ?? null;
+        if ($firstField instanceof FieldDefinitionData) {
+            return $firstField->contentTypeData->contentTypeDraft;
         }
 
         return null;


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
PHPStan complains because `$contentTypeData` is declared as a non-nullable property of FieldDefinitionData.
That means it will always exist, so isset() is redundant. `$contentTypeDraft` is also declared as non-nullable in ContentTypeData.
Using `?? null` suggests it might be `null`, which conflicts with the type declaration.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
