### PR TITLE
IBX-11127: Datepicker is always in english despite BO language change

### DIFF
--- a/src/bundle/Resources/encore/ibexa.js.config.js
+++ b/src/bundle/Resources/encore/ibexa.js.config.js
@@ -59,7 +59,6 @@ const layout = [
     path.resolve(__dirname, '../public/js/scripts/admin.middle.ellipsis.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.form.error.js'),
     path.resolve(__dirname, '../public/js/scripts/embedded.item.actions'),
-    path.resolve(__dirname, '../public/js/scripts/widgets/flatpickr.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.form.tabs.validation.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.search.autocomplete.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.search.autocomplete.content.js'),
@@ -261,5 +260,6 @@ module.exports = (Encore) => {
             path.resolve(__dirname, '../public/js/scripts/admin.notifications.filters.sidebar.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.notifications.list.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.notifications.filters.js'),
-        ]);
+        ])
+        .addEntry('ibexa-admin-ui-flatpickr-js', path.resolve(__dirname, '../public/js/scripts/widgets/flatpickr.js'),);
 };

--- a/src/bundle/Resources/encore/ibexa.js.config.js
+++ b/src/bundle/Resources/encore/ibexa.js.config.js
@@ -261,5 +261,5 @@ module.exports = (Encore) => {
             path.resolve(__dirname, '../public/js/scripts/admin.notifications.list.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.notifications.filters.js'),
         ])
-        .addEntry('ibexa-admin-ui-flatpickr-js', path.resolve(__dirname, '../public/js/scripts/widgets/flatpickr.js'),);
+        .addEntry('ibexa-admin-ui-flatpickr-js', path.resolve(__dirname, '../public/js/scripts/widgets/flatpickr.js'));
 };

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -237,6 +237,7 @@
         </div>
         {{ ibexa_twig_component_group('admin-ui-layout-content-after') }}
 
+        {{ encore_entry_script_tags('ibexa-admin-ui-flatpickr-js', null, 'ibexa') }}
         {{ encore_entry_script_tags('ibexa-admin-ui-layout-js', null, 'ibexa') }}
         {{ encore_entry_script_tags('ibexa-admin-ui-udw-tabs-js', null, 'ibexa') }}
         {{ encore_entry_script_tags('ibexa-admin-ui-udw-extras-js', null, 'ibexa') }}


### PR DESCRIPTION
| :ticket: Issue | IBX-11127 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Flatpickr translation script was being included too late in the chain so I have moved it before the layout-js.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
