### PR TITLE
[Behat] IBX-11567: Fix missing @IbexaDXP tag in ContentTranslation tests

### DIFF
--- a/features/standard/ContentTranslation.feature
+++ b/features/standard/ContentTranslation.feature
@@ -55,7 +55,7 @@ Feature: Content item translation
       | Short description | This field is empty | ibexa_richtext      |
       | Description       | This field is empty | ibexa_richtext      |
 
-  @APIUser:admin @IbexaHeadless @IbexaExperience @IbexaCommerce
+  @APIUser:admin @IbexaHeadless @IbexaExperience @IbexaCommerce @IbexaDXP
   Scenario: Publish new translation based on existing translation
     Given I create "folder" Content items in root in "eng-GB"
       | name             | short_name       | short_description | description      |


### PR DESCRIPTION
| :ticket: Issue |[ IBX-11567](https://ibexa.atlassian.net/browse/IBX-11567) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Add missing @IbexaDXP tag to the ContentTranslation.feature DXP-only scenario, so it's excluded from OSS test runs like every other DXP-specific scenario in the suite.

#### For QA:
Checked ✅ :
- The file parses correctly; the @IbexaDXP tag is now on the third scenario.
- Simulating the ~@IbexaDXP filter (how the OSS run behaves) shows the third scenario is now skipped, while both OSS scenarios still run.                                                                                 
- Simulating the @IbexaDXP filter (DXP run) shows the opposite - only the third scenario runs.                                              

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
