### PR TITLE
IBX-10776: Added Languages tab

### DIFF
--- a/src/bundle/Resources/config/services/tabs.yaml
+++ b/src/bundle/Resources/config/services/tabs.yaml
@@ -2,6 +2,7 @@ imports:
     - { resource: tabs/locationview.yaml }
     - { resource: tabs/content_type.yaml }
     - { resource: tabs/url_management.yaml }
+    - { resource: tabs/languages.yaml }
 
 services:
     _defaults:

--- a/src/bundle/Resources/config/services/tabs/languages.yaml
+++ b/src/bundle/Resources/config/services/tabs/languages.yaml
@@ -1,0 +1,13 @@
+services:
+    ibexa.admin_ui.languages.tab_group:
+        parent: Ibexa\AdminUi\Component\TabsComponent
+        arguments:
+            $template: '@@ibexadesign/ui/tab/languages.html.twig'
+            $groupIdentifier: 'languages'
+        tags:
+            - { name: ibexa.twig.component, group: 'admin-ui-languages-tab-groups' }
+
+    Ibexa\AdminUi\Tab\Language\LanguagesTab:
+        parent: Ibexa\Contracts\AdminUi\Tab\AbstractTab
+        tags:
+            - { name: ibexa.admin_ui.tab, group: 'languages' }

--- a/src/bundle/Resources/views/themes/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/list.html.twig
@@ -1,9 +1,5 @@
 {% extends "@ibexadesign/ui/layout.html.twig" %}
 
-{% from '@ibexadesign/ui/component/macros.html.twig' import results_headline %}
-
-{% form_theme form_languages_delete '@ibexadesign/ui/form_fields.html.twig'  %}
-
 {% trans_default_domain 'ibexa_language' %}
 
 {% block body_class %}ibexa-language-list-view{% endblock %}
@@ -45,140 +41,11 @@
 {% endblock %}
 
 {% block content %}
-    <section class="container ibexa-container">
-        {% set body_rows = [] %}
-        {% for language in pager.currentPageResults %}
-            {% set body_row_cols = [] %}
-
-            {% set col_raw %}
-                {% if can_administrate %}
-                    {{ form_widget(form_languages_delete.languages[language.id]) }}
-                {% else %}
-                    {% do form_languages_delete.languages.setRendered %}
-                {% endif %}
-            {% endset %}
-            {% set body_row_cols = body_row_cols|merge([{
-                has_checkbox: true,
-                content: col_raw,
-                raw: true,
-            }]) %}
-
-            {% set col_raw %}
-                <a href="{{ path( 'ibexa.language.view', {'languageId': language.id} ) }}">
-                    {{ language.name }}
-                </a>
-            {% endset %}
-            {% set body_row_cols = body_row_cols|merge([{
-                content: col_raw,
-                raw: true,
-            }]) %}
-
-            {% set body_row_cols = body_row_cols|merge([
-                { content: language.languageCode },
-                { content: language.id },
-            ]) %}
-
-            {% set col_raw %}
-                <div class="form-check">
-                    <input
-                        type="checkbox"
-                        title="{{ language.enabled ? 'language.enabled'|trans|desc('Enabled')  : 'language.disabled'|trans|desc('Disabled')  }}"
-                        class="ibexa-input ibexa-input--checkbox form-check-input"
-                        disabled
-                        {% if language.enabled %}checked{% endif %}
-                    >
-                </div>
-            {% endset %}
-            {% set body_row_cols = body_row_cols|merge([{
-                content: col_raw,
-                center_content: true,
-                raw: true,
-            }]) %}
-
-            {% set col_raw %}
-                {% if can_administrate %}
-                    <a
-                        title="{{ 'language.edit'|trans|desc('Edit') }}"
-                        href="{{ path('ibexa.language.edit', {'languageId': language.id}) }}"
-                        class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text"
-                    >
-                        <svg class="ibexa-icon ibexa-icon--small-medium">
-                            <use xlink:href="{{ ibexa_icon_path('edit') }}"></use>
-                        </svg>
-                    </a>
-                {% endif %}
-            {% endset %}
-            {% set body_row_cols = body_row_cols|merge([{
-                has_action_btns: true,
-                content: col_raw,
-                raw: true,
-            }]) %}
-
-            {% set body_rows = body_rows|merge([{ cols: body_row_cols }]) %}
-        {% endfor %}
-
-        {% embed '@ibexadesign/ui/component/table/table.html.twig' with {
-            headline: custom_results_headline ?? results_headline(pager.getNbResults()),
-            head_cols: [
-                { has_checkbox: true },
-                { content: 'language.name'|trans|desc('Name') },
-                { content: 'language.code'|trans|desc('Code') },
-                { content: 'language.id'|trans|desc('ID') },
-                {
-                    content: 'language.enabled'|trans|desc('Enabled'),
-                    center_content: true,
-                },
-                { },
-            ],
-            body_rows,
-        } %}
-            {% block header %}
-                {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}
-                    {% block actions %}
-                        {% if can_administrate %}
-                            {% set modal_data_target = 'delete-languages-modal' %}
-                            <button
-                                id="delete-languages"
-                                type="button"
-                                class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
-                                disabled
-                                data-bs-toggle="modal"
-                                data-bs-target="#{{ modal_data_target }}"
-                            >
-                                <svg class="ibexa-icon ibexa-icon--small-medium ibexa-icon--trash">
-                                    <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
-                                </svg>
-                                <span class="ibexa-btn__small">
-                                    {{ 'language.delete'|trans|desc('Delete') }}
-                                </span>
-                            </button>
-                            {% include '@ibexadesign/ui/modal/bulk_delete_confirmation.html.twig' with {
-                                'id': modal_data_target,
-                                'message': 'language.modal.message'|trans|desc(
-                                    'Delete the languages?'
-                                ),
-                                'data_click': '#languages_delete_delete',
-                            }%}
-                        {% endif %}
-                    {% endblock %}
-                {% endembed %}
-            {% endblock %}
-
-            {% block between_header_and_table %}
-                {{ form_start(form_languages_delete, {
-                    'action': path('ibexa.language.bulk_delete'),
-                    'attr': { 'class': 'ibexa-toggle-btn-state', 'data-toggle-button-id': '#delete-languages' }
-                }) }}
-            {% endblock %}
-        {% endembed %}
-        {{ form_end(form_languages_delete) }}
-
-        {% if pager.haveToPaginate %}
-            {% include '@ibexadesign/ui/pagination.html.twig' with {
-                'pager': pager
-            } %}
-        {% endif %}
-    </section>
+    {{ ibexa_twig_component_group('admin-ui-languages-tab-groups', {
+        pager: pager,
+        form_languages_delete: form_languages_delete,
+        can_administrate: can_administrate,
+    }) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/themes/admin/language/tab/languages.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/tab/languages.html.twig
@@ -1,0 +1,138 @@
+{% trans_default_domain 'ibexa_language' %}
+
+{% from '@ibexadesign/ui/component/macros.html.twig' import results_headline %}
+
+{% form_theme form_languages_delete '@ibexadesign/ui/form_fields.html.twig' %}
+
+<section class="container ibexa-container">
+    {% set body_rows = [] %}
+    {% for language in pager.currentPageResults %}
+        {% set body_row_cols = [] %}
+
+        {% set col_raw %}
+            {% if can_administrate %}
+                {{ form_widget(form_languages_delete.languages[language.id]) }}
+            {% else %}
+                {% do form_languages_delete.languages.setRendered %}
+            {% endif %}
+        {% endset %}
+        {% set body_row_cols = body_row_cols|merge([{
+            has_checkbox: true,
+            content: col_raw,
+            raw: true,
+        }]) %}
+
+        {% set col_raw %}
+            <a href="{{ path('ibexa.language.view', {'languageId': language.id}) }}">
+                {{ language.name }}
+            </a>
+        {% endset %}
+        {% set body_row_cols = body_row_cols|merge([{
+            content: col_raw,
+            raw: true,
+        }]) %}
+
+        {% set body_row_cols = body_row_cols|merge([
+            { content: language.languageCode },
+            { content: language.id },
+        ]) %}
+
+        {% set col_raw %}
+            <div class="form-check">
+                <input
+                    type="checkbox"
+                    title="{{ language.enabled ? 'language.enabled'|trans|desc('Enabled') : 'language.disabled'|trans|desc('Disabled') }}"
+                    class="ibexa-input ibexa-input--checkbox form-check-input"
+                    disabled
+                    {% if language.enabled %}checked{% endif %}
+                >
+            </div>
+        {% endset %}
+        {% set body_row_cols = body_row_cols|merge([{
+            content: col_raw,
+            center_content: true,
+            raw: true,
+        }]) %}
+
+        {% set col_raw %}
+            {% if can_administrate %}
+                <a
+                    title="{{ 'language.edit'|trans|desc('Edit') }}"
+                    href="{{ path('ibexa.language.edit', {'languageId': language.id}) }}"
+                    class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text"
+                >
+                    <svg class="ibexa-icon ibexa-icon--small-medium">
+                        <use xlink:href="{{ ibexa_icon_path('edit') }}"></use>
+                    </svg>
+                </a>
+            {% endif %}
+        {% endset %}
+        {% set body_row_cols = body_row_cols|merge([{
+            has_action_btns: true,
+            content: col_raw,
+            raw: true,
+        }]) %}
+
+        {% set body_rows = body_rows|merge([{ cols: body_row_cols }]) %}
+    {% endfor %}
+
+    {% embed '@ibexadesign/ui/component/table/table.html.twig' with {
+        headline: custom_results_headline ?? results_headline(pager.getNbResults()),
+        head_cols: [
+            { has_checkbox: true },
+            { content: 'language.name'|trans|desc('Name') },
+            { content: 'language.code'|trans|desc('Code') },
+            { content: 'language.id'|trans|desc('ID') },
+            {
+                content: 'language.enabled'|trans|desc('Enabled'),
+                center_content: true,
+            },
+            {},
+        ],
+        body_rows,
+    } %}
+        {% block header %}
+            {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}
+                {% block actions %}
+                    {% if can_administrate %}
+                        {% set modal_data_target = 'delete-languages-modal' %}
+                        <button
+                            id="delete-languages"
+                            type="button"
+                            class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--small"
+                            disabled
+                            data-bs-toggle="modal"
+                            data-bs-target="#{{ modal_data_target }}"
+                        >
+                            <svg class="ibexa-icon ibexa-icon--small-medium ibexa-icon--trash">
+                                <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
+                            </svg>
+                            <span class="ibexa-btn__small">
+                                {{ 'language.delete'|trans({}, 'ibexa_language')|desc('Delete') }}
+                            </span>
+                        </button>
+                        {% include '@ibexadesign/ui/modal/bulk_delete_confirmation.html.twig' with {
+                            id: modal_data_target,
+                            message: 'language.modal.message'|trans({}, 'ibexa_language')|desc('Delete the languages?'),
+                            data_click: '#languages_delete_delete',
+                        } %}
+                    {% endif %}
+                {% endblock %}
+            {% endembed %}
+        {% endblock %}
+
+        {% block between_header_and_table %}
+            {{ form_start(form_languages_delete, {
+                action: path('ibexa.language.bulk_delete'),
+                attr: {'class': 'ibexa-toggle-btn-state', 'data-toggle-button-id': '#delete-languages'}
+            }) }}
+        {% endblock %}
+    {% endembed %}
+    {{ form_end(form_languages_delete) }}
+
+    {% if pager.haveToPaginate %}
+        {% include '@ibexadesign/ui/pagination.html.twig' with {
+            pager: pager,
+        } %}
+    {% endif %}
+</section>

--- a/src/bundle/Resources/views/themes/admin/language/tab/languages.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/tab/languages.html.twig
@@ -108,12 +108,12 @@
                                 <use xlink:href="{{ ibexa_icon_path('trash') }}"></use>
                             </svg>
                             <span class="ibexa-btn__small">
-                                {{ 'language.delete'|trans({}, 'ibexa_language')|desc('Delete') }}
+                                {{ 'language.delete'|trans|desc('Delete') }}
                             </span>
                         </button>
                         {% include '@ibexadesign/ui/modal/bulk_delete_confirmation.html.twig' with {
                             id: modal_data_target,
-                            message: 'language.modal.message'|trans({}, 'ibexa_language')|desc('Delete the languages?'),
+                            message: 'language.modal.message'|trans|desc('Delete the languages?'),
                             data_click: '#languages_delete_delete',
                         } %}
                     {% endif %}

--- a/src/bundle/Resources/views/themes/admin/ui/tab/languages.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/tab/languages.html.twig
@@ -1,0 +1,13 @@
+{% set tabs_to_show = tabs|map((tab, index) => {
+    id: group ~ '-' ~ tab.identifier,
+    label: tab.name,
+    content: tab.view,
+    active: index == 0,
+}) %}
+{% include '@ibexadesign/ui/component/tab/tabs.html.twig' with {
+    tabs: tabs_to_show,
+} %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('ibexa-admin-ui-tabs-js', null, 'ibexa') }}
+{% endblock %}

--- a/src/lib/Tab/Language/LanguagesTab.php
+++ b/src/lib/Tab/Language/LanguagesTab.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Tab\Language;
+
+use Ibexa\Contracts\AdminUi\Tab\AbstractTab;
+use Ibexa\Contracts\AdminUi\Tab\OrderedTabInterface;
+use JMS\TranslationBundle\Annotation\Desc;
+
+class LanguagesTab extends AbstractTab implements OrderedTabInterface
+{
+    public function getIdentifier(): string
+    {
+        return 'languages';
+    }
+
+    public function getName(): string
+    {
+        return /** @Desc("Languages") */
+            $this->translator->trans('language.list', [], 'ibexa_language');
+    }
+
+    public function getOrder(): int
+    {
+        return 10;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function renderView(array $parameters): string
+    {
+        return $this->twig->render(
+            '@ibexadesign/language/tab/languages.html.twig',
+            $parameters
+        );
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | [IBX-10776](https://ibexa.atlassian.net/browse/IBX-10776) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
  This PR aligns Languages page rendering with the standard tab-group, while keeping current behavior unchanged for users.

  ## What changed

  - Added a dedicated tab group configuration for languages (groupIdentifier: languages) and registered LanguagesTab in this group.
  - Refactored templates to match the common pattern:
      - ui/tab/languages.html.twig now works as the tab group container.
      - language/tab/languages.html.twig now contains the Languages tab content (the table/list view).
  - Updated language list page to render via the component group (admin-ui-languages-tab-groups), consistent with other sections.

  ## Important behavior note

  By default, users will still see the same old Languages view (without visible tab navigation).
  This is expected and intentional.

  The tabs component renders plain content when there is only one tab in the group.
  Only after a second tab is added to the languages group will the UI switch to visible tab navigation.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-10776]: https://ibexa.atlassian.net/browse/IBX-10776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ