### PR TITLE
IBX-12253: Aligned arrow in add translation modal

### DIFF
--- a/src/bundle/Resources/public/scss/_add-translation.scss
+++ b/src/bundle/Resources/public/scss/_add-translation.scss
@@ -19,8 +19,8 @@
     }
 
     &__arrow {
-        margin-top: calculateRem(32px);
-        height: calculateRem(48px);
+        align-self: flex-end;
+        height: calculateRem(40px);
         transform: rotate(180deg);
         display: flex;
         align-items: center;

--- a/src/bundle/Resources/public/scss/_add-translation.scss
+++ b/src/bundle/Resources/public/scss/_add-translation.scss
@@ -12,6 +12,10 @@
         .ids-label {
             margin-top: 0;
         }
+
+        .ibexa-form-field {
+            margin-bottom: 0;
+        }
     }
 
     .form-group {


### PR DESCRIPTION
| :ticket: Issue | IBX-12253 |
|----------------|-----------|

#### Description:
The arrow between the language dropdowns sat too low: it still used pre-IDS offsets (`margin-top: 32px`, `height: 48px`), while the DS dropdown is now 40px tall and the label has no fixed height. Replaced them with `align-self: flex-end` + the IDS input height, so the icon stays centred on the dropdowns regardless of label height.

Second commit covers the modals whose rows use `.ibexa-form-field` (brand context, its attribute groups and attribute definitions). That class carries a global `margin-bottom: 24px`, which `:last-child` strips from the second field only — so the row heights differed and the arrow was pushed 24px below the inputs. The fields sit side by side here, so the bottom spacing is dropped inside this modal.

#### For QA:
Arrow is vertically centred on both dropdowns in every add-translation modal: content item Translations tab, brand context / attribute group / attribute definition Translations tabs, and the product catalog, payment and shipping ones.

#### Documentation:
