### PR TITLE
IBX-11952: Made system resilient to `Accept-Language: *` locale

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1213,12 +1213,6 @@ parameters:
 			path: src/lib/EventListener/RequestLocaleListener.php
 
 		-
-			message: '#^Parameter \#1 \$locale of method Symfony\\Component\\HttpFoundation\\Request\:\:setLocale\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/EventListener/RequestLocaleListener.php
-
-		-
 			message: '#^Method Ibexa\\AdminUi\\EventListener\\SetViewParametersListener\:\:getIgnoredContentFields\(\) has parameter \$fieldsData with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/lib/EventListener/RequestLocaleListener.php
+++ b/src/lib/EventListener/RequestLocaleListener.php
@@ -105,6 +105,8 @@ final readonly class RequestLocaleListener implements EventSubscriberInterface
     private function isValidLocale(string $locale): bool
     {
         // Mirror the validation Symfony's translator applies before accepting a locale.
+
+        // TODO: Once on Symfony 8.1+, reuse \Symfony\Component\Translation\LocaleFallbackProvider::validateLocale()
         return 1 === preg_match('/^[a-z0-9@_\.\-]+$/i', $locale);
     }
 }

--- a/src/lib/EventListener/RequestLocaleListener.php
+++ b/src/lib/EventListener/RequestLocaleListener.php
@@ -69,7 +69,22 @@ final readonly class RequestLocaleListener implements EventSubscriberInterface
                 break;
             }
         }
+
         $locale = $locale ?? reset($preferableLocales);
+
+        // Defence-in-depth: the fallback above is the browser's top preference, which is
+        // not guaranteed to be a valid locale (e.g. the RFC 7231 `Accept-Language: *`
+        // wildcard). Passing such a value to the translator throws an "Invalid locale"
+        // error, so fall back to an available translation instead.
+        if (!is_string($locale) || !$this->isValidLocale($locale)) {
+            $availableTranslations = $this->availableTranslations;
+            $locale = reset($availableTranslations);
+        }
+
+        if (false === $locale) {
+            return;
+        }
+
         $request->setLocale($locale);
         $request->attributes->set('_locale', $locale);
         // Set of the current locale on the translator service is needed because RequestLocaleListener has lower
@@ -85,5 +100,11 @@ final readonly class RequestLocaleListener implements EventSubscriberInterface
         return (new IsAdmin($this->siteAccessGroups))->isSatisfiedBy(
             $request->attributes->get('siteaccess')
         );
+    }
+
+    private function isValidLocale(string $locale): bool
+    {
+        // Mirror the validation Symfony's translator applies before accepting a locale.
+        return 1 === preg_match('/^[a-z0-9@_\.\-]+$/i', $locale);
     }
 }

--- a/tests/lib/EventListener/RequestLocaleListenerTest.php
+++ b/tests/lib/EventListener/RequestLocaleListenerTest.php
@@ -23,11 +23,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Translation\Translator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class RequestLocaleListenerTest extends TestCase
+final class RequestLocaleListenerTest extends TestCase
 {
-    private const ADMIN_SITEACCESS = 'admin_siteaccess';
+    private const string ADMIN_SITEACCESS = 'admin_siteaccess';
 
-    private const NON_ADMIN_SITEACCESS = 'non_admin_siteaccess';
+    private const string NON_ADMIN_SITEACCESS = 'non_admin_siteaccess';
 
     private Request&MockObject $request;
 
@@ -172,6 +172,42 @@ class RequestLocaleListenerTest extends TestCase
         $requestLocaleListener = new RequestLocaleListener(
             ['admin_group' => [self::ADMIN_SITEACCESS]],
             [],
+            $this->translator,
+            $this->userLanguagePreferenceProvider,
+            $this->configResolver
+        );
+
+        $requestLocaleListener->onKernelRequest($event);
+    }
+
+    public function testInvalidPreferredLocaleFallsBackToAvailableTranslation(): void
+    {
+        $this->translator
+            ->expects(self::once())
+            ->method('setLocale')
+            ->with('en_GB');
+
+        $this->request
+            ->expects(self::once())
+            ->method('setLocale')
+            ->with('en_GB');
+
+        $event = new RequestEvent(
+            $this->httpKernel,
+            $this->request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        // `Accept-Language: *` (RFC 7231 wildcard) surfaces here as the `*` locale, which
+        // is not a valid locale; it must not reach the translator.
+        $this->userLanguagePreferenceProvider
+            ->expects(self::once())
+            ->method('getPreferredLocales')
+            ->willReturn(['*']);
+
+        $requestLocaleListener = new RequestLocaleListener(
+            ['admin_group' => [self::ADMIN_SITEACCESS]],
+            ['en_GB', 'en_US'],
             $this->translator,
             $this->userLanguagePreferenceProvider,
             $this->configResolver


### PR DESCRIPTION
| :ticket: Issue | IBX-11952 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/804

#### Description:
Additional safeguard as a supplement to https://github.com/ibexa/core/pull/804.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
