### PR TITLE
IBX-11694: Corrected condition for DisableSiteRootCheckboxIfRootLocationListener 

### DIFF
--- a/src/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListener.php
+++ b/src/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListener.php
@@ -16,7 +16,7 @@ final readonly class DisableSiteRootCheckboxIfRootLocationListener
     public function onPreSetData(FormEvent $event): void
     {
         $location = $event->getData()->getLocation();
-        if (null === $location || 1 < $location->depth) {
+        if (null === $location || 1 < $location->getDepth()) {
             return;
         }
 

--- a/src/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListener.php
+++ b/src/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListener.php
@@ -16,7 +16,7 @@ final readonly class DisableSiteRootCheckboxIfRootLocationListener
     public function onPreSetData(FormEvent $event): void
     {
         $location = $event->getData()->getLocation();
-        if (null === $location || 1 >= $location->depth) {
+        if (null === $location || 1 < $location->depth) {
             return;
         }
 

--- a/tests/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListenerTest.php
+++ b/tests/lib/Form/EventListener/DisableSiteRootCheckboxIfRootLocationListenerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Ibexa\Tests\AdminUi\Form\EventListener;
+
+use Ibexa\AdminUi\Form\Data\Content\CustomUrl\CustomUrlAddData;
+use Ibexa\AdminUi\Form\EventListener\DisableSiteRootCheckboxIfRootLocationListener;
+use Ibexa\Core\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
+
+class DisableSiteRootCheckboxIfRootLocationListenerTest extends TestCase
+{
+    public function testAddsCheckboxForRootLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->method('getDepth')
+            ->willReturn(1);
+
+        $data = new CustomUrlAddData($location);
+        $form = $this->createMock(FormInterface::class);
+
+        $form
+            ->expects(self::once())
+            ->method('add')
+            ->with(
+                'site_root',
+                CheckboxType::class,
+                [
+                    'required' => false,
+                    'label' => false,
+                    'disabled' => true,
+                ]
+            );
+
+        $event = $this->createMock(FormEvent::class);
+
+        $event
+            ->method('getData')
+            ->willReturn($data);
+
+        $event
+            ->method('getForm')
+            ->willReturn($form);
+
+        $listener = new DisableSiteRootCheckboxIfRootLocationListener();
+
+        $listener->onPreSetData($event);
+    }
+
+    public function testDoesNothingWhenLocationIsNull(): void
+    {
+        $data = new CustomUrlAddData();
+        $form = $this->createMock(FormInterface::class);
+
+        $form
+            ->expects(self::never())
+            ->method('add');
+
+        $event = $this->createMock(FormEvent::class);
+
+        $event
+            ->method('getData')
+            ->willReturn($data);
+
+        $event
+            ->method('getForm')
+            ->willReturn($form);
+
+        $listener = new DisableSiteRootCheckboxIfRootLocationListener();
+
+        $listener->onPreSetData($event);
+
+        $form = $event->getForm();
+
+        self::assertNotTrue($form->has('site_root'));
+    }
+
+    public function testDoesNothingWhenLocationDepthIsGreaterThanOne(): void
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->method('getDepth')
+            ->willReturn(2);
+
+        $data = new CustomUrlAddData($location);
+              $form = $this->createMock(FormInterface::class);
+
+        $form
+            ->expects(self::never())
+            ->method('add');
+
+        $event = $this->createMock(FormEvent::class);
+
+        $event
+            ->method('getData')
+            ->willReturn($data);
+
+        $event
+            ->method('getForm')
+            ->willReturn($form);
+
+        $listener = new DisableSiteRootCheckboxIfRootLocationListener();
+
+        $listener->onPreSetData($event);
+
+        self::assertNotTrue($form->has('site_root'));
+    }
+}


### PR DESCRIPTION

| :ticket: Issue | IBX-11694 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In v5.0, we've shortened this if statement to check the opposite of 4.6, so instead of:

`if (null !== $location && 1 >= $location->depth)`

It should be:
`if (null === $location || 1 < $location->depth)`

But it's
 `if (null === $location || 1 >= $location->depth)`

The first part has been correctly changed, while the second part remains the same, which now causes incorrect operation.

Old behaviour is correct, but incorrect we changed it when we moved code to v5.0



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
