### PR TITLE
IBX-12056: Applied dark mode to the preview header, kept popups light

### DIFF
--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -9,6 +9,8 @@
 
     $self: &;
 
+    --ids-mode: light;
+
     background-color: $ibexa-color-white;
     padding: calculateRem(16px) 0;
     width: calculateRem(700px);

--- a/src/bundle/Resources/public/scss/_popup-menu.scss
+++ b/src/bundle/Resources/public/scss/_popup-menu.scss
@@ -3,6 +3,8 @@
 @use 'sass:color';
 
 .ibexa-popup-menu {
+    --ids-mode: light;
+
     display: flex;
     flex-direction: column;
     gap: calculateRem(1px);

--- a/src/bundle/Resources/public/scss/_preview-header.scss
+++ b/src/bundle/Resources/public/scss/_preview-header.scss
@@ -2,6 +2,8 @@
 @use '@ibexa-admin-ui/src/bundle/Resources/public/scss/functions/calculate.rem' as *;
 
 .ibexa-preview-header {
+    --ids-mode: dark;
+
     display: grid;
     grid-template-areas: 'siteaccess actions back';
     grid-template-columns: auto 1fr auto;

--- a/src/bundle/Resources/views/themes/admin/ui/menu/context_menu.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/context_menu.html.twig
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block item -%}
-    {%- set default_classes = 'btn ibexa-btn' -%}
     {%- set list_item_default_classes = 'ibexa-context-menu__item ibexa-adaptive-items__item' -%}
     {% if item.extras.adaptiveItemsForceHide|default(false) %}
         {%- set list_item_default_classes = list_item_default_classes ~ ' ibexa-adaptive-items__item--force-hide ibexa-context-menu__item--hidden' -%}
@@ -35,7 +34,7 @@
 
     <li class="{{ list_item_default_classes }}">
         {%- if item.displayed -%}
-            {%- set attributes = item.attributes|merge({'class': (item.attributes.class|default('') ~ ' ' ~ default_classes|default('btn btn-secondary btn-block'))|trim}) -%}
+            {%- set attributes = item.attributes|merge({'class': item.attributes.class|default('')|trim}) -%}
             {%- set attributes = attributes|merge({'id': item.name ~ '-tab'}) -%}
 
             {%- if item.uri is not empty %}
@@ -160,7 +159,7 @@
             </{{element}}>
 
         {% else %}
-            {%- set default_classes = 'ids-btn ids-btn--medium' -%}
+            {%- set default_classes = 'btn ibexa-btn ids-btn ids-btn--medium' -%}
 
             {% if not item.extras.noDefaultBtnStyling|default(false) %}
                 {% if item.extras.primary|default(false) %}


### PR DESCRIPTION
| :ticket: Issue | IBX-12056 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/design-system/pull/126 — **must be merged first**; adds the dark mode mechanism this PR relies on
- https://github.com/ibexa/page-builder/pull/570 — Page Builder / Dashboard Builder / Form Builder menu bar
- https://github.com/ibexa/form-builder/pull/246 — form builder modal header
- https://github.com/ibexa/image-editor/pull/137 — image editor header

#### Description:
Two changes, both using the design system's new `--ids-mode` flag.

**Content preview header** — flagged as a dark surface, so the design system buttons it contains (the "Close" link-button and the device switcher) use their dark variants:

```scss
.ibexa-preview-header {
    --ids-mode: dark;
    ...
}
```

**Extra actions and popup menus** — these are white panels that are frequently rendered *inside* a dark container: the Page Builder menu bar hosts both the "Send to review" and "Publish later" extra-action panels in its own DOM subtree. Since `--ids-mode` inherits, they would pick up the dark styling and render white buttons on their white background. Both now assert light mode explicitly:

```scss
.ibexa-extra-actions {
    --ids-mode: light;
    ...
}

.ibexa-popup-menu {
    --ids-mode: light;
    ...
}
```

This is a general safeguard rather than a fix for one page — any future dark surface hosting these panels gets the correct behaviour for free. Popup menus that are moved to `document.body` on init (the multilevel popup menu, the image editor's save menu) never inherited the flag in the first place, but the declaration keeps them correct if that ever changes.

#### For QA:
**Content preview** — preview a content item; the dark header's "Close" button should be white text on a light-neutral border, and the device switcher icons white. Check hover and focus.

**Popups on a dark surface** — edit a Landing Page draft, then in the dark Page Builder menu bar open "Send to review" and the "Publish" chevron → "Publish later". Both panels must stay white with dark text and dark-on-white buttons.

**Regression:** extra-action panels and popup menus on ordinary light pages (e.g. Create buttons on list pages, context menus) must be unchanged.

#### Documentation:
