### PR TITLE
Fixed PHPStan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12474,18 +12474,6 @@ parameters:
 			path: src/lib/Translation/Extractor/LimitationTranslationExtractor.php
 
 		-
-			message: '#^Access to an undefined property PhpParser\\Node\:\:\$args\.$#'
-			identifier: property.notFound
-			count: 5
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Call to function is_object\(\) with PhpParser\\Comment\\Doc will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
 			message: '#^Instanceof between string and PhpParser\\Comment\\Doc will always evaluate to false\.$#'
 			identifier: instanceof.alwaysFalse
 			count: 1
@@ -12506,13 +12494,7 @@ parameters:
 		-
 			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:enterNode\(\) should return int\|PhpParser\\Node\|null but empty return statement found\.$#'
 			identifier: return.empty
-			count: 4
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:enterNode\(\) should return int\|PhpParser\\Node\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
+			count: 2
 			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
 
 		-
@@ -12548,18 +12530,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitTwigFile\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Parameter \#1 \$desc of method JMS\\TranslationBundle\\Model\\Message\:\:setDesc\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Parameter \#1 \$meaning of method JMS\\TranslationBundle\\Model\\Message\:\:setMeaning\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12480,56 +12480,8 @@ parameters:
 			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
 
 		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:afterTraverse\(\) should return array\<PhpParser\\Node\>\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:beforeTraverse\(\) should return array\<PhpParser\\Node\>\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:enterNode\(\) should return int\|PhpParser\\Node\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 2
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:leaveNode\(\) should return array\<PhpParser\\Node\>\|int\|PhpParser\\Node\|null but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:setLogger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitPhpFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
 			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitPhpFile\(\) has parameter \$ast with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
-
-		-
-			message: '#^Method Ibexa\\AdminUi\\Translation\\Extractor\\NotificationTranslationExtractor\:\:visitTwigFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Translation/Extractor/NotificationTranslationExtractor.php
 

--- a/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
@@ -24,6 +24,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use SplFileInfo;
 use Twig\Node\Node as TwigNode;
 
 /**
@@ -86,7 +87,11 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         }
 
         if (!is_string($methodCallNodeName)
-            || !in_array(strtolower($methodCallNodeName), array_map('strtolower', array_keys($this->methodsToExtractFrom)))) {
+            || !in_array(
+                strtolower($methodCallNodeName),
+                array_map('strtolower', array_keys($this->methodsToExtractFrom)),
+                true
+            )) {
             $this->previousNode = $node;
 
             return;
@@ -113,43 +118,61 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
             return;
         }
 
-        if (!$node->args[0]->value instanceof String_) {
-            if ($ignore) {
-                return;
-            }
-
-            $message = sprintf('Can only extract the translation id from a scalar string, not from "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
-
-            $this->logger->error($message);
+        $idArg = $node->args[0] ?? null;
+        if (!$idArg instanceof Node\Arg) {
+            return null;
         }
 
-        $id = $node->args[0]->value->value;
-
-        $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
-        if (isset($node->args[$index])) {
-            if (!$node->args[$index]->value instanceof String_) {
-                if ($ignore) {
-                    return;
-                }
-
-                $message = sprintf('Can only extract the translation domain from a scalar string, not from "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[$index]->value), $this->file, $node->args[$index]->value->getLine());
-
-                $this->logger->error($message);
+        $idExpr = $idArg->value;
+        if (!$idExpr instanceof String_) {
+            if ($ignore) {
+                return null;
             }
 
-            $domain = $node->args[$index]->value->value;
+            $message = sprintf('Can only extract the translation id from a scalar string, not from "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($idExpr), $this->file, $idExpr->getLine());
+
+            $this->logger->error($message);
+
+            return null;
+        }
+
+        $id = $idExpr->value;
+
+        $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
+        if (isset($node->args[$index]) && $node->args[$index] instanceof Node\Arg) {
+            $domainExpr = $node->args[$index]->value;
+            if (!$domainExpr instanceof String_) {
+                if ($ignore) {
+                    return null;
+                }
+
+                $message = sprintf('Can only extract the translation domain from a scalar string, not from "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($domainExpr), $this->file, $domainExpr->getLine());
+
+                $this->logger->error($message);
+
+                return null;
+            }
+
+            $domain = $domainExpr->value;
         } else {
             $domain = 'messages';
         }
 
-        $message = new Message($id, $domain);
-        $message->setDesc($desc);
-        $message->setMeaning($meaning);
-        $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
-        $this->catalogue->add($message);
+        if ($this->catalogue !== null) {
+            $message = new Message($id, $domain);
+            $message->setDesc($desc ?? '');
+            $message->setMeaning($meaning ?? '');
+            if ($this->file !== null) {
+                $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
+            }
+
+            $this->catalogue->add($message);
+        }
+
+        return null;
     }
 
-    public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
     {
         $this->file = $file;
         $this->catalogue = $catalogue;
@@ -168,11 +191,11 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
     {
     }
 
-    public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
     {
     }
 
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 
@@ -180,7 +203,8 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
     {
         // check if there is a doc comment for the ID argument
         // ->trans(/** @Desc("FOO") */ 'my.id')
-        if (null !== $comment = $node->args[0]->getDocComment()) {
+        $idArg = $node->args[0] ?? null;
+        if ($idArg instanceof Node\Arg && null !== $comment = $idArg->getDocComment()) {
             return $comment->getText();
         }
 
@@ -190,10 +214,12 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         // /** @Desc("FOO") */ $translator->trans('my.id')
         if (null !== $comment = $node->getDocComment()) {
             return $comment->getText();
-        } elseif (null !== $this->previousNode && $this->previousNode->getDocComment() !== null) {
+        }
+
+        if (null !== $this->previousNode && $this->previousNode->getDocComment() !== null) {
             $comment = $this->previousNode->getDocComment();
 
-            return is_object($comment) ? $comment->getText() : $comment;
+            return $comment->getText();
         }
 
         return null;

--- a/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
@@ -74,7 +74,7 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         $this->logger = new NullLogger();
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
@@ -94,7 +94,7 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
             )) {
             $this->previousNode = $node;
 
-            return;
+            return null;
         }
 
         $ignore = false;
@@ -115,7 +115,7 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
                 }
             }
         } else {
-            return;
+            return null;
         }
 
         $idArg = $node->args[0] ?? null;
@@ -172,30 +172,33 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         return null;
     }
 
-    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
     {
         $this->file = $file;
         $this->catalogue = $catalogue;
         $this->traverser->traverse($ast);
     }
 
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): ?array
     {
+        return null;
     }
 
     public function leaveNode(Node $node)
     {
+        return null;
     }
 
-    public function afterTraverse(array $nodes)
+    public function afterTraverse(array $nodes): ?array
+    {
+        return null;
+    }
+
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue): void
     {
     }
 
-    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
-    {
-    }
-
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast): void
     {
     }
 


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
```


Error: Access to an undefined property PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder::$value.
Error: Access to an undefined property PhpParser\Node\Expr::$value.
Error: Access to an undefined property PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder::$value.
Error: Access to an undefined property PhpParser\Node\Expr::$value.
Error: Ignored error pattern #^Access to an undefined property PhpParser\\Node\:\:\$args\.$# (property.notFound) in path /home/runner/work/admin-ui/admin-ui/src/lib/Translation/Extractor/NotificationTranslationExtractor.php is expected to occur 5 times, but occurred only 1 time.
 ------ ----------------------------------------------------------------------- 
  Line   src/lib/Translation/Extractor/NotificationTranslationExtractor.php     
 ------ ----------------------------------------------------------------------- 
  116    Access to an undefined property                                        
         PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder::$value.         
         🪪  property.notFound                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-und  
         efined-property                                                        
  126    Access to an undefined property PhpParser\Node\Expr::$value.           
         🪪  property.notFound                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-und  
         efined-property                                                        
  130    Access to an undefined property                                        
         PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder::$value.         
         🪪  property.notFound                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-und  
         efined-property                                                        
  140    Access to an undefined property PhpParser\Node\Expr::$value.           
         🪪  property.notFound                                                  
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-und  
         efined-property                                                        
  183    Ignored error pattern #^Access to an undefined property                
         PhpParser\\Node\:\:\$args\.$# (property.notFound) in path              
         /home/runner/work/admin-ui/admin-ui/src/lib/Translation/Extractor/Not  
         ificationTranslationExtractor.php is expected to occur 5 times, but    
         occurred only 1 time.                                                  
         🪪  ignore.count (non-ignorable)                                       
 ------ ----------------------------------------------------------------------- 


Error:  [ERROR] Found 5 errors                                                         

```

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
