### PR TITLE
Fixed rendering tab menu for single tab

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/component/tab/tabs.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/tab/tabs.html.twig
@@ -11,26 +11,31 @@
     {% endif %}
 {% endset %}
 
-{% embed '@ibexadesign/ui/component/tab/tabs_header.html.twig' with {
-    tabs,
-    active_tab,
-    hide_toggler: hide_toggler|default(false),
-    include_tab_more: include_tab_more|default(false),
-    tab_corner_disabled: tab_corner_disabled|default(false),
-} %}
-    {% block tabs_list_after %}
-        {{ tabs_list_after_content }}
-    {% endblock %}
-{% endembed %}
+{% if tabs|length > 1 %}
+    {% embed '@ibexadesign/ui/component/tab/tabs_header.html.twig' with {
+        tabs,
+        active_tab,
+        hide_toggler: hide_toggler|default(false),
+        include_tab_more: include_tab_more|default(false),
+        tab_corner_disabled: tab_corner_disabled|default(false),
+    } %}
+        {% block tabs_list_after %}
+            {{ tabs_list_after_content }}
+        {% endblock %}
+    {% endembed %}
 
-<div class="tab-content ibexa-tab-content {{ tab_content_class|default('') }}" {{ html.attributes(tab_content_attributes|default({})) }}>
-    {% block tab_content %}
-        {% for tab in tabs %}
-            {% embed '@ibexadesign/ui/component/tab/tab_pane.html.twig' with tab|merge({ active: tab == active_tab }) %}
-                {% block content %}
-                    {{ tab.content|default('')|raw }}
-                {% endblock %}
-            {% endembed %}
-        {% endfor %}
-    {% endblock %}
-</div>
+    <div class="tab-content ibexa-tab-content {{ tab_content_class|default('') }}" {{ html.attributes(tab_content_attributes|default({})) }}>
+        {% block tab_content %}
+            {% for tab in tabs %}
+                {% embed '@ibexadesign/ui/component/tab/tab_pane.html.twig' with tab|merge({ active: tab == active_tab }) %}
+                    {% block content %}
+                        {{ tab.content|default('')|raw }}
+                    {% endblock %}
+                {% endembed %}
+            {% endfor %}
+        {% endblock %}
+    </div>
+{% elseif tabs|length == 1 %}
+    {% set single_tab = tabs|first %}
+    {{ single_tab.content|default('')|raw }}
+{% endif %}


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Updated tabs.html.twig so tab navigation is rendered only when a tab group contains at least two tabs.
### What changed:
• Added a condition to render the tabs header and tab container only for tabs|length > 1.
• Added a single-tab fallback (tabs|length == 1) that renders only the tab content (single_tab.content) without tab navigation/wrapper UI.
### Result:
• Groups registered via ibexa.admin_ui.tab now use the standard view when only one tab is available.
• Tab menu appears only when there are at least two tabs in the group.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
