### PR TITLE
IBX-12237: Passed Search extraClasses to InputTextInput wrapper instead of the input

### DIFF
--- a/src/bundle/ui-dev/src/modules/common/dropdown/dropdown.js
+++ b/src/bundle/ui-dev/src/modules/common/dropdown/dropdown.js
@@ -150,7 +150,7 @@ const Dropdown = ({
             <div className={itemsContainerClass} style={itemsListStyles} ref={containerItemsRef}>
                 <InputTextInput
                     className="ibexa-dropdown__items-filter-wrapper"
-                    extraAria={{
+                    extraInputAttrs={{
                         className: 'ibexa-dropdown__items-filter',
                     }}
                     hasSearchAction={true}

--- a/src/bundle/ui-dev/src/modules/common/input/filter.search.js
+++ b/src/bundle/ui-dev/src/modules/common/input/filter.search.js
@@ -10,9 +10,7 @@ const Search = ({ onChange, placeholder = '', extraClasses = '', value }) => {
 
     return (
         <InputTextInput
-            extraAria={{
-                className: extraClasses,
-            }}
+            className={extraClasses}
             hasSearchAction={true}
             name="filter"
             onChange={(nextValue, event) => onChange(event ?? { target: { value: nextValue } })}

--- a/src/bundle/ui-dev/src/modules/common/popup-menu/popup.menu.search.js
+++ b/src/bundle/ui-dev/src/modules/common/popup-menu/popup.menu.search.js
@@ -19,8 +19,8 @@ const PopupMenuSearch = ({ numberOfItems, filterText = '', setFilterText }) => {
         <div className="c-popup-menu__search">
             <InputTextInput
                 className="c-popup-menu__search-input-wrapper"
-                extraAria={{
-                    className: 'ids-input ids-input--text ids-input--small c-popup-menu__search-input',
+                extraInputAttrs={{
+                    className: 'c-popup-menu__search-input',
                 }}
                 hasSearchAction={true}
                 name="popup-menu-search"

--- a/src/bundle/ui-dev/src/modules/common/taggify/taggify.js
+++ b/src/bundle/ui-dev/src/modules/common/taggify/taggify.js
@@ -77,7 +77,7 @@ const Taggify = forwardRef(
                     <div className="c-taggify__inputs">
                         <InputTextInput
                             className="c-taggify__new-tag-input-wrapper"
-                            extraAria={{
+                            extraInputAttrs={{
                                 className: 'c-taggify__new-tag-input',
                                 onKeyUp: handleInputKeyUp,
                             }}

--- a/src/bundle/ui-dev/src/modules/sub-items/components/sub-items-list/instant.filter.component.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/components/sub-items-list/instant.filter.component.js
@@ -30,7 +30,7 @@ const InstantFilter = ({ items = [], handleItemChange = () => {}, isSearchEnable
         <div className="ibexa-instant-filter">
             <div className={searchInputWrapperClassName}>
                 <InputTextInput
-                    extraAria={{
+                    extraInputAttrs={{
                         className: 'ibexa-instant-filter__input',
                     }}
                     name="sub-items-filter"

--- a/src/bundle/ui-dev/src/modules/sub-items/components/table-view/table.view.item.component.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/components/table-view/table.view.item.component.js
@@ -213,7 +213,7 @@ export default class TableViewItemComponent extends PureComponent {
             <div className="c-table-view-item__priority-wrapper" {...priorityWrapperAttrs}>
                 <div className="c-table-view-item__inner-wrapper c-table-view-item__inner-wrapper--input">
                     <InputTextInput
-                        extraAria={{
+                        extraInputAttrs={{
                             className: 'c-table-view-item__priority-value',
                         }}
                         name="priority"

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
@@ -203,7 +203,7 @@ const ContentCreateWidget = () => {
                         <div className="ibexa-instant-filter">
                             <div className={instantFilterInputWrapperClassName}>
                                 <InputTextInput
-                                    extraAria={{
+                                    extraInputAttrs={{
                                         autoFocus: true,
                                         className: 'ibexa-instant-filter__input',
                                     }}

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/translation-selector/translation.selector.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/translation-selector/translation.selector.js
@@ -91,7 +91,7 @@ const TranslationSelectorButton = ({ hideTranslationSelector, selectTranslation,
                 <div className="ibexa-instant-filter">
                     <div className={searchInputWrapperClassName}>
                         <InputTextInput
-                            extraAria={{
+                            extraInputAttrs={{
                                 className: 'ibexa-instant-filter__input',
                             }}
                             name="translation-filter"


### PR DESCRIPTION
| :ticket: Issue | IBX-12237 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/design-system/pull/129 — BaseInput className merge (merge first)
- https://github.com/ibexa/image-picker/pull/144 — Image library layout + close button
- https://github.com/ibexa/commerce/pull/1931 — regression tests (IBX-12237 + IBX-12246 combined state)

⚠️ Merge order: the design-system PR should merge first.

#### Description:
The shared `Search` component (`common/input/filter.search.js`) routed its `extraClasses` prop through `extraAria.className`, which lands on the raw `<input>` and — due to spread order in the DS `BaseInput` — replaced the `ids-input*` classes entirely. With the default `extraClasses = ''` (the Image library case) the input rendered as `<input class="">`, i.e. completely unstyled.

`extraClasses` is now passed to `InputTextInput`'s `className` prop (the `.ids-input-text` wrapper), matching the established pattern in `top.menu.search.input.js`.

Consumers checked: image-picker passes no `extraClasses`; segmentation passes `c-segments__sidebar-filter`, which has no SCSS/JS references anywhere in that package, so moving the class from the input to the wrapper changes nothing visually.

#### For QA:
1. Create/edit content with an image assets field → **Select from library** → the search input in the Image library header must be styled like other DS inputs (border, 40px height, magnifier button inside).
2. Regression: UDW top-menu search (browse tab), dropdown/popup-menu filter inputs — unchanged.
3. Page Builder → block targeting (segmentation) sidebar segment filter — unchanged.

#### Documentation:

