### PR TITLE
IBX-11423: added optional parameter to urlAliasService:load() call.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/yaml": "^5.0",
         "symfony/webpack-encore-bundle": "^v1.17",
         "jms/translation-bundle": "^1.5",
-        "ibexa/core": "~4.6.0@dev",
+        "ibexa/core": "dev-IBX-11423_cant-delete-product-urlalias-for-translations as 4.6.x-dev",
         "ibexa/content-forms": "~4.6.0@dev",
         "ibexa/design-engine": "~4.6.0@dev",
         "ibexa/user": "~4.6.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/yaml": "^5.0",
         "symfony/webpack-encore-bundle": "^v1.17",
         "jms/translation-bundle": "^1.5",
-        "ibexa/core": "dev-IBX-11423_cant-delete-product-urlalias-for-translations as 4.6.x-dev",
+        "ibexa/core": "~4.6.0@dev",
         "ibexa/content-forms": "~4.6.0@dev",
         "ibexa/design-engine": "~4.6.0@dev",
         "ibexa/user": "~4.6.0@dev",

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,11 @@
+{
+  "recipesEndpoint": "",
+  "packages": [
+    {
+      "requirement": "dev-IBX-11423_cant-delete-product-urlalias-for-translations as 4.6.x-dev",
+      "repositoryUrl": "https://github.com/ibexa/core",
+      "package": "ibexa/core",
+      "shouldBeAddedAsVCS": false
+    }
+  ]
+}

--- a/src/bundle/Controller/UrlAliasController.php
+++ b/src/bundle/Controller/UrlAliasController.php
@@ -99,7 +99,7 @@ class UrlAliasController extends Controller
             $result = $this->submitHandler->handle($form, function (CustomUrlRemoveData $data): RedirectResponse {
                 $aliasToRemoveList = [];
                 foreach ($data->getUrlAliases() as $customUrlId => $selected) {
-                    $aliasToRemoveList[] = $this->urlAliasService->load($customUrlId);
+                    $aliasToRemoveList[] = $this->urlAliasService->load($customUrlId, true);
                 }
                 $this->urlAliasService->removeAliases($aliasToRemoveList);
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11423 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/740


#### Description:

When loading a list of aliases to remove in Ibexa\Bundle\AdminUi\Controller\UrlAliasController::removeAction(), the service loads only aliases in the default language and no aliases for translations, thus the aliases for translations can't be removed. 

Changed the call to service so it loads aliases in all languages, so the aliases for translations are also getting added to the remove list.
Used the optional parameter $showAllTranslations to URLAliasService::load() when deleting URLAlias, which allowed the deletion of URLAlias for translations of contents.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
