### PR TITLE
IBX-12207: Used design system dark input mode in the header search

### DIFF
--- a/src/bundle/Resources/public/scss/_global-search.scss
+++ b/src/bundle/Resources/public/scss/_global-search.scss
@@ -7,21 +7,16 @@
     width: 100%;
     max-width: calculateRem(500px);
     position: relative;
+    --ids-mode: dark;
     --ibexa-input-text-color: #{$ibexa-color-white};
     --ibexa-text-color: #{$ibexa-color-white};
 
     .ids-input-text {
-        --ids-input-default-bg-color: #{$ibexa-color-dark-500};
-        --ids-input-default-border-color: #{$color-neutral-210};
-        --ids-input-default-text-color: #{$ibexa-color-white};
-        --ids-input-hover-border-color: #{$color-primary-50};
-        --ids-input-active-border-color: #{$color-primary-50};
-        --ids-input-focus-border-color: #{$color-primary-50};
-
-        &:hover {
-            .ids-input {
-                border-color: $color-primary-50;
-            }
+        // Header-specific accent; must sit on the element itself to beat the DS dark re-points there
+        .ids-input {
+            --ids-input-hover-border-color: #{$color-primary-50};
+            --ids-input-active-border-color: #{$color-primary-50};
+            --ids-input-focus-border-color: #{$color-primary-50};
         }
 
         &:focus-within {
@@ -102,37 +97,6 @@
     &__input {
         height: calculateRem(40px);
         padding: calculateRem(4px) calculateRem(56px) calculateRem(4px) calculateRem(12px);
-        color: $ibexa-color-white;
-        background: $ibexa-color-dark-500;
-        border-color: $color-neutral-210;
-
-        &:not(:disabled) {
-            &:hover {
-                box-shadow: none;
-                border-color: $color-primary-50;
-            }
-
-            &:focus {
-                color: $ibexa-color-white;
-                border-color: $color-primary-50;
-                background: $ibexa-color-dark-500;
-                box-shadow: 0 0 0 calculateRem(4px) color.change($ibexa-color-white, $alpha: 0.2);
-            }
-
-            &:active,
-            &:not(:placeholder-shown) {
-                box-shadow: none;
-                border-color: $color-primary-50;
-            }
-        }
-
-        &.form-control:focus {
-            color: $ibexa-color-light;
-        }
-
-        &::placeholder {
-            color: $ibexa-color-dark-300;
-        }
     }
 
     &__autocomplete-no-results {
@@ -274,6 +238,8 @@
 
     &__autocomplete {
         position: absolute;
+        // White floating surface inside the dark-scoped search — must re-assert light for DS components inside
+        --ids-mode: light;
         background-color: $ibexa-color-white;
         padding: calculateRem(8px);
         width: 100%;


### PR DESCRIPTION
| :ticket: Issue | IBX-12207 |
|----------------|-----------|

#### Related PRs:
- Stacked on https://github.com/ibexa/admin-ui/pull/2015 — base branch is `IBX-12207-update-header-styling`; only the top commit belongs to this PR.
- https://github.com/ibexa/design-system/pull/131

#### Description:

Switches the header search to the design system's new dark input variant instead of its own hand-rolled dark skin: the wrapper sets `--ids-mode: dark`, the autocomplete panel re-asserts `--ids-mode: light` (it is a white surface inside the dark scope), and ~40 lines of duplicated colour rules are deleted. Only the header's purple accent and the field's size stay local.

**Merge order**: design-system#126 (dark-mode mechanism) → https://github.com/ibexa/design-system/pull/131 (dark input variants) → this PR. Merging earlier renders the search with light input styling on the dark header.

Note for reviewers: the accent override sits on `.ids-input-text .ids-input` rather than the wrapper, because the DS dark variant re-points those custom properties on the input element itself, where an inherited ancestor value cannot win.

#### For QA:

Global search on the dashboard — default, hover, focus, typed, and clear states should look exactly as before this PR (that is the point: same visuals, DS-owned). Autocomplete panel must stay light with correctly styled buttons inside.

#### Documentation:
