### PR TITLE
IBX-10289: Fixed image picker when Image type has no 'tags' field

### DIFF
--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -100,9 +100,16 @@ final class DamWidget implements ProviderInterface
     {
         $imageConfig = [
             'showImageFilters' => $this->showImageFilters(),
-            'aggregations' => $this->config['image']['aggregations'],
             'enableMultipleDownload' => extension_loaded('zip'),
         ];
+
+        // The content type may not have the default fields; in that case, don't add the aggregations
+        $imageType = $this->contentTypeService->loadContentTypeByIdentifier('image');
+        foreach ($this->config['image']['aggregations'] as $aggregation) {
+            if ($imageType->hasFieldDefinition($aggregation['fieldDefinitionIdentifier'])) {
+                $imageConfig['aggregations'][] = $aggregation;
+            }
+        }
 
         $mappings = [];
         $contentTypeIdentifiers = [];

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -51,6 +51,8 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
  */
 final class DamWidget implements ProviderInterface
 {
+    private const IMAGE_TYPE_ID = 5;
+
     /** @phpstan-var TConfig */
     private array $config;
 
@@ -104,7 +106,7 @@ final class DamWidget implements ProviderInterface
         ];
 
         // The content type may not have the default fields; in that case, don't add the aggregations
-        $imageType = $this->contentTypeService->loadContentTypeByIdentifier('image');
+        $imageType = $this->contentTypeService->loadContentType(self::IMAGE_TYPE_ID);
         foreach ($this->config['image']['aggregations'] as $aggregation) {
             if ($imageType->hasFieldDefinition($aggregation['fieldDefinitionIdentifier'])) {
                 $imageConfig['aggregations'][] = $aggregation;

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -102,14 +102,15 @@ final class DamWidget implements ProviderInterface
     {
         $imageConfig = [
             'showImageFilters' => $this->showImageFilters(),
+            'aggregations' => [],
             'enableMultipleDownload' => extension_loaded('zip'),
         ];
 
         // The content type may not have the default fields; in that case, don't add the aggregations
         $imageType = $this->contentTypeService->loadContentType(self::IMAGE_TYPE_ID);
-        foreach ($this->config['image']['aggregations'] as $aggregation) {
+        foreach ($this->config['image']['aggregations'] as $key => $aggregation) {
             if ($imageType->hasFieldDefinition($aggregation['fieldDefinitionIdentifier'])) {
-                $imageConfig['aggregations'][] = $aggregation;
+                $imageConfig['aggregations'][$key] = $aggregation;
             }
         }
 

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -52,8 +52,6 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
  */
 final class DamWidget implements ProviderInterface
 {
-    private const IMAGE_TYPE_ID = 5;
-
     /** @phpstan-var TConfig */
     private array $config;
 
@@ -103,9 +101,9 @@ final class DamWidget implements ProviderInterface
     {
         $imageConfig = [
             'showImageFilters' => $this->showImageFilters(),
+            'aggregations' => [],
             'enableMultipleDownload' => extension_loaded('zip'),
         ];
-
 
         // The content type may not have the default fields; in that case, don't add the aggregations
         foreach ($this->config['image']['aggregations'] as $key => $aggregation) {

--- a/src/lib/UI/Config/Provider/Module/DamWidget.php
+++ b/src/lib/UI/Config/Provider/Module/DamWidget.php
@@ -108,7 +108,9 @@ final class DamWidget implements ProviderInterface
         // The content type may not have the default fields; in that case, don't add the aggregations
         foreach ($this->config['image']['aggregations'] as $key => $aggregation) {
             try {
-                $imageType = $this->contentTypeService->loadContentTypeByIdentifier($aggregation['contentTypeIdentifier']);
+                $imageType = $this->contentTypeService->loadContentTypeByIdentifier(
+                    $aggregation['contentTypeIdentifier']
+                );
                 if ($imageType->hasFieldDefinition($aggregation['fieldDefinitionIdentifier'])) {
                     $imageConfig['aggregations'][$key] = $aggregation;
                 }

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -70,8 +70,8 @@ final class DamWidgetTest extends TestCase
     private const IMAGE_AGGREGATIONS = [
         'KeywordTermAggregation' => [
             'name' => 'keywords',
-            'contentTypeIdentifier' => 'keywords',
-            'fieldDefinitionIdentifier' => 'keywords',
+            'contentTypeIdentifier' => self::IMAGE_FOO_CONTENT_TYPE_IDENTIFIER,
+            'fieldDefinitionIdentifier' => 'tags',
         ],
     ];
 
@@ -168,9 +168,14 @@ final class DamWidgetTest extends TestCase
      */
     public function provideDataForTestGetConfig(): iterable
     {
+        $imageContentType = $this->createContentTypeMock(self::IMAGE_FOO_NAME_SCHEMA);
+        $imageContentType->expects(self::atLeastOnce())
+            ->method('hasFieldDefinition')
+            ->willReturn(true);
+
         $loadContentTypeValueMap = [
             [self::FOLDER_CONTENT_TYPE_IDENTIFIER, [], $this->createContentTypeMock(self::FOLDER_NAME_SCHEMA)],
-            [self::IMAGE_FOO_CONTENT_TYPE_IDENTIFIER, [], $this->createContentTypeMock(self::IMAGE_FOO_NAME_SCHEMA)],
+            [self::IMAGE_FOO_CONTENT_TYPE_IDENTIFIER, [], $imageContentType],
             [self::IMAGE_BAR_CONTENT_TYPE_IDENTIFIER, [], $this->createContentTypeMock(self::IMAGE_BAR_NAME_SCHEMA)],
         ];
 
@@ -204,6 +209,9 @@ final class DamWidgetTest extends TestCase
         ];
     }
 
+    /**
+     * @phpstan-return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType & \PHPUnit\Framework\MockObject\MockObject
+     */
     private function createContentTypeMock(string $nameSchema): ContentType
     {
         $contentType = $this->createMock(ContentType::class);
@@ -261,16 +269,6 @@ final class DamWidgetTest extends TestCase
         $this->contentTypeService
             ->method('loadContentTypeByIdentifier')
             ->willReturnMap($valueMap);
-    }
-
-    private function mockContentTypeServiceLoadContentType(): void
-    {
-        $contetnType = $this->createMock(ContentType::class);
-        $contetnType->method('hasFieldDefinition')->willReturn(true);
-
-        $this->contentTypeService
-            ->method('loadContentType')
-            ->willReturn($contetnType);
     }
 
     /**

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -137,6 +137,7 @@ final class DamWidgetTest extends TestCase
         $this->mockRepositoryConfigurationProviderGetRepositoryConfig($repositoryConfig);
         $this->mockContentTypeServiceLoadContentTypeByIdentifier($loadContentTypeValueMap);
         $this->mockSchemaIdentifierExtractorExtract($extractSchemaIdentifiersValueMap);
+        $this->mockContentTypeServiceLoadContentType();
 
         self::assertEquals(
             $expectedConfiguration,
@@ -261,6 +262,16 @@ final class DamWidgetTest extends TestCase
         $this->contentTypeService
             ->method('loadContentTypeByIdentifier')
             ->willReturnMap($valueMap);
+    }
+
+    private function mockContentTypeServiceLoadContentType(): void
+    {
+        $contetnType = $this->createMock(ContentType::class);
+        $contetnType->method('hasFieldDefinition')->willReturn(true);
+
+        $this->contentTypeService
+            ->method('loadContentType')
+            ->willReturn($contetnType);
     }
 
     /**

--- a/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
+++ b/tests/lib/UI/Config/Provider/Module/DamWidgetTest.php
@@ -137,7 +137,6 @@ final class DamWidgetTest extends TestCase
         $this->mockRepositoryConfigurationProviderGetRepositoryConfig($repositoryConfig);
         $this->mockContentTypeServiceLoadContentTypeByIdentifier($loadContentTypeValueMap);
         $this->mockSchemaIdentifierExtractorExtract($extractSchemaIdentifiersValueMap);
-        $this->mockContentTypeServiceLoadContentType();
 
         self::assertEquals(
             $expectedConfiguration,


### PR DESCRIPTION
| :ticket: Issue | IBX-10289 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Stop image aggregations from being added when the Image content type has no required field.
 
<!--
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->


<!--
#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
