### PR TITLE
IBX-10203: Fixed image max size input conflicting with language settings

### DIFF
--- a/src/bundle/Resources/public/scss/_content-type-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-type-edit.scss
@@ -103,6 +103,12 @@
                     &__body-content {
                         padding: 0 calculateRem(24px) calculateRem(20px);
                         min-height: calculateRem(410px);
+
+                        .ezimage-validator.max-file-size {
+                            .ibexa-input-text-wrapper--type-text {
+                                max-width: calculateRem(150px);
+                            }
+                        }
                     }
                 }
             }

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -84,7 +84,9 @@
 
 {% block ezimage_field_definition_edit %}
     <div class="ezimage-validator max-file-size{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.maxSize) -}}
+        {{- form_row(form.maxSize,{
+            type: 'text',
+        }) -}}
     </div>
 
     {% if form.mimeTypes is defined %}


### PR DESCRIPTION
| :ticket: Issue | IBX-10203 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
The following PR fixes the issue where another language version of Back Office (for instance, German), which uses a comma instead of a dot as the decimal separator, does not display numbers in the input field.

This problem is solved through alteration of the type of the element to text rather than number. It is required because the problem originates from browser behavior (which cannot be considered a browser bug).

Additional styling is provided for .ezimage-validator.max-file-size to avoid too-wide rendering of the text field.


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
