### PR TITLE
IBX-11505: Add a tooltip on hover to display the complete, untrimmed name of the block

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/text.helper.ts
+++ b/src/bundle/Resources/public/js/scripts/helpers/text.helper.ts
@@ -17,4 +17,12 @@ const escapeHTMLAttribute = (str: unknown): string => {
     return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
 };
 
-export { escapeHTML, escapeHTMLAttribute };
+const stripHTML = (str: string): string => {
+    const tempNode = doc.createElement('div');
+
+    tempNode.innerHTML = str;
+
+    return tempNode.textContent ?? '';
+};
+
+export { escapeHTML, escapeHTMLAttribute, stripHTML };

--- a/src/bundle/Resources/public/js/scripts/helpers/text.helper.ts
+++ b/src/bundle/Resources/public/js/scripts/helpers/text.helper.ts
@@ -18,11 +18,11 @@ const escapeHTMLAttribute = (str: unknown): string => {
 };
 
 const stripHTML = (str: string): string => {
-    const tempNode = doc.createElement('div');
+    const divNode = doc.createElement('div');
 
-    tempNode.innerHTML = str;
+    divNode.innerHTML = str;
 
-    return tempNode.textContent ?? '';
+    return divNode.textContent ?? '';
 };
 
 export { escapeHTML, escapeHTMLAttribute, stripHTML };

--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,5 +1,6 @@
 import { isSafari } from './browser.helper';
 import { getBootstrap } from './context.helper';
+import { stripHTML } from './text.helper';
 
 const { document: doc } = window;
 
@@ -118,7 +119,7 @@ const getTextHeight = (text, styles) => {
     return texHeight;
 };
 const isTitleEllipsized = (node) => {
-    const title = node.dataset.originalTitle;
+    const title = stripHTML(node.dataset.originalTitle);
     const { width: nodeWidth, height: nodeHeight } = node.getBoundingClientRect();
     const computedNodeStyles = getComputedStyle(node);
     const styles = {
@@ -226,6 +227,7 @@ const parse = (baseElement = doc) => {
             if (hasNewTitle) {
                 tooltipNode.dataset.originalTitle = tooltipNode.title;
             }
+
             const tooltipInstance = bootstrap.Tooltip.getInstance(tooltipNode);
             const hasTooltip = !!tooltipInstance;
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11505 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/page-builder/pull/496

#### Description:
Added `stripHTML` function to `text.helper.ts` and applied it in `isTitleEllipsized` to strip HTML tags from the title before measuring text dimensions. Previously, when the title contained HTML markup, tag characters were included in the measurement, causing incorrect ellipsis detection.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
