### PR TITLE
IBX-11753: Make sure title is stripHTML only when useHTML in tooltips

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -119,7 +119,8 @@ const getTextHeight = (text, styles) => {
     return texHeight;
 };
 const isTitleEllipsized = (node) => {
-    const title = stripHTML(node.dataset.originalTitle);
+    const useHtml = node.dataset.tooltipUseHtml !== undefined;
+    const title = useHtml ? stripHTML(node.dataset.originalTitle) : node.dataset.originalTitle;
     const { width: nodeWidth, height: nodeHeight } = node.getBoundingClientRect();
     const computedNodeStyles = getComputedStyle(node);
     const styles = {


### PR DESCRIPTION
| :ticket: Issue | IBX-11753 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
