### PR TITLE
IBX-11949: Added is_not_translatable form variable support to form_ro…

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -80,7 +80,9 @@
     {% set fieldtype = form.parent %}
     {% set fieldtype_identifier = fieldtype.vars.value.fieldDefinition.fieldTypeIdentifier %}
     {% set translation_mode = fieldtype.vars.mainLanguageCode != fieldtype.vars.languageCode %}
-    {% set fieldtype_is_not_translatable = translation_mode and not fieldtype.vars.value.fieldDefinition.isTranslatable %}
+    {% set fieldtype_is_not_translatable = fieldtype.vars.is_not_translatable is defined
+        ? fieldtype.vars.is_not_translatable
+        : (translation_mode and not fieldtype.vars.value.fieldDefinition.isTranslatable) %}
     {% set has_distraction_free_mode = fieldtype_identifier == 'ibexa_richtext' %}
 
     {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ibexa-field-edit__data')|trim}) %}


### PR DESCRIPTION
| :ticket: Issue | IBX-11949 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/translations-management/pull/139


#### Description:
The `form_row_fieldtype` block hardcodes how `fieldtype_is_not_translatable` is determined, making it impossible for external packages to override this value. This change checks for a `is_not_translatable` form variable first, falling back to the existing logic when it's not set. This is needed so that the side-by-side translation view in `ibexa/translations-management` can signal to the field template that a field should display the non-translatable message inside the field wrapper, achieving proper visual alignment with the target form column.


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
