### PR TITLE
IBX-11949: Added content language context extension point

### DIFF
--- a/src/bundle/Resources/config/services/services.yaml
+++ b/src/bundle/Resources/config/services/services.yaml
@@ -13,3 +13,14 @@ services:
 
     Ibexa\Contracts\AdminUi\ContentType\ContentTypeFieldsByExpressionServiceInterface:
         '@Ibexa\AdminUi\ContentType\ContentTypeFieldsByExpressionService'
+
+    Ibexa\AdminUi\Request\Resolver\AdminUiContentLanguageCodeResolver:
+        tags:
+            - { name: ibexa.admin_ui.content_language_code_resolver, priority: 100 }
+
+    Ibexa\AdminUi\Request\Resolver\ChainContentLanguageCodeResolver:
+        arguments:
+            $resolvers: !tagged_iterator ibexa.admin_ui.content_language_code_resolver
+
+    Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface:
+        '@Ibexa\AdminUi\Request\Resolver\ChainContentLanguageCodeResolver'

--- a/src/contracts/Request/ContentLanguageContext.php
+++ b/src/contracts/Request/ContentLanguageContext.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\Request;
+
+final class ContentLanguageContext
+{
+    public const ATTRIBUTE_NAME = 'contentLanguageCode';
+}

--- a/src/contracts/Request/Resolver/ContentLanguageCodeResolverInterface.php
+++ b/src/contracts/Request/Resolver/ContentLanguageCodeResolverInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\AdminUi\Request\Resolver;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ContentLanguageCodeResolverInterface
+{
+    public function resolve(Request $request): ?string;
+}

--- a/src/lib/EventListener/NormalizedLanguageCodeListener.php
+++ b/src/lib/EventListener/NormalizedLanguageCodeListener.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\EventListener;
+
+use Ibexa\Contracts\AdminUi\Request\ContentLanguageContext;
+use Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class NormalizedLanguageCodeListener implements EventSubscriberInterface
+{
+    private ContentLanguageCodeResolverInterface $resolver;
+
+    public function __construct(ContentLanguageCodeResolverInterface $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 12],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (HttpKernelInterface::MAIN_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $normalizedLanguageCode = $request->attributes->get(ContentLanguageContext::ATTRIBUTE_NAME);
+        if (is_string($normalizedLanguageCode) && $normalizedLanguageCode !== '') {
+            return;
+        }
+
+        if (null !== $languageCode = $this->resolver->resolve($request)) {
+            $request->attributes->set(ContentLanguageContext::ATTRIBUTE_NAME, $languageCode);
+        }
+    }
+}

--- a/src/lib/Request/Resolver/AdminUiContentLanguageCodeResolver.php
+++ b/src/lib/Request/Resolver/AdminUiContentLanguageCodeResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Request\Resolver;
+
+use Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Symfony\Component\HttpFoundation\Request;
+
+final class AdminUiContentLanguageCodeResolver implements ContentLanguageCodeResolverInterface
+{
+    public function resolve(Request $request): ?string
+    {
+        $language = $request->attributes->get('language');
+        if ($language instanceof Language) {
+            return $language->getLanguageCode();
+        }
+
+        if (is_string($language) && $language !== '') {
+            return $language;
+        }
+
+        $languageCode = $request->attributes->get('languageCode');
+        if (is_string($languageCode) && $languageCode !== '') {
+            return $languageCode;
+        }
+
+        return null;
+    }
+}

--- a/src/lib/Request/Resolver/ChainContentLanguageCodeResolver.php
+++ b/src/lib/Request/Resolver/ChainContentLanguageCodeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Request\Resolver;
+
+use Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ChainContentLanguageCodeResolver implements ContentLanguageCodeResolverInterface
+{
+    /** @var iterable<\Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface> */
+    private iterable $resolvers;
+
+    /**
+     * @param iterable<\Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface> $resolvers
+     */
+    public function __construct(iterable $resolvers)
+    {
+        $this->resolvers = $resolvers;
+    }
+
+    public function resolve(Request $request): ?string
+    {
+        foreach ($this->resolvers as $resolver) {
+            $languageCode = $resolver->resolve($request);
+
+            if (is_string($languageCode) && $languageCode !== '') {
+                return $languageCode;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/lib/EventListener/NormalizedLanguageCodeListenerTest.php
+++ b/tests/lib/EventListener/NormalizedLanguageCodeListenerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\EventListener;
+
+use Ibexa\AdminUi\EventListener\NormalizedLanguageCodeListener;
+use Ibexa\Contracts\AdminUi\Request\ContentLanguageContext;
+use Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class NormalizedLanguageCodeListenerTest extends TestCase
+{
+    private NormalizedLanguageCodeListener $listener;
+
+    /**
+     * @var \Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private ContentLanguageCodeResolverInterface $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = $this->createMock(ContentLanguageCodeResolverInterface::class);
+        $this->listener = new NormalizedLanguageCodeListener($this->resolver);
+    }
+
+    public function testLanguageCodeIsSetFromResolver(): void
+    {
+        $request = new Request();
+        $this->resolver
+            ->expects(self::once())
+            ->method('resolve')
+            ->with($request)
+            ->willReturn('eng-GB');
+
+        $this->listener->onKernelRequest($this->createEvent($request, HttpKernelInterface::MAIN_REQUEST));
+
+        self::assertSame('eng-GB', $request->attributes->get(ContentLanguageContext::ATTRIBUTE_NAME));
+    }
+
+    public function testNormalizedLanguageCodeHasPriorityOverResolver(): void
+    {
+        $request = new Request([], [], [ContentLanguageContext::ATTRIBUTE_NAME => 'eng-GB']);
+        $this->resolver
+            ->expects(self::never())
+            ->method('resolve');
+
+        $this->listener->onKernelRequest($this->createEvent($request, HttpKernelInterface::MAIN_REQUEST));
+
+        self::assertSame('eng-GB', $request->attributes->get(ContentLanguageContext::ATTRIBUTE_NAME));
+    }
+
+    public function testNullValueFromResolverIsIgnored(): void
+    {
+        $request = new Request();
+        $this->resolver
+            ->expects(self::once())
+            ->method('resolve')
+            ->with($request)
+            ->willReturn(null);
+
+        $this->listener->onKernelRequest($this->createEvent($request, HttpKernelInterface::MAIN_REQUEST));
+
+        self::assertNull($request->attributes->get(ContentLanguageContext::ATTRIBUTE_NAME));
+    }
+
+    public function testLanguageCodeIsNotChangedOnSubRequest(): void
+    {
+        $request = new Request();
+        $this->resolver
+            ->expects(self::never())
+            ->method('resolve');
+
+        $this->listener->onKernelRequest($this->createEvent($request, HttpKernelInterface::SUB_REQUEST));
+
+        self::assertNull($request->attributes->get(ContentLanguageContext::ATTRIBUTE_NAME));
+    }
+
+    public function testSubscribedEvents(): void
+    {
+        self::assertSame(
+            [KernelEvents::REQUEST => ['onKernelRequest', 12]],
+            NormalizedLanguageCodeListener::getSubscribedEvents()
+        );
+    }
+
+    private function createEvent(Request $request, int $requestType): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            $requestType
+        );
+    }
+}

--- a/tests/lib/Request/Resolver/AdminUiContentLanguageCodeResolverTest.php
+++ b/tests/lib/Request/Resolver/AdminUiContentLanguageCodeResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Request\Resolver;
+
+use Ibexa\AdminUi\Request\Resolver\AdminUiContentLanguageCodeResolver;
+use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class AdminUiContentLanguageCodeResolverTest extends TestCase
+{
+    private AdminUiContentLanguageCodeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new AdminUiContentLanguageCodeResolver();
+    }
+
+    /**
+     * @dataProvider provideResolvableLanguageContext
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function testResolvesLanguageCode(array $attributes, string $expectedLanguageCode): void
+    {
+        $request = new Request([], [], $attributes);
+
+        self::assertSame($expectedLanguageCode, $this->resolver->resolve($request));
+    }
+
+    /**
+     * @dataProvider provideUnresolvableLanguageContext
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function testReturnsNullForUnresolvableLanguageContext(array $attributes): void
+    {
+        self::assertNull($this->resolver->resolve(new Request([], [], $attributes)));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public function provideResolvableLanguageContext(): iterable
+    {
+        yield 'language object' => [
+            ['language' => new Language(['languageCode' => 'eng-GB'])],
+            'eng-GB',
+        ];
+        yield 'language string' => [
+            ['language' => 'ger-DE'],
+            'ger-DE',
+        ];
+        yield 'languageCode string' => [
+            ['languageCode' => 'pol-PL'],
+            'pol-PL',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public function provideUnresolvableLanguageContext(): iterable
+    {
+        yield 'missing context' => [[]];
+        yield 'empty context' => [['language' => '', 'languageCode' => '']];
+    }
+}

--- a/tests/lib/Request/Resolver/ChainContentLanguageCodeResolverTest.php
+++ b/tests/lib/Request/Resolver/ChainContentLanguageCodeResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\Request\Resolver;
+
+use Ibexa\AdminUi\Request\Resolver\ChainContentLanguageCodeResolver;
+use Ibexa\Contracts\AdminUi\Request\Resolver\ContentLanguageCodeResolverInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ChainContentLanguageCodeResolverTest extends TestCase
+{
+    public function testReturnsFirstNonEmptyLanguageCode(): void
+    {
+        $request = new Request();
+        $resolver = new ChainContentLanguageCodeResolver([
+            $this->createResolverMock(null),
+            $this->createResolverMock(''),
+            $this->createResolverMock('eng-GB'),
+            $this->createResolverMock('ger-DE'),
+        ]);
+
+        self::assertSame('eng-GB', $resolver->resolve($request));
+    }
+
+    public function testReturnsNullWhenNoResolverMatches(): void
+    {
+        $resolver = new ChainContentLanguageCodeResolver([
+            $this->createResolverMock(null),
+            $this->createResolverMock(''),
+        ]);
+
+        self::assertNull($resolver->resolve(new Request()));
+    }
+
+    private function createResolverMock(?string $value): ContentLanguageCodeResolverInterface
+    {
+        $resolver = $this->createMock(ContentLanguageCodeResolverInterface::class);
+        $resolver
+            ->method('resolve')
+            ->willReturn($value);
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11949 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Adds a content language context extension point in `admin-ui` and makes it the owner of the normalized back-office request attribute `contentLanguageCode`. `admin-ui` now exposes the public contract through `ContentLanguageContext::ATTRIBUTE_NAME`, resolves the language code through a tagged resolver chain, and stores the normalized value on the request in `NormalizedLanguageCodeListener`.

This removes package-specific request parsing from `connector-ai` and lets packages that already depend on `admin-ui` extend language context resolution without changing `connector-ai` itself. `page-builder` can register a resolver that reads `request_block_configuration['language']`, while `connector-ai` only reads `Request::attributes[ContentLanguageContext::ATTRIBUTE_NAME]`.



#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
