### PR TITLE
fix: BaseRichText.getData() null safety

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/validator/richtext-validator.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/validator/richtext-validator.js
@@ -24,6 +24,11 @@ class RichTextValidator extends ibexa.BaseFieldValidator {
         const fieldContainer = event.currentTarget.closest(this.selectorField);
         const isRequired = fieldContainer.classList.contains('ibexa-field-edit--required');
         const label = fieldContainer.querySelector(this.labelSelector)?.innerHTML;
+
+        if (!this.richtextEditor.editor) {
+            return { isError: false };
+        }
+
         const isEmpty = !this.richtextEditor.getData().length;
         const isError = isRequired && isEmpty;
         const result = { isError };


### PR DESCRIPTION
Added an early return to prevent null reference errors on getData call when editor is not initialized yet

I saw this behaviour:
RichText validators were created before CKEditor instances finished initializing
During publishing validation, this.richtextEditor.getData() failed because this.editor was still null