### PR TITLE
[Behat] IBX-11567: Adjust behat tests for content translation feature

### DIFF
--- a/features/standard/ContentTranslation.feature
+++ b/features/standard/ContentTranslation.feature
@@ -1,7 +1,7 @@
-@javascript @translation @IbexaOSS @IbexaHeadless @IbexaExperience @IbexaCommerce
-Feature: Content item transation
+@javascript @translation
+Feature: Content item translation
 
-  @APIUser:admin
+  @APIUser:admin @IbexaOSS
   Scenario: Publish new translation based on existing translation
     Given I create "folder" Content items in root in "eng-GB"
       | name             | short_name       | short_description | description      |
@@ -30,7 +30,7 @@ Feature: Content item transation
       | Short description | EnglishPublished |
       | Description       | EnglishPublished |
 
-  @APIUser:admin
+  @APIUser:admin @IbexaOSS
   Scenario: Publish new translation without base translation
     Given I create "folder" Content items in root in "eng-GB"
       | name            | short_name       | short_description | description      |
@@ -51,6 +51,35 @@ Feature: Content item transation
     And content attributes equal
       | label             | value               | fieldTypeIdentifier |
       | Name              | Folder              |                     |
-      | Short name        | This field is empty | ibexa_string            |
-      | Short description | This field is empty | ibexa_richtext          |
-      | Description       | This field is empty | ibexa_richtext          |
+      | Short name        | This field is empty | ibexa_string        |
+      | Short description | This field is empty | ibexa_richtext      |
+      | Description       | This field is empty | ibexa_richtext      |
+
+  @APIUser:admin @IbexaHeadless @IbexaExperience @IbexaCommerce
+  Scenario: Publish new translation based on existing translation
+    Given I create "folder" Content items in root in "eng-GB"
+      | name             | short_name       | short_description | description      |
+      | EnglishPublished | EnglishPublished | EnglishPublished  | EnglishPublished |
+    And I am logged as admin
+    And I'm on Content view Page for "EnglishPublished"
+    When I switch to "Translations" tab in Content structure
+    And I add new translation "French" basing on "English (United Kingdom)" translation
+    And I set content fields
+      | label      | value           |
+      | Name       | FrenchPublished |
+      | Short name | FrenchPublished |
+    And I perform the "Publish" action
+    Then success notification that "Content published." appears
+    And content attributes equal
+      | label             | value            |
+      | Name              | EnglishPublished |
+      | Short name        | EnglishPublished |
+      | Short description | EnglishPublished |
+      | Description       | EnglishPublished |
+    And I choose "French" preview in Content View
+    And content attributes equal
+      | label             | value               | fieldTypeIdentifier |
+      | Name              | FrenchPublished     | ibexa_string        |
+      | Short name        | FrenchPublished     | ibexa_string        |
+      | Short description | This field is empty | ibexa_richtext      |
+      | Description       | This field is empty | ibexa_richtext      |


### PR DESCRIPTION
| :ticket: Issue |[IBX-11567](https://ibexa.atlassian.net/browse/IBX-11567) |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/136


#### Description:
translations-management is available only starting from the Headless edition. As part of that feature, the "no Base Translation selected" option is no longer available.
Because of this, the existing browser test scenario is no longer valid for Headless and higher editions. It is now executed only against the **OSS** edition, where this behavior still exists.
For **Headless, Experience, and Commerce** editions, this PR introduces a separate set of browser tests covering the side-by-side translation workflow integrated with the translation optimization feature.

#### For QA:
Regression: https://github.com/ibexa/commerce/pull/1854
https://github.com/ibexa/oss/pull/282


#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-11567]: https://ibexa.atlassian.net/browse/IBX-11567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ