### PR TITLE
IBX-12091: Replaced frontend installation in backend CI

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -84,12 +84,7 @@ jobs:
             satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
             satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      - uses: actions/setup-node@v7
-        with:
-            node-version: '24'
-
-      - name: Install frontend dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+      - uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -138,12 +133,7 @@ jobs:
               satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
               satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      -   uses: actions/setup-node@v7
-          with:
-              node-version: '24'
-
-      -   name: Install frontend dependencies
-          run: yarn install --frozen-lockfile --ignore-scripts
+      -   uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
 
       -   name: Setup problem matchers for PHPUnit
           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -196,12 +186,7 @@ jobs:
               satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
               satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      -   uses: actions/setup-node@v7
-          with:
-              node-version: '24'
-
-      -   name: Install frontend dependencies
-          run: yarn install --frozen-lockfile --ignore-scripts
+      -   uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
 
       -   name: Setup problem matchers for PHPUnit
           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -84,7 +84,7 @@ jobs:
             satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
             satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      - uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
+      - uses: ibexa/gh-workflows/actions/frontend-install@main
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -133,7 +133,7 @@ jobs:
               satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
               satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      -   uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
+      -   uses: ibexa/gh-workflows/actions/frontend-install@main
 
       -   name: Setup problem matchers for PHPUnit
           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -186,7 +186,7 @@ jobs:
               satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
               satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
-      -   uses: ibexa/gh-workflows/actions/frontend-install@IBX-12091-install-typescript-estree
+      -   uses: ibexa/gh-workflows/actions/frontend-install@main
 
       -   name: Setup problem matchers for PHPUnit
           run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
| :ticket: Issue | IBX-12091 |
|----------------|-----------|

#### Related PRs:

- https://github.com/ibexa/gh-workflows/pull/106
- https://github.com/ibexa/recipes-dev/pull/255
- https://github.com/ibexa/translations/pull/3

#### Description:

Replaced full `yarn install` calls in the Admin UI backend jobs with the shared `ibexa/gh-workflows/actions/frontend-install@main` action. The action installs only the locked Node dependencies required by the TypeScript translation extractor and exposes them through the repository-root `node_modules/` directory.

The action is used by the unit, PostgreSQL integration, and MySQL integration jobs. This prepares Admin UI CI for moving the generic JavaScript and TypeScript extractors to `ibexa/translations`.

#### For QA:

No manual QA is required. The affected backend jobs verify the installation in CI.

#### Documentation:

No documentation changes are required.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
