### PR TITLE
[DON'T MERGE - POC] IBX-11739: Added playwright tests for Trash

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -13,7 +13,7 @@ jobs:
         uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'oss'
-            test-suite: ''
+            test-package: 'admin-ui'
         secrets: inherit
 
     playwright-headless:
@@ -21,7 +21,7 @@ jobs:
         uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'headless'
-            test-suite: ''
+            test-package: 'admin-ui'
         secrets: inherit
 
     playwright-experience:
@@ -29,7 +29,7 @@ jobs:
         uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'experience'
-            test-suite: ''
+            test-package: 'admin-ui'
         secrets: inherit
 
     playwright-commerce:
@@ -37,5 +37,5 @@ jobs:
         uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'commerce'
-            test-suite: ''
+            test-package: 'admin-ui'
         secrets: inherit

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,0 +1,37 @@
+name: Playwright tests
+
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+
+jobs:
+    playwright-oss:
+        name: "Playwright/OSS"
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        with:
+            project-edition: 'oss'
+        secrets: inherit
+
+    playwright-headless:
+        name: "Playwright/Headless"
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        with:
+            project-edition: 'headless'
+        secrets: inherit
+
+    playwright-experience:
+        name: "Playwright/Experience"
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        with:
+            project-edition: 'experience'
+        secrets: inherit
+
+    playwright-commerce:
+        name: "Playwright/Commerce"
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        with:
+            project-edition: 'commerce'
+        secrets: inherit

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -10,23 +10,26 @@ on:
 jobs:
     playwright-oss:
         name: "Playwright/OSS"
-        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'oss'
+            test-suite: ''
         secrets: inherit
 
     playwright-headless:
         name: "Playwright/Headless"
-        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'headless'
+            test-suite: ''
         secrets: inherit
 
     playwright-experience:
         name: "Playwright/Experience"
-        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'experience'
+            test-suite: ''
         secrets: inherit
 
     playwright-commerce:

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -31,7 +31,8 @@ jobs:
 
     playwright-commerce:
         name: "Playwright/Commerce"
-        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/playwright-browser-tests.yml@ibx-11740-playwright
         with:
             project-edition: 'commerce'
+            test-suite: ''
         secrets: inherit

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -3,7 +3,6 @@ name: Playwright tests
 on:
     push:
         branches:
-            - main
             - '[0-9]+.[0-9]+'
     pull_request: ~
 

--- a/tests/playwright-tests/.gitignore
+++ b/tests/playwright-tests/.gitignore
@@ -1,0 +1,9 @@
+.env
+.auth/
+playwright-report/
+test-results/
+node_modules/
+dist/
+# un-ignore files excluded by root .gitignore
+!tsconfig.json
+!package-lock.json

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -1,29 +1,17 @@
 import { Page, expect } from '@playwright/test';
-import { AdminUiPage } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
 
 export class ContentManagementPage extends AdminUiPage {
+    readonly udw: UniversalDiscoveryWidget;
+
     constructor(page: Page) {
         super(page);
+        this.udw = new UniversalDiscoveryWidget(page);
     }
 
     async open(contentId: number, locationId: number): Promise<void> {
         await this.page.goto(`/admin/view/content/${contentId}/full/1/${locationId}`);
-        await this.page.waitForLoadState('networkidle');
-        // Wait for the React content tree (c-tb-* toolbox tree) to render initial items
-        await this.page.locator('.c-tb-list-item-single').first()
-            .waitFor({ state: 'attached', timeout: 20_000 }).catch(() => {});
-        // Click "See more" to load additional items until the current item appears
-        // (tree loads 30 items at a time; newly created items may not be in the first batch)
-        for (let i = 0; i < 20; i++) {
-            const active = await this.page.locator('.c-tb-list-item-single--active')
-                .first().isVisible({ timeout: 500 }).catch(() => false);
-            if (active) break;
-            const loadMore = this.page.locator('.c-tb-list-item-single__load-more').first();
-            const found = await loadMore.count() > 0;
-            if (!found) break;
-            await loadMore.click();
-            await this.page.waitForTimeout(1_500);
-        }
+        await expect(this.page.locator('.ibexa-context-menu')).toBeVisible({ timeout: 20_000 });
     }
 
     /**
@@ -32,227 +20,83 @@ export class ContentManagementPage extends AdminUiPage {
      */
     async performAction(label: string): Promise<void> {
         const contextMenu = this.page.locator('.ibexa-context-menu');
-        await contextMenu.waitFor({ state: 'visible', timeout: 10_000 });
+        await expect(contextMenu).toBeVisible({ timeout: 10_000 });
 
-        // Check primary buttons — only click ones not physically covered by the "More" overlay.
-        // Use elementFromPoint to confirm the button is the topmost element at its center.
-        const primaryButtons = contextMenu.locator(
-            '.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn',
-        );
-        const count = await primaryButtons.count();
-        for (let i = 0; i < count; i++) {
-            const btn = primaryButtons.nth(i);
-            const text = (await btn.textContent() ?? '').trim();
-            if (!text.includes(label)) continue;
+        const primaryButton = contextMenu
+            .locator('.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn')
+            .filter({ hasText: label })
+            .first();
 
-            const box = await btn.boundingBox();
-            if (!box) continue;
-
-            const cx = box.x + box.width / 2;
-            const cy = box.y + box.height / 2;
-
-            // Check whether the button (or its child) is the topmost element at (cx, cy)
-            const isOnTop = await this.page.evaluate(
-                ([x, y, btnId]: [number, number, string]) => {
-                    const el = document.elementFromPoint(x, y);
-                    const target = document.getElementById(btnId) ?? document.querySelector(`[id="${btnId}"]`);
-                    return target ? target.contains(el) || el === target : false;
-                },
-                [cx, cy, await btn.getAttribute('id') ?? ''] as [number, number, string],
-            );
-
-            if (isOnTop) {
-                await btn.click({ force: true });
-                await this.page.waitForLoadState('networkidle');
-                return;
-            }
+        // A primary button can be present in the DOM but covered by the "More" overflow —
+        // the click then fails its actionability check and we fall back to the "More" menu.
+        try {
+            await primaryButton.click({ timeout: 3_000 });
+            return;
+        } catch {
+            // fall through to the "More" menu
         }
 
-        // Fall back to the "More" overflow popup — trigger is the .ibexa-btn--more button, not the <li>
-        const moreButton = contextMenu.locator('.ibexa-btn--more');
-        await moreButton.waitFor({ state: 'visible', timeout: 5_000 });
-        await moreButton.click();
+        await contextMenu.locator('.ibexa-btn--more').click();
 
-        // The multilevel popup branch is appended to <body> by the JS.
-        // Visibility is toggled via CSS class ibexa-popup-menu--hidden (not HTML hidden attr).
-        const popupItems = this.page.locator(
-            '.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden) .ibexa-multilevel-popup-menu__item-content',
-        );
-        await popupItems.first().waitFor({ state: 'visible', timeout: 5_000 });
-
-        const popupCount = await popupItems.count();
-        const popupTexts: string[] = [];
-        for (let i = 0; i < popupCount; i++) {
-            const item = popupItems.nth(i);
-            const text = (await item.textContent() ?? '').trim();
-            popupTexts.push(text);
-            if (text.includes(label)) {
-                await item.click();
-                await this.page.waitForLoadState('networkidle');
-                return;
-            }
-        }
-
-        throw new Error(`Action button '${label}' not found in context menu`);
+        // The multilevel popup branch is appended to <body>; visibility is toggled
+        // via the ibexa-popup-menu--hidden CSS class.
+        const popupItem = this.page
+            .locator('.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden)')
+            .filter({ hasText: label })
+            .first();
+        await expect(popupItem, `Action '${label}' not found in context menu`).toBeVisible({ timeout: 5_000 });
+        await popupItem.click();
     }
 
     async sendToTrash(): Promise<void> {
         await this.performAction('Send to trash');
 
-        // "Send to trash" always opens #trash-location-modal.
-        // For items with children/relations a confirm checkbox is required to enable the button;
-        // for empty items the button is already enabled — we just click it.
-        const trashModal = this.page.locator('#trash-location-modal, .ibexa-modal--trash-location');
-        const isModalVisible = await trashModal.waitFor({ state: 'visible', timeout: 5_000 })
-            .then(() => true).catch(() => false);
+        const modal = this.page.locator('#trash-location-modal, .ibexa-modal--trash-location').first();
+        await expect(modal).toBeVisible({ timeout: 10_000 });
 
-        if (!isModalVisible) {
-            // No modal — action was handled without confirmation
-            await this.page.waitForLoadState('networkidle');
-            return;
-        }
-
-        // Check all unchecked checkboxes in the modal (options + confirm checkbox)
-        await this.page.evaluate(() => {
-            const modal = document.querySelector('#trash-location-modal, .ibexa-modal--trash-location');
-            if (!modal) return;
-            modal.querySelectorAll<HTMLInputElement>('input[type="checkbox"]:not(:checked)')
-                .forEach(cb => cb.click());
-        });
-        await this.page.waitForTimeout(300);
-
-        // Click the submit button inside the modal
-        const submitBtn = trashModal.locator('.ibexa-btn--confirm-send-to-trash');
-        await submitBtn.waitFor({ state: 'visible', timeout: 5_000 });
-        await submitBtn.click();
-        await this.page.waitForLoadState('networkidle');
-    }
-
-    /**
-     * Selects a content item in the UDW by navigating the tree path (e.g. "Media/Files").
-     * Each path segment is a branch level in the UDW finder.
-     */
-    async selectInUDW(itemPath: string): Promise<void> {
-        const udw = this.page.locator('.m-ud');
-        await udw.waitFor({ state: 'visible', timeout: 10_000 });
-
-        const segments = itemPath.split('/');
-        for (let level = 1; level <= segments.length; level++) {
-            const segmentName = segments[level - 1];
-            const branchLocator = this.page.locator(`div.c-finder-branch:nth-of-type(${level}) .c-finder-leaf`);
-            await branchLocator.first().waitFor({ state: 'visible', timeout: 10_000 });
-
-            const leafCount = await branchLocator.count();
-            let found = false;
-            for (let i = 0; i < leafCount; i++) {
-                const leaf = branchLocator.nth(i);
-                const text = (await leaf.textContent() ?? '').trim();
-                if (text.includes(segmentName)) {
-                    if (level < segments.length) {
-                        await leaf.locator('.c-finder-leaf__name').click();
-                    } else {
-                        // Last segment: check the checkbox to select (multiple-mode UDW)
-                        const checkbox = leaf.locator('input[type="checkbox"]');
-                        if (await checkbox.count() > 0) {
-                            await this.page.evaluate((el) => (el as HTMLInputElement).click(), await checkbox.elementHandle());
-                            await this.page.waitForTimeout(300);
-                        } else {
-                            await leaf.locator('.c-finder-leaf__name').click();
-                        }
-                    }
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                console.warn(`UDW tree item '${segmentName}' not found at level ${level} — stopping navigation`);
-                return;
-            }
-
-            if (level < segments.length) {
-                // For intermediate nodes: wait for next branch to appear (navigation happened)
-                const nextBranch = this.page.locator(`div.c-finder-branch:nth-of-type(${level + 1})`);
-                await nextBranch.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+        // For items with children/relations the modal requires ticking confirmation
+        // checkboxes before the submit button becomes enabled.
+        const submitButton = modal.locator('.ibexa-btn--confirm-send-to-trash');
+        if (await submitButton.isDisabled()) {
+            const checkboxes = modal.locator('input[type="checkbox"]:not(:checked)');
+            const count = await checkboxes.count();
+            for (let i = 0; i < count; i++) {
+                await checkboxes.nth(i).check({ force: true });
             }
         }
-    }
 
-    async confirmUDW(): Promise<void> {
-        const confirmButton = this.page.locator('.c-actions-menu__confirm-btn');
-        await confirmButton.waitFor({ state: 'visible', timeout: 10_000 });
-        await confirmButton.click({ force: true });
-        await this.page.locator('.m-ud').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
-        await this.page.waitForLoadState('domcontentloaded');
-    }
-
-    async closeUDW(): Promise<void> {
-        const cancelButton = this.page.locator('.c-top-menu__cancel-btn');
-        await cancelButton.waitFor({ state: 'visible', timeout: 10_000 });
-        await cancelButton.click();
-        await this.page.locator('.m-ud').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
-        await this.page.waitForLoadState('domcontentloaded');
-    }
-
-    async assertOnContentView(itemName: string): Promise<void> {
-        const pageTitle = this.page.locator('.ibexa-page-title h1');
-        await pageTitle.waitFor({ state: 'visible', timeout: 10_000 });
-        await expect(pageTitle).toContainText(itemName);
-    }
-
-    async assertSuccessNotification(text: string): Promise<void> {
-        const notification = this.page.locator('.ibexa-notifications-container .ibexa-alert--success');
-        await notification.waitFor({ state: 'visible', timeout: 10_000 });
-        await expect(notification).toContainText(text);
-    }
-
-    async assertSubitemAbsent(name: string): Promise<void> {
-        // .m-sub-items is a React mount point — wait for it to render rows inside
-        const subItemsTable = this.page.locator('.m-sub-items');
-        await subItemsTable.waitFor({ state: 'attached', timeout: 10_000 });
-        await this.page.waitForFunction(
-            (sel) => {
-                const el = document.querySelector(sel);
-                return el && el.querySelectorAll('.ibexa-table__row').length > 0;
-            },
-            '.m-sub-items',
-            { timeout: 10_000 },
-        );
-        const items = subItemsTable.locator('.ibexa-table__row');
-        const count = await items.count();
-        for (let i = 0; i < count; i++) {
-            const text = (await items.nth(i).textContent() ?? '').trim();
-            expect(text).not.toContain(name);
-        }
+        await expect(submitButton).toBeEnabled({ timeout: 5_000 });
+        await submitButton.click();
+        await expect(modal).toBeHidden({ timeout: 10_000 });
     }
 
     async hide(): Promise<void> {
-        // Hide works by submitting form[name="content_visibility_update"] with visible=0.
-        // We set the visibility field and submit the form directly.
-        await this.page.locator('.ibexa-context-menu').waitFor({ state: 'visible', timeout: 10_000 });
+        await this.performAction('Hide');
+        // "Hide" opens the "Schedule hiding" panel; confirm with the default "Hide now" option
+        await expect(
+            this.page.getByRole('heading', { name: 'Schedule hiding' }).filter({ visible: true }).first(),
+        ).toBeVisible({ timeout: 10_000 });
+        await this.page.getByRole('button', { name: 'Confirm' }).filter({ visible: true }).first().click();
+    }
 
-        const submitted = await this.page.evaluate(() => {
-            const form = document.querySelector('form[name="content_visibility_update"]') as HTMLFormElement | null;
-            if (!form) return 'NO_FORM';
-            const visField = form.querySelector('#content_visibility_update_visible') as HTMLInputElement | null;
-            if (!visField) return 'NO_FIELD';
-            visField.value = '0';
-            form.submit();
-            return 'OK';
-        });
-
-        if (submitted !== 'OK') {
-            throw new Error(`Hide form issue: ${submitted}`);
-        }
-
-        await this.page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+    async assertOnContentView(itemName: string): Promise<void> {
+        await expect(this.page.locator('.ibexa-page-title h1')).toContainText(itemName, { timeout: 10_000 });
     }
 
     async assertSubitemPresent(name: string): Promise<void> {
-        const subItemsTable = this.page.locator('.m-sub-items');
-        await subItemsTable.waitFor({ state: 'attached', timeout: 10_000 });
-        const row = subItemsTable.locator('.ibexa-table__row').filter({ hasText: name }).first();
-        await row.waitFor({ state: 'attached', timeout: 10_000 });
-        await expect(row).toContainText(name);
+        const subItems = this.page.locator('.m-sub-items');
+        await expect(
+            subItems.locator('.ibexa-table__row').filter({ hasText: name }).first(),
+        ).toBeVisible({ timeout: 10_000 });
+    }
+
+    async assertSubitemAbsent(name: string): Promise<void> {
+        // .m-sub-items is a React mount point — anchor on the rendered table
+        // (or its empty state) before asserting absence, to avoid passing on a blank mount.
+        const subItems = this.page.locator('.m-sub-items');
+        await expect(
+            subItems.locator('.ibexa-table, .ibexa-table__empty-table-text').first(),
+        ).toBeVisible({ timeout: 10_000 });
+        await expect(subItems.locator('.ibexa-table__row').filter({ hasText: name })).toHaveCount(0);
     }
 }

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -1,9 +1,9 @@
 import { Page, Locator, expect } from '@playwright/test';
-import { AdminUiPage, UniversalDiscoveryWidget, ContextMenu } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget, ContentActionsMenu } from '@ibexa/cohesivo-playwright';
 
 export class ContentManagementPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
-    readonly contextMenu: ContextMenu;
+    readonly contentActionsMenu: ContentActionsMenu;
 
     private readonly trashModal: Locator;
     private readonly trashModalSubmit: Locator;
@@ -12,7 +12,7 @@ export class ContentManagementPage extends AdminUiPage {
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
-        this.contextMenu = new ContextMenu(page);
+        this.contentActionsMenu = new ContentActionsMenu(page);
         this.trashModal = page.locator('#trash-location-modal, .ibexa-modal--trash-location').first();
         this.trashModalSubmit = this.trashModal.locator('.ibexa-btn--confirm-send-to-trash');
         this.subItems = page.locator('.m-sub-items');
@@ -24,11 +24,11 @@ export class ContentManagementPage extends AdminUiPage {
 
     async open(contentId: number, locationId: number): Promise<void> {
         await this.page.goto(`/admin/view/content/${contentId}/full/1/${locationId}`);
-        await this.contextMenu.expectVisible();
+        await this.contentActionsMenu.expectVisible();
     }
 
     async sendToTrash(): Promise<void> {
-        await this.contextMenu.clickAction('Send to trash');
+        await this.contentActionsMenu.clickButton('Send to trash');
         await expect(this.trashModal).toBeVisible({ timeout: 10_000 });
 
         // For items with children/relations the modal requires ticking confirmation
@@ -47,7 +47,7 @@ export class ContentManagementPage extends AdminUiPage {
     }
 
     async hide(): Promise<void> {
-        await this.contextMenu.clickAction('Hide');
+        await this.contentActionsMenu.clickButton('Hide');
         // "Hide" opens the "Schedule hiding" panel; confirm with the default "Hide now" option
         await expect(
             this.page.getByRole('heading', { name: 'Schedule hiding' }).filter({ visible: true }).first(),

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -20,20 +20,25 @@ export class ContentManagementPage extends AdminUiPage {
      */
     async performAction(label: string): Promise<void> {
         const contextMenu = this.page.locator('.ibexa-context-menu');
-        await expect(contextMenu).toBeVisible({ timeout: 10_000 });
+        await expect(contextMenu.locator('.ibexa-btn').first()).toBeVisible({ timeout: 10_000 });
 
         const primaryButton = contextMenu
             .locator('.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn')
             .filter({ hasText: label })
             .first();
 
-        // A primary button can be present in the DOM but covered by the "More" overflow —
-        // the click then fails its actionability check and we fall back to the "More" menu.
-        try {
-            await primaryButton.click({ timeout: 3_000 });
+        // A primary button can be present in the DOM but covered by the "More" overflow.
+        // Probe with elementFromPoint (read-only, no failed click attempt in the report)
+        // and only then click for real, with Playwright's actionability checks intact.
+        const isClickable = await primaryButton.count() > 0 && await primaryButton.evaluate((el) => {
+            const box = el.getBoundingClientRect();
+            const topmost = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
+            return topmost !== null && (el === topmost || el.contains(topmost));
+        });
+
+        if (isClickable) {
+            await primaryButton.click();
             return;
-        } catch {
-            // fall through to the "More" menu
         }
 
         await contextMenu.locator('.ibexa-btn--more').click();

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -1,17 +1,48 @@
-import { Page, expect } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
 
 export class ContentManagementPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
 
+    private readonly contextMenu: Locator;
+    private readonly moreButton: Locator;
+    private readonly trashModal: Locator;
+    private readonly trashModalSubmit: Locator;
+    private readonly subItems: Locator;
+
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
+        this.contextMenu = page.locator('.ibexa-context-menu');
+        this.moreButton = this.contextMenu.locator('.ibexa-btn--more');
+        this.trashModal = page.locator('#trash-location-modal, .ibexa-modal--trash-location').first();
+        this.trashModalSubmit = this.trashModal.locator('.ibexa-btn--confirm-send-to-trash');
+        this.subItems = page.locator('.m-sub-items');
+    }
+
+    /** Primary (always-visible) context-menu action button by its label. */
+    private primaryAction(label: string): Locator {
+        return this.contextMenu
+            .locator('.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn')
+            .filter({ hasText: label })
+            .first();
+    }
+
+    /** Same action when it lives in the "More" overflow popup (appended to <body>). */
+    private overflowAction(label: string): Locator {
+        return this.page
+            .locator('.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden)')
+            .filter({ hasText: label })
+            .first();
+    }
+
+    private subItemRow(name: string): Locator {
+        return this.subItems.locator('.ibexa-table__row').filter({ hasText: name });
     }
 
     async open(contentId: number, locationId: number): Promise<void> {
         await this.page.goto(`/admin/view/content/${contentId}/full/1/${locationId}`);
-        await expect(this.page.locator('.ibexa-context-menu')).toBeVisible({ timeout: 20_000 });
+        await expect(this.contextMenu).toBeVisible({ timeout: 20_000 });
     }
 
     /**
@@ -19,13 +50,9 @@ export class ContentManagementPage extends AdminUiPage {
      * Handles both primary (visible) buttons and items hidden behind the "More" overflow button.
      */
     async performAction(label: string): Promise<void> {
-        const contextMenu = this.page.locator('.ibexa-context-menu');
-        await expect(contextMenu.locator('.ibexa-btn').first()).toBeVisible({ timeout: 10_000 });
+        await expect(this.contextMenu.locator('.ibexa-btn').first()).toBeVisible({ timeout: 10_000 });
 
-        const primaryButton = contextMenu
-            .locator('.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn')
-            .filter({ hasText: label })
-            .first();
+        const primaryButton = this.primaryAction(label);
 
         // A primary button can be present in the DOM but covered by the "More" overflow.
         // Probe with elementFromPoint (read-only, no failed click attempt in the report)
@@ -41,38 +68,29 @@ export class ContentManagementPage extends AdminUiPage {
             return;
         }
 
-        await contextMenu.locator('.ibexa-btn--more').click();
-
-        // The multilevel popup branch is appended to <body>; visibility is toggled
-        // via the ibexa-popup-menu--hidden CSS class.
-        const popupItem = this.page
-            .locator('.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden)')
-            .filter({ hasText: label })
-            .first();
-        await expect(popupItem, `Action '${label}' not found in context menu`).toBeVisible({ timeout: 5_000 });
-        await popupItem.click();
+        await this.moreButton.click();
+        const item = this.overflowAction(label);
+        await expect(item, `Action '${label}' not found in context menu`).toBeVisible({ timeout: 5_000 });
+        await item.click();
     }
 
     async sendToTrash(): Promise<void> {
         await this.performAction('Send to trash');
-
-        const modal = this.page.locator('#trash-location-modal, .ibexa-modal--trash-location').first();
-        await expect(modal).toBeVisible({ timeout: 10_000 });
+        await expect(this.trashModal).toBeVisible({ timeout: 10_000 });
 
         // For items with children/relations the modal requires ticking confirmation
         // checkboxes before the submit button becomes enabled.
-        const submitButton = modal.locator('.ibexa-btn--confirm-send-to-trash');
-        if (await submitButton.isDisabled()) {
-            const checkboxes = modal.locator('input[type="checkbox"]:not(:checked)');
+        if (await this.trashModalSubmit.isDisabled()) {
+            const checkboxes = this.trashModal.locator('input[type="checkbox"]:not(:checked)');
             const count = await checkboxes.count();
             for (let i = 0; i < count; i++) {
                 await checkboxes.nth(i).check({ force: true });
             }
         }
 
-        await expect(submitButton).toBeEnabled({ timeout: 5_000 });
-        await submitButton.click();
-        await expect(modal).toBeHidden({ timeout: 10_000 });
+        await expect(this.trashModalSubmit).toBeEnabled({ timeout: 5_000 });
+        await this.trashModalSubmit.click();
+        await expect(this.trashModal).toBeHidden({ timeout: 10_000 });
     }
 
     async hide(): Promise<void> {
@@ -85,23 +103,20 @@ export class ContentManagementPage extends AdminUiPage {
     }
 
     async assertOnContentView(itemName: string): Promise<void> {
-        await expect(this.page.locator('.ibexa-page-title h1')).toContainText(itemName, { timeout: 10_000 });
+        // reuse the shared page-title assertion from AdminUiPage
+        await this.assertPageTitle(itemName);
     }
 
     async assertSubitemPresent(name: string): Promise<void> {
-        const subItems = this.page.locator('.m-sub-items');
-        await expect(
-            subItems.locator('.ibexa-table__row').filter({ hasText: name }).first(),
-        ).toBeVisible({ timeout: 10_000 });
+        await expect(this.subItemRow(name).first()).toBeVisible({ timeout: 10_000 });
     }
 
     async assertSubitemAbsent(name: string): Promise<void> {
         // .m-sub-items is a React mount point — anchor on the rendered table
         // (or its empty state) before asserting absence, to avoid passing on a blank mount.
-        const subItems = this.page.locator('.m-sub-items');
         await expect(
-            subItems.locator('.ibexa-table, .ibexa-table__empty-table-text').first(),
+            this.subItems.locator('.ibexa-table, .ibexa-table__empty-table-text').first(),
         ).toBeVisible({ timeout: 10_000 });
-        await expect(subItems.locator('.ibexa-table__row').filter({ hasText: name })).toHaveCount(0);
+        await expect(this.subItemRow(name)).toHaveCount(0);
     }
 }

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -1,0 +1,258 @@
+import { Page, expect } from '@playwright/test';
+import { AdminUiPage } from '@ibexa/cohesivo-playwright';
+
+export class ContentManagementPage extends AdminUiPage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    async open(contentId: number, locationId: number): Promise<void> {
+        await this.page.goto(`/admin/view/content/${contentId}/full/1/${locationId}`);
+        await this.page.waitForLoadState('networkidle');
+        // Wait for the React content tree (c-tb-* toolbox tree) to render initial items
+        await this.page.locator('.c-tb-list-item-single').first()
+            .waitFor({ state: 'attached', timeout: 20_000 }).catch(() => {});
+        // Click "See more" to load additional items until the current item appears
+        // (tree loads 30 items at a time; newly created items may not be in the first batch)
+        for (let i = 0; i < 20; i++) {
+            const active = await this.page.locator('.c-tb-list-item-single--active')
+                .first().isVisible({ timeout: 500 }).catch(() => false);
+            if (active) break;
+            const loadMore = this.page.locator('.c-tb-list-item-single__load-more').first();
+            const found = await loadMore.count() > 0;
+            if (!found) break;
+            await loadMore.click();
+            await this.page.waitForTimeout(1_500);
+        }
+    }
+
+    /**
+     * Clicks an action button in the context menu by its visible label text.
+     * Handles both primary (visible) buttons and items hidden behind the "More" overflow button.
+     */
+    async performAction(label: string): Promise<void> {
+        const contextMenu = this.page.locator('.ibexa-context-menu');
+        await contextMenu.waitFor({ state: 'visible', timeout: 10_000 });
+
+        // Check primary buttons — only click ones not physically covered by the "More" overlay.
+        // Use elementFromPoint to confirm the button is the topmost element at its center.
+        const primaryButtons = contextMenu.locator(
+            '.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn',
+        );
+        const count = await primaryButtons.count();
+        for (let i = 0; i < count; i++) {
+            const btn = primaryButtons.nth(i);
+            const text = (await btn.textContent() ?? '').trim();
+            if (!text.includes(label)) continue;
+
+            const box = await btn.boundingBox();
+            if (!box) continue;
+
+            const cx = box.x + box.width / 2;
+            const cy = box.y + box.height / 2;
+
+            // Check whether the button (or its child) is the topmost element at (cx, cy)
+            const isOnTop = await this.page.evaluate(
+                ([x, y, btnId]: [number, number, string]) => {
+                    const el = document.elementFromPoint(x, y);
+                    const target = document.getElementById(btnId) ?? document.querySelector(`[id="${btnId}"]`);
+                    return target ? target.contains(el) || el === target : false;
+                },
+                [cx, cy, await btn.getAttribute('id') ?? ''] as [number, number, string],
+            );
+
+            if (isOnTop) {
+                await btn.click({ force: true });
+                await this.page.waitForLoadState('networkidle');
+                return;
+            }
+        }
+
+        // Fall back to the "More" overflow popup — trigger is the .ibexa-btn--more button, not the <li>
+        const moreButton = contextMenu.locator('.ibexa-btn--more');
+        await moreButton.waitFor({ state: 'visible', timeout: 5_000 });
+        await moreButton.click();
+
+        // The multilevel popup branch is appended to <body> by the JS.
+        // Visibility is toggled via CSS class ibexa-popup-menu--hidden (not HTML hidden attr).
+        const popupItems = this.page.locator(
+            '.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden) .ibexa-multilevel-popup-menu__item-content',
+        );
+        await popupItems.first().waitFor({ state: 'visible', timeout: 5_000 });
+
+        const popupCount = await popupItems.count();
+        const popupTexts: string[] = [];
+        for (let i = 0; i < popupCount; i++) {
+            const item = popupItems.nth(i);
+            const text = (await item.textContent() ?? '').trim();
+            popupTexts.push(text);
+            if (text.includes(label)) {
+                await item.click();
+                await this.page.waitForLoadState('networkidle');
+                return;
+            }
+        }
+
+        throw new Error(`Action button '${label}' not found in context menu`);
+    }
+
+    async sendToTrash(): Promise<void> {
+        await this.performAction('Send to trash');
+
+        // "Send to trash" always opens #trash-location-modal.
+        // For items with children/relations a confirm checkbox is required to enable the button;
+        // for empty items the button is already enabled — we just click it.
+        const trashModal = this.page.locator('#trash-location-modal, .ibexa-modal--trash-location');
+        const isModalVisible = await trashModal.waitFor({ state: 'visible', timeout: 5_000 })
+            .then(() => true).catch(() => false);
+
+        if (!isModalVisible) {
+            // No modal — action was handled without confirmation
+            await this.page.waitForLoadState('networkidle');
+            return;
+        }
+
+        // Check all unchecked checkboxes in the modal (options + confirm checkbox)
+        await this.page.evaluate(() => {
+            const modal = document.querySelector('#trash-location-modal, .ibexa-modal--trash-location');
+            if (!modal) return;
+            modal.querySelectorAll<HTMLInputElement>('input[type="checkbox"]:not(:checked)')
+                .forEach(cb => cb.click());
+        });
+        await this.page.waitForTimeout(300);
+
+        // Click the submit button inside the modal
+        const submitBtn = trashModal.locator('.ibexa-btn--confirm-send-to-trash');
+        await submitBtn.waitFor({ state: 'visible', timeout: 5_000 });
+        await submitBtn.click();
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    /**
+     * Selects a content item in the UDW by navigating the tree path (e.g. "Media/Files").
+     * Each path segment is a branch level in the UDW finder.
+     */
+    async selectInUDW(itemPath: string): Promise<void> {
+        const udw = this.page.locator('.m-ud');
+        await udw.waitFor({ state: 'visible', timeout: 10_000 });
+
+        const segments = itemPath.split('/');
+        for (let level = 1; level <= segments.length; level++) {
+            const segmentName = segments[level - 1];
+            const branchLocator = this.page.locator(`div.c-finder-branch:nth-of-type(${level}) .c-finder-leaf`);
+            await branchLocator.first().waitFor({ state: 'visible', timeout: 10_000 });
+
+            const leafCount = await branchLocator.count();
+            let found = false;
+            for (let i = 0; i < leafCount; i++) {
+                const leaf = branchLocator.nth(i);
+                const text = (await leaf.textContent() ?? '').trim();
+                if (text.includes(segmentName)) {
+                    if (level < segments.length) {
+                        await leaf.locator('.c-finder-leaf__name').click();
+                    } else {
+                        // Last segment: check the checkbox to select (multiple-mode UDW)
+                        const checkbox = leaf.locator('input[type="checkbox"]');
+                        if (await checkbox.count() > 0) {
+                            await this.page.evaluate((el) => (el as HTMLInputElement).click(), await checkbox.elementHandle());
+                            await this.page.waitForTimeout(300);
+                        } else {
+                            await leaf.locator('.c-finder-leaf__name').click();
+                        }
+                    }
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                console.warn(`UDW tree item '${segmentName}' not found at level ${level} — stopping navigation`);
+                return;
+            }
+
+            if (level < segments.length) {
+                // For intermediate nodes: wait for next branch to appear (navigation happened)
+                const nextBranch = this.page.locator(`div.c-finder-branch:nth-of-type(${level + 1})`);
+                await nextBranch.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+            }
+        }
+    }
+
+    async confirmUDW(): Promise<void> {
+        const confirmButton = this.page.locator('.c-actions-menu__confirm-btn');
+        await confirmButton.waitFor({ state: 'visible', timeout: 10_000 });
+        await confirmButton.click({ force: true });
+        await this.page.locator('.m-ud').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+        await this.page.waitForLoadState('domcontentloaded');
+    }
+
+    async closeUDW(): Promise<void> {
+        const cancelButton = this.page.locator('.c-top-menu__cancel-btn');
+        await cancelButton.waitFor({ state: 'visible', timeout: 10_000 });
+        await cancelButton.click();
+        await this.page.locator('.m-ud').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+        await this.page.waitForLoadState('domcontentloaded');
+    }
+
+    async assertOnContentView(itemName: string): Promise<void> {
+        const pageTitle = this.page.locator('.ibexa-page-title h1');
+        await pageTitle.waitFor({ state: 'visible', timeout: 10_000 });
+        await expect(pageTitle).toContainText(itemName);
+    }
+
+    async assertSuccessNotification(text: string): Promise<void> {
+        const notification = this.page.locator('.ibexa-notifications-container .ibexa-alert--success');
+        await notification.waitFor({ state: 'visible', timeout: 10_000 });
+        await expect(notification).toContainText(text);
+    }
+
+    async assertSubitemAbsent(name: string): Promise<void> {
+        // .m-sub-items is a React mount point — wait for it to render rows inside
+        const subItemsTable = this.page.locator('.m-sub-items');
+        await subItemsTable.waitFor({ state: 'attached', timeout: 10_000 });
+        await this.page.waitForFunction(
+            (sel) => {
+                const el = document.querySelector(sel);
+                return el && el.querySelectorAll('.ibexa-table__row').length > 0;
+            },
+            '.m-sub-items',
+            { timeout: 10_000 },
+        );
+        const items = subItemsTable.locator('.ibexa-table__row');
+        const count = await items.count();
+        for (let i = 0; i < count; i++) {
+            const text = (await items.nth(i).textContent() ?? '').trim();
+            expect(text).not.toContain(name);
+        }
+    }
+
+    async hide(): Promise<void> {
+        // Hide works by submitting form[name="content_visibility_update"] with visible=0.
+        // We set the visibility field and submit the form directly.
+        await this.page.locator('.ibexa-context-menu').waitFor({ state: 'visible', timeout: 10_000 });
+
+        const submitted = await this.page.evaluate(() => {
+            const form = document.querySelector('form[name="content_visibility_update"]') as HTMLFormElement | null;
+            if (!form) return 'NO_FORM';
+            const visField = form.querySelector('#content_visibility_update_visible') as HTMLInputElement | null;
+            if (!visField) return 'NO_FIELD';
+            visField.value = '0';
+            form.submit();
+            return 'OK';
+        });
+
+        if (submitted !== 'OK') {
+            throw new Error(`Hide form issue: ${submitted}`);
+        }
+
+        await this.page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+    }
+
+    async assertSubitemPresent(name: string): Promise<void> {
+        const subItemsTable = this.page.locator('.m-sub-items');
+        await subItemsTable.waitFor({ state: 'attached', timeout: 10_000 });
+        const row = subItemsTable.locator('.ibexa-table__row').filter({ hasText: name }).first();
+        await row.waitFor({ state: 'attached', timeout: 10_000 });
+        await expect(row).toContainText(name);
+    }
+}

--- a/tests/playwright-tests/Pages/ContentManagementPage.ts
+++ b/tests/playwright-tests/Pages/ContentManagementPage.ts
@@ -1,11 +1,10 @@
 import { Page, Locator, expect } from '@playwright/test';
-import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget, ContextMenu } from '@ibexa/cohesivo-playwright';
 
 export class ContentManagementPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
+    readonly contextMenu: ContextMenu;
 
-    private readonly contextMenu: Locator;
-    private readonly moreButton: Locator;
     private readonly trashModal: Locator;
     private readonly trashModalSubmit: Locator;
     private readonly subItems: Locator;
@@ -13,27 +12,10 @@ export class ContentManagementPage extends AdminUiPage {
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
-        this.contextMenu = page.locator('.ibexa-context-menu');
-        this.moreButton = this.contextMenu.locator('.ibexa-btn--more');
+        this.contextMenu = new ContextMenu(page);
         this.trashModal = page.locator('#trash-location-modal, .ibexa-modal--trash-location').first();
         this.trashModalSubmit = this.trashModal.locator('.ibexa-btn--confirm-send-to-trash');
         this.subItems = page.locator('.m-sub-items');
-    }
-
-    /** Primary (always-visible) context-menu action button by its label. */
-    private primaryAction(label: string): Locator {
-        return this.contextMenu
-            .locator('.ibexa-context-menu__item:not(.ibexa-context-menu__item--more) .ibexa-btn')
-            .filter({ hasText: label })
-            .first();
-    }
-
-    /** Same action when it lives in the "More" overflow popup (appended to <body>). */
-    private overflowAction(label: string): Locator {
-        return this.page
-            .locator('.ibexa-multilevel-popup-menu__branch:not(.ibexa-popup-menu--hidden) .ibexa-popup-menu__item:not(.ibexa-popup-menu__item--hidden)')
-            .filter({ hasText: label })
-            .first();
     }
 
     private subItemRow(name: string): Locator {
@@ -42,40 +24,11 @@ export class ContentManagementPage extends AdminUiPage {
 
     async open(contentId: number, locationId: number): Promise<void> {
         await this.page.goto(`/admin/view/content/${contentId}/full/1/${locationId}`);
-        await expect(this.contextMenu).toBeVisible({ timeout: 20_000 });
-    }
-
-    /**
-     * Clicks an action button in the context menu by its visible label text.
-     * Handles both primary (visible) buttons and items hidden behind the "More" overflow button.
-     */
-    async performAction(label: string): Promise<void> {
-        await expect(this.contextMenu.locator('.ibexa-btn').first()).toBeVisible({ timeout: 10_000 });
-
-        const primaryButton = this.primaryAction(label);
-
-        // A primary button can be present in the DOM but covered by the "More" overflow.
-        // Probe with elementFromPoint (read-only, no failed click attempt in the report)
-        // and only then click for real, with Playwright's actionability checks intact.
-        const isClickable = await primaryButton.count() > 0 && await primaryButton.evaluate((el) => {
-            const box = el.getBoundingClientRect();
-            const topmost = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
-            return topmost !== null && (el === topmost || el.contains(topmost));
-        });
-
-        if (isClickable) {
-            await primaryButton.click();
-            return;
-        }
-
-        await this.moreButton.click();
-        const item = this.overflowAction(label);
-        await expect(item, `Action '${label}' not found in context menu`).toBeVisible({ timeout: 5_000 });
-        await item.click();
+        await this.contextMenu.expectVisible();
     }
 
     async sendToTrash(): Promise<void> {
-        await this.performAction('Send to trash');
+        await this.contextMenu.clickAction('Send to trash');
         await expect(this.trashModal).toBeVisible({ timeout: 10_000 });
 
         // For items with children/relations the modal requires ticking confirmation
@@ -94,7 +47,7 @@ export class ContentManagementPage extends AdminUiPage {
     }
 
     async hide(): Promise<void> {
-        await this.performAction('Hide');
+        await this.contextMenu.clickAction('Hide');
         // "Hide" opens the "Schedule hiding" panel; confirm with the default "Hide now" option
         await expect(
             this.page.getByRole('heading', { name: 'Schedule hiding' }).filter({ visible: true }).first(),

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -7,6 +7,7 @@ export class TrashPage extends AdminUiPage {
 
     private readonly firstRow: Locator;
     private readonly emptyState: Locator;
+    private readonly searchInput: Locator;
     private readonly restoreButton: Locator;
     private readonly restoreUnderNewLocationButton: Locator;
     private readonly bulkDeleteButton: Locator;
@@ -20,6 +21,7 @@ export class TrashPage extends AdminUiPage {
         this.emptyState = page.locator('.ibexa-table__empty-table-text')
             .or(page.getByText('Trash is empty'))
             .or(page.getByText('No items'));
+        this.searchInput = page.locator('input[name="trash_search[content_name]"]');
         this.restoreButton = page.getByRole('button', { name: 'Restore', exact: true });
         this.restoreUnderNewLocationButton = page.getByRole('button', { name: 'Restore in a new location' })
             .or(page.locator('button.ibexa-btn--open-udw')).first();
@@ -82,8 +84,11 @@ export class TrashPage extends AdminUiPage {
     }
 
     async searchInTrash(query: string): Promise<void> {
-        const url = this.page.url().split('?')[0];
-        await this.page.goto(`${url}?trash_search[content_name]=${encodeURIComponent(query)}`);
+        // Drive the search form as a user would: type the query and submit.
+        // The form is a plain GET, so pressing Enter navigates to the filtered list.
+        await this.searchInput.fill(query);
+        await this.searchInput.press('Enter');
+        await this.page.waitForLoadState('networkidle');
     }
 
     async filterByContentType(contentTypeName: string): Promise<void> {

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -1,9 +1,12 @@
 import { Page, expect } from '@playwright/test';
-import { AdminUiPage } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
 
 export class TrashPage extends AdminUiPage {
+    readonly udw: UniversalDiscoveryWidget;
+
     constructor(page: Page) {
         super(page);
+        this.udw = new UniversalDiscoveryWidget(page);
     }
 
     async open(): Promise<void> {
@@ -11,25 +14,22 @@ export class TrashPage extends AdminUiPage {
     }
 
     async assertNotEmpty(): Promise<void> {
-        const rows = this.page.locator('.ibexa-table__row').filter({ hasText: /\S/ });
-        const count = await rows.count();
-        expect(count).toBeGreaterThan(0);
+        await expect(this.page.locator('.ibexa-table__row').first()).toBeVisible({ timeout: 10_000 });
     }
 
     async assertEmpty(): Promise<void> {
         const emptyEl = this.page.locator('.ibexa-table__empty-table-text')
             .or(this.page.getByText('Trash is empty'))
             .or(this.page.getByText('No items'));
-        await emptyEl.first().waitFor({ state: 'visible', timeout: 10_000 });
+        await expect(emptyEl.first()).toBeVisible({ timeout: 10_000 });
     }
 
     async emptyTrash(): Promise<void> {
         const emptyBtn = this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty Trash' })
             .or(this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty' })).first();
-        await emptyBtn.waitFor({ state: 'visible', timeout: 10_000 });
-        await emptyBtn.click({ force: true });
+        await emptyBtn.click();
         await this.confirmDialogButton('Delete');
-        await this.page.waitForLoadState('networkidle');
+        await this.assertEmpty();
     }
 
     async assertItemInTrash(name: string): Promise<void> {
@@ -45,10 +45,8 @@ export class TrashPage extends AdminUiPage {
             await this.checkTableRow(item);
         }
         const deleteBtn = this.page.locator('button:not([data-bs-dismiss])').filter({ hasText: 'Delete' }).first();
-        await deleteBtn.waitFor({ state: 'visible', timeout: 10_000 });
-        await deleteBtn.click({ force: true });
+        await deleteBtn.click();
         await this.confirmDialogButton('Delete');
-        await this.page.waitForLoadState('networkidle');
     }
 
     async restoreFromTrash(items: string[]): Promise<void> {
@@ -57,32 +55,32 @@ export class TrashPage extends AdminUiPage {
         }
         // Find "Restore" button (not "Restore in a new location") by matching inner text exactly
         const restoreBtn = this.page.locator('button').filter({ hasNotText: 'in a new location' }).filter({ hasText: 'Restore' }).first();
-        await restoreBtn.waitFor({ state: 'visible', timeout: 10_000 });
         await restoreBtn.click();
-        await this.page.waitForLoadState('networkidle');
     }
 
+    /**
+     * Restores the checked items under the location given by path (e.g. "Media/Files"),
+     * driving the whole flow: restore button → UDW navigation → UDW confirm.
+     */
     async restoreUnderNewLocation(items: string[], newLocationPath: string): Promise<void> {
         for (const item of items) {
             await this.checkTableRow(item);
         }
         const restoreBtn = this.page.locator('button').filter({ hasText: 'Restore in a new location' })
             .or(this.page.locator('button.ibexa-btn--open-udw')).first();
-        await restoreBtn.waitFor({ state: 'visible', timeout: 10_000 });
         await restoreBtn.click();
-        await this.page.waitForTimeout(1000);
+
+        await this.udw.selectPath(newLocationPath);
+        await this.udw.confirm();
     }
 
     async searchInTrash(query: string): Promise<void> {
         const url = this.page.url().split('?')[0];
         await this.page.goto(`${url}?trash_search[content_name]=${encodeURIComponent(query)}`);
-        await this.page.waitForLoadState('networkidle');
     }
 
     async filterByContentType(contentTypeName: string): Promise<void> {
         const select = this.page.locator('select').first();
-        await select.waitFor({ state: 'visible', timeout: 10_000 });
         await select.selectOption({ label: contentTypeName });
-        await this.page.waitForLoadState('networkidle');
     }
 }

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -1,12 +1,32 @@
-import { Page, expect } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
 
 export class TrashPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
 
+    private readonly firstRow: Locator;
+    private readonly emptyState: Locator;
+    private readonly emptyTrashButton: Locator;
+    private readonly restoreButton: Locator;
+    private readonly restoreUnderNewLocationButton: Locator;
+    private readonly bulkDeleteButton: Locator;
+
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
+
+        this.firstRow = page.locator('.ibexa-table__row').first();
+        this.emptyState = page.locator('.ibexa-table__empty-table-text')
+            .or(page.getByText('Trash is empty'))
+            .or(page.getByText('No items'));
+        this.emptyTrashButton = page.locator('.ibexa-context-menu .ibexa-btn')
+            .filter({ hasText: /Empty( Trash)?/ })
+            .first();
+        this.restoreButton = page.getByRole('button', { name: 'Restore', exact: true });
+        this.restoreUnderNewLocationButton = page.getByRole('button', { name: 'Restore in a new location' })
+            .or(page.locator('button.ibexa-btn--open-udw')).first();
+        // toolbar Delete only — [data-bs-dismiss] excludes the modal's own dismiss button
+        this.bulkDeleteButton = page.locator('button:not([data-bs-dismiss])').filter({ hasText: 'Delete' }).first();
     }
 
     async open(): Promise<void> {
@@ -14,20 +34,15 @@ export class TrashPage extends AdminUiPage {
     }
 
     async assertNotEmpty(): Promise<void> {
-        await expect(this.page.locator('.ibexa-table__row').first()).toBeVisible({ timeout: 10_000 });
+        await expect(this.firstRow).toBeVisible({ timeout: 10_000 });
     }
 
     async assertEmpty(): Promise<void> {
-        const emptyEl = this.page.locator('.ibexa-table__empty-table-text')
-            .or(this.page.getByText('Trash is empty'))
-            .or(this.page.getByText('No items'));
-        await expect(emptyEl.first()).toBeVisible({ timeout: 10_000 });
+        await expect(this.emptyState.first()).toBeVisible({ timeout: 10_000 });
     }
 
     async emptyTrash(): Promise<void> {
-        const emptyBtn = this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty Trash' })
-            .or(this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty' })).first();
-        await emptyBtn.click();
+        await this.emptyTrashButton.click();
         await this.confirmDialogButton('Delete');
         await this.assertEmpty();
     }
@@ -44,8 +59,7 @@ export class TrashPage extends AdminUiPage {
         for (const item of items) {
             await this.checkTableRow(item);
         }
-        const deleteBtn = this.page.locator('button:not([data-bs-dismiss])').filter({ hasText: 'Delete' }).first();
-        await deleteBtn.click();
+        await this.bulkDeleteButton.click();
         await this.confirmDialogButton('Delete');
     }
 
@@ -53,9 +67,7 @@ export class TrashPage extends AdminUiPage {
         for (const item of items) {
             await this.checkTableRow(item);
         }
-        // Find "Restore" button (not "Restore in a new location") by matching inner text exactly
-        const restoreBtn = this.page.locator('button').filter({ hasNotText: 'in a new location' }).filter({ hasText: 'Restore' }).first();
-        await restoreBtn.click();
+        await this.restoreButton.click();
     }
 
     /**
@@ -66,10 +78,7 @@ export class TrashPage extends AdminUiPage {
         for (const item of items) {
             await this.checkTableRow(item);
         }
-        const restoreBtn = this.page.locator('button').filter({ hasText: 'Restore in a new location' })
-            .or(this.page.locator('button.ibexa-btn--open-udw')).first();
-        await restoreBtn.click();
-
+        await this.restoreUnderNewLocationButton.click();
         await this.udw.selectPath(newLocationPath);
         await this.udw.confirm();
     }
@@ -80,7 +89,6 @@ export class TrashPage extends AdminUiPage {
     }
 
     async filterByContentType(contentTypeName: string): Promise<void> {
-        const select = this.page.locator('select').first();
-        await select.selectOption({ label: contentTypeName });
+        await this.page.locator('select').first().selectOption({ label: contentTypeName });
     }
 }

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -1,9 +1,9 @@
 import { Page, Locator, expect } from '@playwright/test';
-import { AdminUiPage, UniversalDiscoveryWidget, ContextMenu } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget, ContentActionsMenu } from '@ibexa/cohesivo-playwright';
 
 export class TrashPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
-    readonly contextMenu: ContextMenu;
+    readonly contentActionsMenu: ContentActionsMenu;
 
     private readonly firstRow: Locator;
     private readonly emptyState: Locator;
@@ -15,7 +15,7 @@ export class TrashPage extends AdminUiPage {
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
-        this.contextMenu = new ContextMenu(page);
+        this.contentActionsMenu = new ContentActionsMenu(page);
 
         this.firstRow = page.locator('.ibexa-table__row').first();
         this.emptyState = page.locator('.ibexa-table__empty-table-text')
@@ -42,7 +42,7 @@ export class TrashPage extends AdminUiPage {
     }
 
     async emptyTrash(): Promise<void> {
-        await this.contextMenu.clickAction(/Empty( Trash)?/);
+        await this.contentActionsMenu.clickButton(/Empty( Trash)?/);
         await this.confirmDialogButton('Delete');
         await this.assertEmpty();
     }

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -1,12 +1,12 @@
 import { Page, Locator, expect } from '@playwright/test';
-import { AdminUiPage, UniversalDiscoveryWidget } from '@ibexa/cohesivo-playwright';
+import { AdminUiPage, UniversalDiscoveryWidget, ContextMenu } from '@ibexa/cohesivo-playwright';
 
 export class TrashPage extends AdminUiPage {
     readonly udw: UniversalDiscoveryWidget;
+    readonly contextMenu: ContextMenu;
 
     private readonly firstRow: Locator;
     private readonly emptyState: Locator;
-    private readonly emptyTrashButton: Locator;
     private readonly restoreButton: Locator;
     private readonly restoreUnderNewLocationButton: Locator;
     private readonly bulkDeleteButton: Locator;
@@ -14,14 +14,12 @@ export class TrashPage extends AdminUiPage {
     constructor(page: Page) {
         super(page);
         this.udw = new UniversalDiscoveryWidget(page);
+        this.contextMenu = new ContextMenu(page);
 
         this.firstRow = page.locator('.ibexa-table__row').first();
         this.emptyState = page.locator('.ibexa-table__empty-table-text')
             .or(page.getByText('Trash is empty'))
             .or(page.getByText('No items'));
-        this.emptyTrashButton = page.locator('.ibexa-context-menu .ibexa-btn')
-            .filter({ hasText: /Empty( Trash)?/ })
-            .first();
         this.restoreButton = page.getByRole('button', { name: 'Restore', exact: true });
         this.restoreUnderNewLocationButton = page.getByRole('button', { name: 'Restore in a new location' })
             .or(page.locator('button.ibexa-btn--open-udw')).first();
@@ -42,7 +40,7 @@ export class TrashPage extends AdminUiPage {
     }
 
     async emptyTrash(): Promise<void> {
-        await this.emptyTrashButton.click();
+        await this.contextMenu.clickAction(/Empty( Trash)?/);
         await this.confirmDialogButton('Delete');
         await this.assertEmpty();
     }

--- a/tests/playwright-tests/Pages/TrashPage.ts
+++ b/tests/playwright-tests/Pages/TrashPage.ts
@@ -1,0 +1,88 @@
+import { Page, expect } from '@playwright/test';
+import { AdminUiPage } from '@ibexa/cohesivo-playwright';
+
+export class TrashPage extends AdminUiPage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    async open(): Promise<void> {
+        await this.navigateTo(`/admin/trash/list`);
+    }
+
+    async assertNotEmpty(): Promise<void> {
+        const rows = this.page.locator('.ibexa-table__row').filter({ hasText: /\S/ });
+        const count = await rows.count();
+        expect(count).toBeGreaterThan(0);
+    }
+
+    async assertEmpty(): Promise<void> {
+        const emptyEl = this.page.locator('.ibexa-table__empty-table-text')
+            .or(this.page.getByText('Trash is empty'))
+            .or(this.page.getByText('No items'));
+        await emptyEl.first().waitFor({ state: 'visible', timeout: 10_000 });
+    }
+
+    async emptyTrash(): Promise<void> {
+        const emptyBtn = this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty Trash' })
+            .or(this.page.locator('.ibexa-context-menu .ibexa-btn').filter({ hasText: 'Empty' })).first();
+        await emptyBtn.waitFor({ state: 'visible', timeout: 10_000 });
+        await emptyBtn.click({ force: true });
+        await this.confirmDialogButton('Delete');
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    async assertItemInTrash(name: string): Promise<void> {
+        await this.assertTableRowPresent(name);
+    }
+
+    async assertItemNotInTrash(name: string): Promise<void> {
+        await this.assertTableRowAbsent(name);
+    }
+
+    async deleteFromTrash(items: string[]): Promise<void> {
+        for (const item of items) {
+            await this.checkTableRow(item);
+        }
+        const deleteBtn = this.page.locator('button:not([data-bs-dismiss])').filter({ hasText: 'Delete' }).first();
+        await deleteBtn.waitFor({ state: 'visible', timeout: 10_000 });
+        await deleteBtn.click({ force: true });
+        await this.confirmDialogButton('Delete');
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    async restoreFromTrash(items: string[]): Promise<void> {
+        for (const item of items) {
+            await this.checkTableRow(item);
+        }
+        // Find "Restore" button (not "Restore in a new location") by matching inner text exactly
+        const restoreBtn = this.page.locator('button').filter({ hasNotText: 'in a new location' }).filter({ hasText: 'Restore' }).first();
+        await restoreBtn.waitFor({ state: 'visible', timeout: 10_000 });
+        await restoreBtn.click();
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    async restoreUnderNewLocation(items: string[], newLocationPath: string): Promise<void> {
+        for (const item of items) {
+            await this.checkTableRow(item);
+        }
+        const restoreBtn = this.page.locator('button').filter({ hasText: 'Restore in a new location' })
+            .or(this.page.locator('button.ibexa-btn--open-udw')).first();
+        await restoreBtn.waitFor({ state: 'visible', timeout: 10_000 });
+        await restoreBtn.click();
+        await this.page.waitForTimeout(1000);
+    }
+
+    async searchInTrash(query: string): Promise<void> {
+        const url = this.page.url().split('?')[0];
+        await this.page.goto(`${url}?trash_search[content_name]=${encodeURIComponent(query)}`);
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    async filterByContentType(contentTypeName: string): Promise<void> {
+        const select = this.page.locator('select').first();
+        await select.waitFor({ state: 'visible', timeout: 10_000 });
+        await select.selectOption({ label: contentTypeName });
+        await this.page.waitForLoadState('networkidle');
+    }
+}

--- a/tests/playwright-tests/Tests/Trash.spec.ts
+++ b/tests/playwright-tests/Tests/Trash.spec.ts
@@ -4,7 +4,7 @@ import { ContentManagementPage } from '../Pages/ContentManagementPage';
 import { IbexaApiClient } from '@ibexa/cohesivo-playwright';
 
 
-test.describe('Trash management', { tag: ['@IbexaHeadless', '@IbexaExperience', '@IbexaCommerce'] }, () => {
+test.describe('Trash management', { tag: ['@IbexaOSS', '@IbexaHeadless', '@IbexaExperience', '@IbexaCommerce'] }, () => {
     let api: IbexaApiClient;
     let trashTestLocationId: number;
     let trashTestContentId: number;
@@ -15,8 +15,12 @@ test.describe('Trash management', { tag: ['@IbexaHeadless', '@IbexaExperience', 
         await api.init();
         runId = Date.now().toString().slice(-6);
 
-        trashTestContentId = await api.createFolder('TrashTest', 2);
+        trashTestContentId = await api.createFolder(`TrashTest${runId}`, 2);
         trashTestLocationId = await api.getMainLocationId(trashTestContentId);
+    });
+
+    test.afterAll(async () => {
+        await api.deleteContent(trashTestContentId);
     });
 
     test('Trash can be emptied', async ({ page }) => {
@@ -98,12 +102,14 @@ test.describe('Trash management', { tag: ['@IbexaHeadless', '@IbexaExperience', 
         await trash.assertItemInTrash(name);
         await trash.restoreUnderNewLocation([name], 'Media/Files');
 
-        const contentMgmt = new ContentManagementPage(page);
-        await contentMgmt.selectInUDW('Media/Files');
-        await contentMgmt.confirmUDW();
-
         await trash.assertSuccessNotification("Restored content under Location 'Files'");
         await trash.assertItemNotInTrash(name);
+
+        // Verify the content actually landed under Media/Files (path resolution throws if absent)
+        const restoredContentId = await api.getContentIdByPath(`Media/Files/${name}`);
+        expect(restoredContentId).toBe(childId);
+
+        await api.deleteContent(childId);
     });
 
     test('Element in trash can be found by search', async ({ page }) => {
@@ -124,5 +130,6 @@ test.describe('Trash management', { tag: ['@IbexaHeadless', '@IbexaExperience', 
         await trash.open();
         await trash.searchInTrash(name1);
         await trash.assertItemInTrash(name1);
+        await trash.assertItemNotInTrash(name2);
     });
 });

--- a/tests/playwright-tests/Tests/Trash.spec.ts
+++ b/tests/playwright-tests/Tests/Trash.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import { TrashPage } from '../Pages/TrashPage';
+import { ContentManagementPage } from '../Pages/ContentManagementPage';
+import { IbexaApiClient } from '@ibexa/cohesivo-playwright';
+
+
+test.describe('Trash management', { tag: ['@IbexaHeadless', '@IbexaExperience', '@IbexaCommerce'] }, () => {
+    let api: IbexaApiClient;
+    let trashTestLocationId: number;
+    let trashTestContentId: number;
+    let runId: string;
+
+    test.beforeAll(async () => {
+        api = new IbexaApiClient();
+        await api.init();
+        runId = Date.now().toString().slice(-6);
+
+        trashTestContentId = await api.createFolder('TrashTest', 2);
+        trashTestLocationId = await api.getMainLocationId(trashTestContentId);
+    });
+
+    test('Trash can be emptied', async ({ page }) => {
+        const childId = await api.createFolder(`FolderToTrash${runId}`, trashTestLocationId);
+        const childLocId = await api.getMainLocationId(childId);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId, childLocId);
+        await contentPage.sendToTrash();
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.assertNotEmpty();
+        await trash.emptyTrash();
+        await trash.assertEmpty();
+    });
+
+    test('Content can be moved to trash', async ({ page }) => {
+        const name = `FolderToTrashManually${runId}`;
+        const childId = await api.createFolder(name, trashTestLocationId);
+        const childLocId = await api.getMainLocationId(childId);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId, childLocId);
+        await contentPage.sendToTrash();
+
+        await contentPage.assertSuccessNotification(`Location '${name}' moved to Trash`);
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.assertItemInTrash(name);
+    });
+
+    test('Element in trash can be deleted', async ({ page }) => {
+        const name = `DeleteFromTrash${runId}`;
+        const childId = await api.createFolder(name, trashTestLocationId);
+        const childLocId = await api.getMainLocationId(childId);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId, childLocId);
+        await contentPage.sendToTrash();
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.assertItemInTrash(name);
+        await trash.deleteFromTrash([name]);
+        await trash.assertSuccessNotification('Deleted selected item(s) from Trash');
+        await trash.assertItemNotInTrash(name);
+    });
+
+    test('Element in trash can be restored', async ({ page }) => {
+        const name = `RestoreFromTrash${runId}`;
+        const childId = await api.createFolder(name, trashTestLocationId);
+        const childLocId = await api.getMainLocationId(childId);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId, childLocId);
+        await contentPage.sendToTrash();
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.assertItemInTrash(name);
+        await trash.restoreFromTrash([name]);
+        await trash.assertSuccessNotification('Restored content to its original Location');
+        await trash.assertItemNotInTrash(name);
+    });
+
+    test('Element in trash can be restored under new location', async ({ page }) => {
+        const name = `RestoreFromTrashNewLocation${runId}`;
+        const childId = await api.createFolder(name, trashTestLocationId);
+        const childLocId = await api.getMainLocationId(childId);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId, childLocId);
+        await contentPage.sendToTrash();
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.assertItemInTrash(name);
+        await trash.restoreUnderNewLocation([name], 'Media/Files');
+
+        const contentMgmt = new ContentManagementPage(page);
+        await contentMgmt.selectInUDW('Media/Files');
+        await contentMgmt.confirmUDW();
+
+        await trash.assertSuccessNotification("Restored content under Location 'Files'");
+        await trash.assertItemNotInTrash(name);
+    });
+
+    test('Element in trash can be found by search', async ({ page }) => {
+        const name1 = `TrashSearch1${runId}`;
+        const name2 = `TrashSearch2${runId}`;
+        const childId1 = await api.createFolder(name1, trashTestLocationId);
+        const childLocId1 = await api.getMainLocationId(childId1);
+        const childId2 = await api.createFolder(name2, trashTestLocationId);
+        const childLocId2 = await api.getMainLocationId(childId2);
+
+        const contentPage = new ContentManagementPage(page);
+        await contentPage.open(childId1, childLocId1);
+        await contentPage.sendToTrash();
+        await contentPage.open(childId2, childLocId2);
+        await contentPage.sendToTrash();
+
+        const trash = new TrashPage(page);
+        await trash.open();
+        await trash.searchInTrash(name1);
+        await trash.assertItemInTrash(name1);
+    });
+});

--- a/tests/playwright-tests/package-lock.json
+++ b/tests/playwright-tests/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "@ibexa/admin-ui-playwright-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ibexa/admin-ui-playwright-tests",
+      "version": "1.0.0",
+      "dependencies": {
+        "@ibexa/cohesivo-playwright": "file:../../../cohesivo-playwright"
+      }
+    },
+    "../../../cohesivo-playwright": {
+      "name": "@ibexa/cohesivo-playwright",
+      "version": "1.0.0",
+      "dependencies": {
+        "@playwright/test": "^1.60.0",
+        "@types/node": "^20.0.0",
+        "dotenv": "^17.4.2",
+        "typescript": "^5.4.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ibexa/cohesivo-playwright": {
+      "resolved": "../../../cohesivo-playwright",
+      "link": true
+    }
+  }
+}

--- a/tests/playwright-tests/package.json
+++ b/tests/playwright-tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@ibexa/admin-ui-playwright-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test",
+    "test:headless": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=headless",
+    "test:experience": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=experience",
+    "test:commerce": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=commerce"
+  },
+  "dependencies": {
+    "@ibexa/cohesivo-playwright": "file:../../../cohesivo-playwright"
+  }
+}

--- a/tests/playwright-tests/package.json
+++ b/tests/playwright-tests/package.json
@@ -6,7 +6,8 @@
     "test": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test",
     "test:headless": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=headless",
     "test:experience": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=experience",
-    "test:commerce": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=commerce"
+    "test:commerce": "NODE_PATH=./node_modules/@ibexa/cohesivo-playwright/node_modules ./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/playwright test --project=commerce",
+    "typecheck": "./node_modules/@ibexa/cohesivo-playwright/node_modules/.bin/tsc --noEmit"
   },
   "dependencies": {
     "@ibexa/cohesivo-playwright": "file:../../../cohesivo-playwright"

--- a/tests/playwright-tests/playwright.config.ts
+++ b/tests/playwright-tests/playwright.config.ts
@@ -1,0 +1,3 @@
+import { defineIbexaConfig } from '@ibexa/cohesivo-playwright';
+
+export default defineIbexaConfig({ testDir: './Tests' });

--- a/tests/playwright-tests/tsconfig.json
+++ b/tests/playwright-tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/@ibexa/cohesivo-playwright/tsconfig.playwright.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "Tests/**/*.ts",
+    "Pages/**/*.ts",
+    "Utils/**/*.ts",
+    "playwright.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11739 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/commerce/pull/1833
- https://github.com/ibexa/gh-workflows/pull/100
- https://github.com/ibexa/cohesivo-playwright/pull/1


#### Description: 
 Sets up Playwright testing for the admin-ui package using the shared cohesivo-playwright library.
 
  - Added tests/playwright-tests/ directory with playwright.config.ts, tsconfig.json, and package.json
  - Implemented TrashPage and ContentManagementPage page objects
  - Added Trash.spec.ts with 6 tests covering: empty trash, move to trash, restore, restore under new location, delete from trash, and search
  - Added .github/workflows/playwright-tests.yml calling the reusable workflow for all four editions (oss/headless/experience/commerce)


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
