### PR TITLE
IBX-12187: Update form-label bottom margin to match labels design

### DIFF
--- a/src/bundle/Resources/public/scss/ibexa-bootstrap.scss
+++ b/src/bundle/Resources/public/scss/ibexa-bootstrap.scss
@@ -160,6 +160,8 @@ $bootstrap-danger: color.to-space($ibexa-color-danger, rgb);
     $input-focus-border-color: $bootstrap-primary,
     $input-focus-color: $bootstrap-dark-300,
     $input-focus-box-shadow: 0 0 calculateRem(2px) 0 color.change($bootstrap-primary, $alpha: 0.75),
+    //Labels
+    $form-label-margin-bottom: calculateRem(4px),
     //Buttons
     $btn-line-height: calculateRem(16px),
     $btn-font-size: calculateRem(15px),


### PR DESCRIPTION
> [!NOTE]
> Browser tests here stay red until ibexa/design-system#125 merges (the CI-only `dependencies.json` pin was removed for merge — CI was green with it, see comments). Delete the `admin-ui-assets#IBX-12187-labels-design` branch after merging.

| :ticket: Issue | IBX-12187 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/design-system/pull/125

#### Description:
Labels rendered with Bootstrap's `form-label` class (e.g. `<twig:ibexa:label class="form-label">` across admin-ui, discounts, order-management, …) kept Bootstrap's default `margin-bottom: .5rem` (7px at our 14px root), overriding the 4px label→input gap introduced in the design system (ibexa/design-system#125). Sets `$form-label-margin-bottom: calculateRem(4px)` in the Bootstrap config so all of them match the labels design.

#### For QA:
`/admin/payment-method` and `/admin/discounts/create/catalog/fixed_amount?language_code=eng-GB`: every label should sit 4px above its input (previously 7px on `form-label` ones).

#### Documentation:

🤖 Generated with [Claude Code](https://claude.com/claude-code)


