### PR TITLE
[MERCURE] Add notification handler and update modal title on notifications event

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -317,6 +317,13 @@
         });
     };
 
-    getNotificationsStatusLoop();
+    doc.body.addEventListener('ibexa-notifications:update', (event) => {
+        setPendingNotificationCount(event.detail);
+        updateModalTitleTotalInfo(event.detail.total);
+    });
+
+    if (!doc.querySelector('meta[name="ibexa-notification-handler"]')) {
+        getNotificationsStatusLoop();
+    }
     attachActionsListeners();
 })(window, window.document, window.ibexa, window.Translator, window.Routing);

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -243,6 +243,7 @@
         {% block react_modules %}{% endblock %}
         {% block javascripts %}{% endblock %}
         {{ ibexa_twig_component_group('admin-ui-stylesheet-body') }}
+        {{ ibexa_twig_component_group('admin-ui-notification-handler') }}
         {{ ibexa_twig_component_group('admin-ui-script-body') }}
     </body>
 </html>


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

*   Decoupled Notification Polling: Refactored `admin.notifications.modal.js` to skip the default 30s polling loop if an external notification handler (like Mercure) is detected via a meta tag.
*   Standardized Update Event: Added a global listener for ibexa-notifications:update on document.body. This allows external handlers to push updated pending and total counts directly into the UI.
*   Automatic Refresh: Integrated the new update event with existing internal methods (`setPendingNotificationCount` and `updateModalTitleTotalInfo`) to ensure the notice dot and notification list refresh automatically when an update is pushed.
*   New Twig Component Group: Added the `admin-ui-notification-handler` group to the main layout, providing a clean entry point for other bundles to inject notification-related logic without hacking existing scripts.

This way I could get rid of that ugly hacking with HUGE new interval that was disabling old pooling from outside admin-ui bundle.

#### For QA:
Just check if notifcations are working as always.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
