### PR TITLE
IBX-11747: Admin 405 responses trigger exception loop in prod mode

### DIFF
--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -281,6 +281,21 @@
         <target state="new">Sorry, this page isn't available</target>
         <note>key: error.page.404.title</note>
       </trans-unit>
+      <trans-unit id="09bb755e1c17c18536fc7b0dc258ca692e4a17ab" resname="error.page.405.actions">
+        <source><![CDATA[Go back to the <a href="%dashboard%">dashboard</a> or <a href="%search%">search</a> for another item.]]></source>
+        <target state="new"><![CDATA[Go back to the <a href="%dashboard%">dashboard</a> or <a href="%search%">search</a> for another item.]]></target>
+        <note>key: error.page.405.actions</note>
+      </trans-unit>
+      <trans-unit id="d4ab8cd5c5505500d4b650eb4b757b0a1761c32e" resname="error.page.405.sub_title">
+        <source>The requested method is not allowed for this page.</source>
+        <target state="new">The requested method is not allowed for this page.</target>
+        <note>key: error.page.405.sub_title</note>
+      </trans-unit>
+      <trans-unit id="95ee0da0a43116ba2d3252675d6afcd38a77d084" resname="error.page.405.title">
+        <source>This action isn't available</source>
+        <target state="new">This action isn't available</target>
+        <note>key: error.page.405.title</note>
+      </trans-unit>
       <trans-unit id="a599d59a63814826906caa9842f0b3c33db24d09" resname="error.page.default.actions">
         <source><![CDATA[Contact you Administrator to report the problem.<br/>Go back to the <a href="%dashboard%">dashboard</a> or reload the application.]]></source>
         <target state="new"><![CDATA[Contact you Administrator to report the problem.<br/>Go back to the <a href="%dashboard%">dashboard</a> or reload the application.]]></target>

--- a/src/bundle/Resources/views/themes/admin/ui/error_page/405.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/405.html.twig
@@ -1,0 +1,23 @@
+{% extends '@ibexadesign/ui/layout_error.html.twig' %}
+
+{% block user_menu %}{% endblock %}
+{% block left_sidebar %}{% endblock %}
+
+{% block content %}
+    <div class="ibexa-error-page">
+        <div class="ibexa-error-page__messages-container">
+            <div class="ibexa-error-page__icon-wrapper">
+                <img class="ibexa-error-page__icon" src="{{ asset('bundles/ibexaadminui/img/error_unknown.svg') }}" />
+            </div>
+            <h2 class="ibexa-error-page__title">
+                {{ 'error.page.405.title'|trans|desc('This action isn\'t available')  }}
+            </h2>
+            <h3 class="ibexa-error-page__subtitle">
+                {{ 'error.page.405.sub_title'|trans|desc('The requested method is not allowed for this page.') }}
+            </h3>
+        </div>
+        <p class="ibexa-error-page__message">
+            {{ 'error.page.405.actions'|trans({ '%dashboard%': path('ibexa.dashboard'), '%search%': path('ibexa.search') })|raw|desc('Go back to the <a href="%dashboard%">dashboard</a> or <a href="%search%">search</a> for another item.') }}
+        </p>
+    </div>
+{% endblock %}

--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -91,6 +91,10 @@ class AdminExceptionListener implements LoggerAwareInterface
             return;
         }
 
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         if (!$this->isAdminException($event)) {
             return;
         }
@@ -129,6 +133,9 @@ class AdminExceptionListener implements LoggerAwareInterface
                 break;
             case 403:
                 $content = $this->twig->render('@ibexadesign/ui/error_page/403.html.twig');
+                break;
+            case 405:
+                $content = $this->twig->render('@ibexadesign/ui/error_page/405.html.twig');
                 break;
             default:
                 $content = $this->twig->render('@ibexadesign/ui/error_page/unknown.html.twig');

--- a/tests/lib/EventListener/AdminExceptionListenerTest.php
+++ b/tests/lib/EventListener/AdminExceptionListenerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AdminUi\EventListener;
+
+use Ibexa\AdminUi\EventListener\AdminExceptionListener;
+use Ibexa\Bundle\AdminUi\IbexaAdminUiBundle;
+use Ibexa\Contracts\AdminUi\Notification\NotificationHandlerInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+use Throwable;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+
+class AdminExceptionListenerTest extends TestCase
+{
+    private const ADMIN_SITEACCESS = 'admin_siteaccess';
+    private const NON_ADMIN_SITEACCESS = 'non_admin_siteaccess';
+
+    /** @var \Twig\Environment|\PHPUnit\Framework\MockObject\MockObject */
+    private $twig;
+
+    /** @var \Ibexa\Contracts\AdminUi\Notification\NotificationHandlerInterface|\PHPUnit\Framework\MockObject\Stub */
+    private $notificationHandler;
+
+    /** @var \Symfony\WebpackEncoreBundle\Asset\TagRenderer|\PHPUnit\Framework\MockObject\MockObject */
+    private $encoreTagRenderer;
+
+    /** @var \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $entrypointLookupCollection;
+
+    /** @var \Ibexa\AdminUi\EventListener\AdminExceptionListener */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twig = $this->createMock(Environment::class);
+        $this->notificationHandler = $this->createStub(NotificationHandlerInterface::class);
+        $this->encoreTagRenderer = $this->createMock(TagRenderer::class);
+        $this->entrypointLookupCollection = $this->createMock(EntrypointLookupCollectionInterface::class);
+
+        $this->listener = $this->createListener();
+    }
+
+    /**
+     * @dataProvider provideNoOpConditions
+     */
+    public function testOnKernelExceptionIsNoOpWhenGuardConditionFails(
+        string $environment,
+        int $requestType,
+        string $siteaccessName
+    ): void {
+        $this->twig->expects($this->never())->method('render');
+
+        $event = $this->createExceptionEvent(new NotFoundHttpException(), $requestType, $siteaccessName);
+        $this->createListener($environment)->onKernelException($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: int, 2: string}>
+     */
+    public function provideNoOpConditions(): iterable
+    {
+        yield 'non-prod environment' => ['test', HttpKernelInterface::MAIN_REQUEST, self::ADMIN_SITEACCESS];
+        yield 'sub-request' => ['prod', HttpKernelInterface::SUB_REQUEST, self::ADMIN_SITEACCESS];
+        yield 'non-admin siteaccess' => ['prod', HttpKernelInterface::MAIN_REQUEST, self::NON_ADMIN_SITEACCESS];
+    }
+
+    /**
+     * @dataProvider provideHttpExceptionsWithDedicatedErrorPages
+     *
+     * @param array<string, string> $expectedHeaders
+     */
+    public function testOnKernelExceptionRendersDedicatedErrorPage(
+        Throwable $exception,
+        int $expectedStatusCode,
+        string $expectedTemplate,
+        array $expectedHeaders
+    ): void {
+        $this->twig
+            ->expects($this->once())
+            ->method('render')
+            ->with($expectedTemplate)
+            ->willReturn('rendered_error_page_content');
+
+        $event = $this->createExceptionEvent($exception, HttpKernelInterface::MAIN_REQUEST, self::ADMIN_SITEACCESS);
+        $this->listener->onKernelException($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame($expectedStatusCode, $response->getStatusCode());
+        $this->assertSame('rendered_error_page_content', $response->getContent());
+
+        foreach ($expectedHeaders as $name => $value) {
+            $this->assertSame($value, $response->headers->get($name));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{0: \Throwable, 1: int, 2: string, 3: array<string, string>}>
+     */
+    public function provideHttpExceptionsWithDedicatedErrorPages(): iterable
+    {
+        yield 'not found' => [
+            new NotFoundHttpException(),
+            Response::HTTP_NOT_FOUND,
+            '@ibexadesign/ui/error_page/404.html.twig',
+            [],
+        ];
+
+        yield 'access denied' => [
+            new AccessDeniedHttpException(),
+            Response::HTTP_FORBIDDEN,
+            '@ibexadesign/ui/error_page/403.html.twig',
+            [],
+        ];
+
+        yield 'method not allowed' => [
+            new MethodNotAllowedHttpException(['POST']),
+            Response::HTTP_METHOD_NOT_ALLOWED,
+            '@ibexadesign/ui/error_page/405.html.twig',
+            ['Allow' => 'POST'],
+        ];
+    }
+
+    public function testOnKernelExceptionResetsEncoreAssetsForRuntimeError(): void
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())->method('reset');
+
+        $this->entrypointLookupCollection
+            ->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->with('ibexa')
+            ->willReturn($entrypointLookup);
+
+        $this->encoreTagRenderer->expects($this->once())->method('reset');
+
+        $this->twig
+            ->expects($this->once())
+            ->method('render')
+            ->with('@ibexadesign/ui/error_page/unknown.html.twig')
+            ->willReturn('unknown_page_content');
+
+        $event = $this->createExceptionEvent(
+            new RuntimeError('broken template'),
+            HttpKernelInterface::MAIN_REQUEST,
+            self::ADMIN_SITEACCESS
+        );
+        $this->listener->onKernelException($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+    }
+
+    private function createListener(string $environment = 'prod'): AdminExceptionListener
+    {
+        $listener = new AdminExceptionListener(
+            $this->twig,
+            $this->notificationHandler,
+            $this->encoreTagRenderer,
+            $this->entrypointLookupCollection,
+            [IbexaAdminUiBundle::ADMIN_GROUP_NAME => [self::ADMIN_SITEACCESS]],
+            '/kernel/root',
+            $environment,
+            'error'
+        );
+        $listener->setLogger($this->createStub(LoggerInterface::class));
+
+        return $listener;
+    }
+
+    private function createExceptionEvent(Throwable $exception, int $requestType, string $siteaccessName): ExceptionEvent
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', new SiteAccess($siteaccessName));
+
+        return new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            $requestType,
+            $exception
+        );
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11747 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
I'm preventing the loping by only processing the error from the main request
```
        if (!$event->isMainRequest()) {
            return;
        }
```
I'm also handling the 405 code as a separate case with its own template
```
            case 405:
                $content = $this->twig->render('@ibexadesign/ui/error_page/405.html.twig');
                break;
```

This listener had no test coverage previously so I have added that as well, covered both the fix and the expected behavior outside this specific case.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
