### PR TITLE
IBX-11797: [GHA][Backend CI] Removed redundant PHP setup

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -16,24 +16,16 @@ jobs:
         php:
           - '8.0'
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-          extensions: 'pdo_sqlite, gd'
-          tools: cs2pr
+      - uses: actions/checkout@v6
 
       - uses: ibexa/gh-workflows/actions/setup-composer-root-version@main
 
       - uses: ibexa/gh-workflows/actions/composer-install@main
         with:
-          gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
-          satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+            gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+            satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+            satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
@@ -52,15 +44,7 @@ jobs:
           - '8.4'
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-          extensions: pdo_sqlite, gd
-          tools: cs2pr
+      - uses: actions/checkout@v6
 
       - uses: ibexa/gh-workflows/actions/setup-composer-root-version@main
 
@@ -108,15 +92,7 @@ jobs:
           - '8.4'
 
     steps:
-      -   uses: actions/checkout@v3
-
-      -   name: Setup PHP Action
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: ${{ matrix.php }}
-            coverage: none
-            extensions: pdo_pgsql, gd
-            tools: cs2pr
+      -   uses: actions/checkout@v6
 
       -   uses: ibexa/gh-workflows/actions/setup-composer-root-version@main
 
@@ -168,15 +144,7 @@ jobs:
           - '8.4'
 
     steps:
-      -   uses: actions/checkout@v3
-
-      -   name: Setup PHP Action
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: ${{ matrix.php }}
-            coverage: none
-            extensions: pdo_mysql, gd
-            tools: cs2pr
+      -   uses: actions/checkout@v6
 
       -   uses: ibexa/gh-workflows/actions/setup-composer-root-version@main
 


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-11797 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/gh-workflows/pull/97


#### Description:

Testing ibexa/gh-workflows#97.

I saw we have a redundant PHP setup, which is part of Ibexa `composer-install` action, so I removed it.

#### For QA:
No QA required.