### PR TITLE
IBX-12251: Aligned low-emphasis table actions on `tertiary-alt` button type

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/urls.html.twig
@@ -50,7 +50,7 @@
 {% macro table_header_tools(form_custom_url_remove, can_edit_custom_url) %}
     {% if can_edit_custom_url %}
         <twig:ibexa:button
-            type="tertiary"
+            type="tertiary-alt"
             size="small"
             icon="add"
             class="ids-btn--prevented"

--- a/src/bundle/Resources/views/themes/admin/url_wildcard/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/url_wildcard/list.html.twig
@@ -101,7 +101,7 @@
                 {% block actions %}
                     <twig:ibexa:button
                         id="create-wildcards"
-                        type="tertiary"
+                        type="tertiary-alt"
                         size="small"
                         icon="add"
                         icon_size="small-medium"

--- a/src/bundle/Resources/views/themes/admin/user/policy/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/policy/list.html.twig
@@ -93,7 +93,7 @@
                         <twig:ibexa:link
                             href="{{ path('ibexa.policy.create', {roleId: role.id}) }}"
                             variant="button"
-                            type="tertiary"
+                            type="tertiary-alt"
                             size="small"
                             icon="add"
                             icon_size="small-medium"

--- a/src/bundle/Resources/views/themes/admin/user/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/role_assignment/list.html.twig
@@ -77,7 +77,7 @@
                         <twig:ibexa:link
                             href="{{ path('ibexa.role_assignment.create', {roleId: role.id}) }}"
                             variant="button"
-                            type="tertiary"
+                            type="tertiary-alt"
                             size="small"
                             icon="assign-user"
                             icon_size="small-medium"

--- a/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/sub.items.module.js
@@ -1250,7 +1250,7 @@ export default class SubItemsModule extends Component {
                 disabled={disabled}
                 onClick={this.onMoveBtnClick}
                 icon="folder-open-move"
-                type={ButtonType.Tertiary}
+                type={ButtonType.TertiaryAlt}
                 size={ButtonSize.Medium}
             >
                 {label}


### PR DESCRIPTION
| :ticket: Issue | IBX-12251 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/product-catalog/pull/1565
- https://github.com/ibexa/corporate-account/pull/377
- https://github.com/ibexa/discounts/pull/350
- https://github.com/ibexa/payment/pull/210
- https://github.com/ibexa/shipping/pull/161
- https://github.com/ibexa/connector-ai/pull/206
- https://github.com/ibexa/taxonomy/pull/439
- https://github.com/ibexa/version-comparison/pull/135

#### Description:
The "+ Add" button above a table was purple on some tabs and dark on others. Switched the
remaining `tertiary` occurrences to `tertiary-alt`, so every low-emphasis table action is dark at
rest and turns purple on hover.

#### For QA:
In all cases the action should be **dark (near-black) at rest and purple on hover**, matching the
"Delete" button beside it. Before the fix it was purple at rest.

- Open any content item → **URL** tab → "+ Add" above the table. Compare with the **Translations**
  and **Locations** tabs — all three toolbars should now look identical. *(This is the case from the
  ticket screenshots.)*
- **Admin** → **URL management** → *Wildcards* → "+ Add" above the list.
- **Admin** → **Roles** → open any role → *Policies* → "+ Add" above the policy list.
- Same role → *Assignments* → the "+ Assign" action above the assignment list.

#### Documentation:
