### PR TITLE
Fixed Prettier violation in _custom.scss left by 5.0 into 6.0 merge

### DIFF
--- a/src/bundle/Resources/public/scss/_custom.scss
+++ b/src/bundle/Resources/public/scss/_custom.scss
@@ -143,8 +143,6 @@ $ibexa-text-font-size-extra-small: calculateRem(8px);
 $ibexa-font-weight-normal: normal;
 $ibexa-font-weight-bold: 600;
 
-
-
 // Ibexa shadows
 $ibexa-btn-focus-box-shadow: 0 0 0 calculateRem(3px) color.change($ibexa-color-primary, $alpha: 0.2);
 $ibexa-btn-focus-box-shadow-info: 0 0 0 calculateRem(3px) color.change($ibexa-color-info, $alpha: 0.2);


### PR DESCRIPTION
| :ticket: Issue | n/a — trivial base-branch fix |
|----------------|-------------------------------|

#### Related PRs:
- none

#### Description:
The merge commit d151ba7e ("Merged branch '5.0' into 6.0", 2026-08-05) left three consecutive blank lines in `src/bundle/Resources/public/scss/_custom.scss` (lines 145–147). Prettier collapses runs of blank lines to one, so `yarn prettier-test` — the first step of the "Frontend build test" CI job — fails on every PR targeting `6.0` since then.

This removes two of the three blank lines. Verified locally with the exact CI command:
`prettier --check "./src/bundle/Resources/**/*.{js,ts,scss}"` → all files pass.

#### For QA:
Whitespace-only change, no functional impact. CI "Frontend build test" going green is the verification.

#### Documentation:
