### PR TITLE
IBX-11436: Made logic for anchor-menu-items css classes reusable

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -1,11 +1,11 @@
 {% extends view_base_layout is defined ? view_base_layout : '@ibexadesign/ui/layout.html.twig' %}
 
-{% macro main_container_classes(anchor_params, ignored_content_fields) %}
+{% macro anchor_container_classes(anchor_params, ignored_content_fields) %}
     {%- set has_anchor_menu_items = (anchor_params.items|default([])|length > 1)
         or (ignored_content_fields|default([]) is not empty) -%}
     {%- set has_anchor_close_btn = anchor_params.close_href|default(null) is not empty -%}
 
-    {%- set classes = ['ibexa-main-container--edit-container'] -%}
+    {%- set classes = [] -%}
 
     {%- set classes = classes|merge([ has_anchor_menu_items ? 'ibexa-main-container--with-anchor-menu-items' : 'ibexa-main-container--without-anchor-menu-items' ]) -%}
     {%- set classes = classes|merge([ not has_anchor_close_btn ? 'ibexa-main-container--without-anchor-close-btn' : '' ]) -%}
@@ -13,10 +13,11 @@
     {{- classes|join(' ') -}}
 {% endmacro %}
 
-{% from _self import main_container_classes %}
+{% from _self import anchor_container_classes %}
 
 {% block main_container_class %}
-    {{ main_container_classes(anchor_params|default({}), ignored_content_fields|default([])) }}
+    ibexa-main-container--edit-container
+    {{ anchor_container_classes(anchor_params|default({}), ignored_content_fields|default([])) }}
 {% endblock %}
 
 {% block header_row %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -1,13 +1,22 @@
 {% extends view_base_layout is defined ? view_base_layout : '@ibexadesign/ui/layout.html.twig' %}
 
-{% block main_container_class %}
-    ibexa-main-container--edit-container
-
-    {%- set has_anchor_menu_items = anchor_params.items|default([])|length > 1 or ignored_content_fields|default([]) is not empty -%}
+{% macro main_container_classes(anchor_params, ignored_content_fields) %}
+    {%- set has_anchor_menu_items = (anchor_params.items|default([])|length > 1)
+        or (ignored_content_fields|default([]) is not empty) -%}
     {%- set has_anchor_close_btn = anchor_params.close_href|default(null) is not empty -%}
 
-    {{- has_anchor_menu_items ? ' ibexa-main-container--with-anchor-menu-items ' : ' ibexa-main-container--without-anchor-menu-items ' -}}
-    {{- not has_anchor_close_btn ? ' ibexa-main-container--without-anchor-close-btn ' -}}
+    {%- set classes = ['ibexa-main-container--edit-container'] -%}
+
+    {%- set classes = classes|merge([ has_anchor_menu_items ? 'ibexa-main-container--with-anchor-menu-items' : 'ibexa-main-container--without-anchor-menu-items' ]) -%}
+    {%- set classes = classes|merge([ not has_anchor_close_btn ? 'ibexa-main-container--without-anchor-close-btn' : '' ]) -%}
+
+    {{- classes|join(' ') -}}
+{% endmacro %}
+
+{% from _self import main_container_classes %}
+
+{% block main_container_class %}
+    {{ main_container_classes(anchor_params|default({}), ignored_content_fields|default([])) }}
 {% endblock %}
 
 {% block header_row %}{% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -5,9 +5,7 @@
         or (ignored_content_fields|default([]) is not empty) -%}
     {%- set has_anchor_close_btn = anchor_params.close_href|default(null) is not empty -%}
 
-    {%- set classes = [] -%}
-
-    {%- set classes = classes|merge([ has_anchor_menu_items ? 'ibexa-main-container--with-anchor-menu-items' : 'ibexa-main-container--without-anchor-menu-items' ]) -%}
+    {%- set classes = [ has_anchor_menu_items ? 'ibexa-main-container--with-' : 'ibexa-main-container--without-anchor-menu-items' ] -%}
     {%- set classes = classes|merge([ not has_anchor_close_btn ? 'ibexa-main-container--without-anchor-close-btn' : '' ]) -%}
 
     {{- classes|join(' ') -}}

--- a/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/edit_base.html.twig
@@ -1,13 +1,21 @@
 {% extends view_base_layout is defined ? view_base_layout : '@ibexadesign/ui/layout.html.twig' %}
 
-{% block main_container_class %}
-    ibexa-main-container--edit-container
-
-    {%- set has_anchor_menu_items = anchor_params.items|default([])|length > 1 or ignored_content_fields|default([]) is not empty -%}
+{% macro anchor_container_classes(anchor_params, ignored_content_fields) %}
+    {%- set has_anchor_menu_items = (anchor_params.items|default([])|length > 1)
+        or (ignored_content_fields|default([]) is not empty) -%}
     {%- set has_anchor_close_btn = anchor_params.close_href|default(null) is not empty -%}
 
-    {{- has_anchor_menu_items ? ' ibexa-main-container--with-anchor-menu-items ' : ' ibexa-main-container--without-anchor-menu-items ' -}}
-    {{- not has_anchor_close_btn ? ' ibexa-main-container--without-anchor-close-btn ' -}}
+    {%- set classes = [ has_anchor_menu_items ? 'ibexa-main-container--with-' : 'ibexa-main-container--without-anchor-menu-items' ] -%}
+    {%- set classes = classes|merge([ not has_anchor_close_btn ? 'ibexa-main-container--without-anchor-close-btn' : '' ]) -%}
+
+    {{- classes|join(' ') -}}
+{% endmacro %}
+
+{% from _self import anchor_container_classes %}
+
+{% block main_container_class %}
+    ibexa-main-container--edit-container
+    {{ anchor_container_classes(anchor_params|default({}), ignored_content_fields|default([])) }}
 {% endblock %}
 
 {% block header_row %}{% endblock %}


### PR DESCRIPTION
| :ticket: Issue | IBX-11436 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/page-builder/pull/498

#### Description:
We need to calculate the main container classes in pagebuilder as well. As twig doesn't support importing only one specific block from a given template, I opted for defining the logic in a macro

An alternative could be to move the block to a dedicated template 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
