### PR TITLE
IBX-11605: Added translations row action extension point

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/translations/tab.html.twig
@@ -4,6 +4,7 @@
 
 {% import _self as tab %}
 {% set can_translate = can_translate is defined ? can_translate : true %}
+{% set has_translation_actions = has_translation_actions|default(false) %}
 <section>
     {% if can_translate %}
         {{ form_start(form_translation_remove, {
@@ -15,6 +16,7 @@
     {% set body_rows = [] %}
     {% for translation in translations %}
         {% set body_row_cols = [] %}
+        {% set is_main = translation.languageCode == content.contentInfo.mainLanguageCode %}
 
         {% set col_raw %}
             {% if can_translate %}
@@ -54,6 +56,23 @@
             }]) %}
         {% endif %}
 
+        {% set row_actions %}
+            {% if has_translation_actions %}
+                {{ ibexa_twig_component_group('admin-ui-content-translations-row-actions', {
+                    content: content,
+                    location: location,
+                    translation: translation
+                }) }}
+            {% endif %}
+        {% endset %}
+        {% if has_translation_actions %}
+            {% set body_row_cols = body_row_cols|merge([{
+                has_action_btns: true,
+                content: row_actions,
+                raw: true,
+            }]) %}
+        {% endif %}
+
         {% set body_rows = body_rows|merge([{ cols: body_row_cols }]) %}
     {% endfor %}
 
@@ -72,6 +91,10 @@
         {% set head_cols = head_cols|merge([{
             content: 'tab.translations.main_language'|trans|desc('Main language'),
         }]) %}
+    {% endif %}
+
+    {% if has_translation_actions %}
+        {% set head_cols = head_cols|merge([{ }]) %}
     {% endif %}
 
     {% include '@ibexadesign/ui/component/table/table.html.twig' with {

--- a/src/bundle/Resources/views/themes/admin/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/translations/tab.html.twig
@@ -16,7 +16,6 @@
     {% set body_rows = [] %}
     {% for translation in translations %}
         {% set body_row_cols = [] %}
-        {% set is_main = translation.languageCode == content.contentInfo.mainLanguageCode %}
 
         {% set col_raw %}
             {% if can_translate %}

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -22,6 +22,7 @@ use Ibexa\Contracts\Core\Repository\LanguageService;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\TwigComponents\Component\Registry as ComponentRegistry;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -42,7 +43,8 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
         EventDispatcherInterface $eventDispatcher,
         private readonly FormFactoryInterface $formFactory,
         private readonly PermissionResolver $permissionResolver,
-        private readonly LanguageService $languageService
+        private readonly LanguageService $languageService,
+        private readonly ComponentRegistry $componentRegistry
     ) {
         parent::__construct($twig, $translator, $eventDispatcher);
     }
@@ -94,6 +96,7 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
             iterator_to_array($this->languageService->loadLanguages()),
             'languageCode'
         );
+        $hasTranslationActions = $this->componentRegistry->getComponents('admin-ui-content-translations-row-actions') !== [];
 
         $canTranslate = $this->permissionResolver->canUser(
             'content',
@@ -112,6 +115,7 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
             'form_main_translation_update' => $mainTranslationUpdateForm->createView(),
             'main_translation_switch' => true,
             'can_translate' => $canTranslate,
+            'has_translation_actions' => $hasTranslationActions,
         ];
 
         return array_replace($contextParameters, $viewParameters);

--- a/tests/lib/Tab/LocationView/TranslationsTabTest.php
+++ b/tests/lib/Tab/LocationView/TranslationsTabTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Tab\LocationView;
+
+use Ibexa\AdminUi\Tab\LocationView\TranslationsTab;
+use Ibexa\AdminUi\UI\Dataset\DatasetFactory;
+use Ibexa\AdminUi\UI\Dataset\TranslationsDataset;
+use Ibexa\Contracts\Core\Repository\LanguageService;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Contracts\TwigComponents\ComponentInterface;
+use Ibexa\TwigComponents\Component\Registry as ComponentRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+final class TranslationsTabTest extends TestCase
+{
+    private const string ROW_ACTIONS_GROUP = 'admin-ui-content-translations-row-actions';
+
+    private DatasetFactory & MockObject $datasetFactory;
+
+    private FormFactoryInterface & MockObject $formFactory;
+
+    private PermissionResolver & MockObject $permissionResolver;
+
+    private LanguageService & MockObject $languageService;
+
+    private Content & MockObject $content;
+
+    private Location & MockObject $location;
+
+    private TranslationsDataset & MockObject $translationsDataset;
+
+    protected function setUp(): void
+    {
+        $this->datasetFactory = $this->createMock(DatasetFactory::class);
+        $this->formFactory = $this->createMock(FormFactoryInterface::class);
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->languageService = $this->createMock(LanguageService::class);
+        $this->content = $this->createMock(Content::class);
+        $this->location = $this->createMock(Location::class);
+        $this->translationsDataset = $this->createMock(TranslationsDataset::class);
+    }
+
+    /**
+     * @dataProvider provideHasTranslationActions
+     */
+    public function testGetTemplateParametersSetsHasTranslationActions(
+        bool $hasComponents,
+        bool $expectedFlag
+    ): void {
+        $this->configureContext();
+        $tab = $this->createTab($hasComponents);
+
+        $parameters = $tab->getTemplateParameters([
+            'content' => $this->content,
+            'location' => $this->location,
+        ]);
+
+        self::assertSame($expectedFlag, $parameters['has_translation_actions']);
+    }
+
+    /**
+     * @return iterable<string, array{0: bool, 1: bool}>
+     */
+    public static function provideHasTranslationActions(): iterable
+    {
+        yield 'without components' => [
+            false,
+            false,
+        ];
+
+        yield 'with components' => [
+            true,
+            true,
+        ];
+    }
+
+    private function configureContext(): void
+    {
+        $this->configureContentContext();
+        $this->configureTranslationsDataset();
+        $this->configureForms();
+        $this->configurePermissions();
+    }
+
+    private function configureContentContext(): void
+    {
+        $contentInfo = $this->createMock(ContentInfo::class);
+        $versionInfo = $this->createMock(VersionInfo::class);
+
+        $this->content
+            ->method('getVersionInfo')
+            ->willReturn($versionInfo);
+        $this->content
+            ->method('getContentInfo')
+            ->willReturn($contentInfo);
+
+        $this->location
+            ->method('getContentInfo')
+            ->willReturn($contentInfo);
+
+        $versionInfo
+            ->method('getContentInfo')
+            ->willReturn($contentInfo);
+        $contentInfo
+            ->method('getMainLanguageCode')
+            ->willReturn('eng-GB');
+    }
+
+    private function configureTranslationsDataset(): void
+    {
+        $versionInfo = $this->content->getVersionInfo();
+
+        $this->translationsDataset
+            ->expects(self::once())
+            ->method('load')
+            ->with($versionInfo)
+            ->willReturnSelf();
+        $this->translationsDataset
+            ->method('getTranslations')
+            ->willReturn([]);
+        $this->translationsDataset
+            ->method('getLanguageCodes')
+            ->willReturn([]);
+
+        $this->datasetFactory
+            ->expects(self::once())
+            ->method('translations')
+            ->willReturn($this->translationsDataset);
+    }
+
+    private function configureForms(): void
+    {
+        $this->formFactory
+            ->expects(self::exactly(2))
+            ->method('createNamed')
+            ->willReturnOnConsecutiveCalls(
+                $this->createFormMock(),
+                $this->createFormMock()
+            );
+        $this->formFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($this->createFormMock());
+    }
+
+    private function configurePermissions(): void
+    {
+        $this->permissionResolver
+            ->expects(self::once())
+            ->method('canUser')
+            ->willReturn(true);
+
+        $this->languageService
+            ->expects(self::once())
+            ->method('loadLanguages')
+            ->willReturn([]);
+    }
+
+    private function createTab(bool $hasComponents): TranslationsTab
+    {
+        $components = $hasComponents
+            ? ['component-id' => $this->createStub(ComponentInterface::class)]
+            : [];
+
+        return new TranslationsTab(
+            $this->createMock(Environment::class),
+            $this->createMock(TranslatorInterface::class),
+            $this->datasetFactory,
+            $this->createMock(UrlGeneratorInterface::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->formFactory,
+            $this->permissionResolver,
+            $this->languageService,
+            new ComponentRegistry([self::ROW_ACTIONS_GROUP => $components]),
+        );
+    }
+
+    /**
+     * @return FormInterface<mixed>&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createFormMock(): FormInterface
+    {
+        $form = $this->createMock(FormInterface::class);
+        $form
+            ->method('createView')
+            ->willReturn(new FormView());
+
+        return $form;
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11605 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR adds an extension point to the content Translations tab in Admin UI. It introduces a dedicated row action column and renders components registered under admin-ui-content-translations-row-actions. This allows other bundles to add actions directly to translation rows without overriding the tab template. The tab now exposes `has_translation_actions`, so the extra column is rendered only when at least one component is registered.

Bundles can register Twig components under `admin-ui-content-translations-row-actions` to add row-level actions such as Version Comparison or side-by-side. Whether an action is shown for a given row, including the main language row, is decided by the component itself.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
